### PR TITLE
functions to control nonce space and timeouts for all chip topologies

### DIFF
--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -129,7 +129,6 @@ void ASIC_set_nonce_space(GlobalState * GLOBAL_STATE)
     int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
     int asic_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
     float frequency = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.actual_frequency;
-    
 
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
         case BM1397:
@@ -158,7 +157,7 @@ double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE)
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
         case BM1397:
             // no version-rolling so same Nonce Space is splitted between Big Cores
-            return calculate_bm_timeout_ms(freq, asic_count, small_cores, cores, 4.0, 1.0, asic_default_timeout_divided);
+            return calculate_bm_timeout_ms(freq, asic_count, small_cores, cores, 4, 1.0, asic_default_timeout_divided);
         case BM1366:
         case BM1368:
         case BM1370:

--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -133,7 +133,7 @@ double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE)
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
         case BM1397:
             // no version-rolling so same Nonce Space is splitted between Big Cores
-            return calculate_bm_timeout_ms(freq, asic_count, small_cores, cores, 4.0, ASIC_SET_TIMEOUT_PERCENT);
+            return calculate_bm_timeout_ms(freq, asic_count, small_cores, cores, 4.0, ASIC_SET_TIMEOUT_PERCENT, 20);
         case BM1366:
             // ASIC_calculate_bm_timeout_ms(GLOBAL_STATE, GLOBAL_STATE->version_mask >> 13, 1.0);
             return 2000 / GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;

--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -123,27 +123,17 @@ void ASIC_set_frequency(GlobalState * GLOBAL_STATE)
     ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set frequency", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
 }
 
-double ASIC_calculate_bm_timeout_ms(GlobalState * GLOBAL_STATE, float max_versions, float timeout_percent)
-{
-    float freq = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
-    int cores = _largest_power_of_two(GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count);
-    int small_cores = _largest_power_of_two(GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count);
-    int asic_count = _largest_power_of_two(GLOBAL_STATE->DEVICE_CONFIG.family.asic_count);
-    double nonce_space_divided = NONCE_SPACE/(double)cores/(double)asic_count;
-
-    // for version rolling chips
-    double midstates = small_cores/cores;
-
-    // this applies to bitmain chips only, calulates the timeout in ms
-    return timeout_percent * (max_versions / midstates) * ASIC_SET_NONCE_SPACE_PERCENT * (nonce_space_divided / freq);
-}
-
 double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE)
 {
+    float freq = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
+    int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
+    int small_cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count;
+    int asic_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
+
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
         case BM1397:
             // no version-rolling so same Nonce Space is splitted between Big Cores
-            return ASIC_calculate_bm_timeout_ms(GLOBAL_STATE, 4.0, 1.0);
+            return calculate_bm_timeout_ms(freq, asic_count, small_cores, cores, 4.0, ASIC_SET_TIMEOUT_PERCENT);
         case BM1366:
             // ASIC_calculate_bm_timeout_ms(GLOBAL_STATE, GLOBAL_STATE->version_mask >> 13, 1.0);
             return 2000 / GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;

--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -123,6 +123,30 @@ void ASIC_set_frequency(GlobalState * GLOBAL_STATE)
     ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set frequency", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
 }
 
+void ASIC_set_nonce_space(GlobalState * GLOBAL_STATE)
+{
+    float nonce_percent = 1.0;
+    int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
+    int asic_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
+    float frequency = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.actual_frequency;
+    
+
+    switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
+        case BM1397:
+            return;
+        case BM1366:
+            BM1366_set_nonce_space(nonce_percent, frequency, asic_count, cores);
+            return;
+        case BM1368:
+            BM1368_set_nonce_space(nonce_percent, frequency, asic_count, cores);
+            return;
+        case BM1370:
+            BM1370_set_nonce_space(nonce_percent, frequency, asic_count, cores);
+            return;
+    }
+    ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set nonce space", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
+}
+
 double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE)
 {
     float freq = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;

--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -134,7 +134,7 @@ double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE)
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
         case BM1397:
             // no version-rolling so same Nonce Space is splitted between Big Cores
-            return calculate_bm_timeout_ms(freq, asic_count, small_cores, cores, 4.0, ASIC_SET_TIMEOUT_PERCENT, asic_default_timeout_divided);
+            return calculate_bm_timeout_ms(freq, asic_count, small_cores, cores, 4.0, 1.0, asic_default_timeout_divided);
         case BM1366:
         case BM1368:
         case BM1370:

--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -11,14 +11,11 @@
 #include "device_config.h"
 #include "frequency_transition_bmXX.h"
 
-static const double NONCE_SPACE = 4294967296.0; //  2^32
-
 static const char *TAG = "asic";
 
 uint8_t ASIC_init(GlobalState * GLOBAL_STATE)
 {
     ESP_LOGI(TAG, "Initializing %dx %s", GLOBAL_STATE->DEVICE_CONFIG.family.asic_count, GLOBAL_STATE->DEVICE_CONFIG.family.asic.name);
-
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
         case BM1397:
             return BM1397_init(GLOBAL_STATE);
@@ -126,16 +123,33 @@ void ASIC_set_frequency(GlobalState * GLOBAL_STATE)
     ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set frequency", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
 }
 
+double ASIC_calculate_bm_timeout_ms(GlobalState * GLOBAL_STATE, float max_versions, float timeout_percent)
+{
+    float freq = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
+    int cores = _largest_power_of_two(GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count);
+    int small_cores = _largest_power_of_two(GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count);
+    int asic_count = _largest_power_of_two(GLOBAL_STATE->DEVICE_CONFIG.family.asic_count);
+    double nonce_space_divided = NONCE_SPACE/(double)cores/(double)asic_count;
+
+    // for version rolling chips
+    double midstates = small_cores/cores;
+
+    // this applies to bitmain chips only, calulates the timeout in ms
+    return timeout_percent * (max_versions / midstates) * ASIC_SET_NONCE_SPACE_PERCENT * (nonce_space_divided / freq);
+}
+
 double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE)
 {
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
         case BM1397:
-            // no version-rolling so same Nonce Space is splitted between Small Cores
-            return (NONCE_SPACE / (double) (GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value * GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count * 1000)) / (double) GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
+            // no version-rolling so same Nonce Space is splitted between Big Cores
+            return ASIC_calculate_bm_timeout_ms(GLOBAL_STATE, 4.0, 1.0);
         case BM1366:
+            // ASIC_calculate_bm_timeout_ms(GLOBAL_STATE, GLOBAL_STATE->version_mask >> 13, 1.0);
             return 2000 / GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
         case BM1368:
         case BM1370:
+            // ASIC_calculate_bm_timeout_ms(GLOBAL_STATE, GLOBAL_STATE->version_mask >> 13, 1.0);
             return 500 / GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
     }
     ESP_LOGE(TAG, "Unknown ASIC id %d — cannot compute job frequency", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);

--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -129,18 +129,16 @@ double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE)
     int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
     int small_cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count;
     int asic_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
+    int asic_default_timeout_divided = GLOBAL_STATE->DEVICE_CONFIG.family.asic.default_asic_timeout / _next_power_of_two(asic_count);
 
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
         case BM1397:
             // no version-rolling so same Nonce Space is splitted between Big Cores
-            return calculate_bm_timeout_ms(freq, asic_count, small_cores, cores, 4.0, ASIC_SET_TIMEOUT_PERCENT, 20);
+            return calculate_bm_timeout_ms(freq, asic_count, small_cores, cores, 4.0, ASIC_SET_TIMEOUT_PERCENT, asic_default_timeout_divided);
         case BM1366:
-            // ASIC_calculate_bm_timeout_ms(GLOBAL_STATE, GLOBAL_STATE->version_mask >> 13, 1.0);
-            return 2000 / GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
         case BM1368:
         case BM1370:
-            // ASIC_calculate_bm_timeout_ms(GLOBAL_STATE, GLOBAL_STATE->version_mask >> 13, 1.0);
-            return 500 / GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
+            return asic_default_timeout_divided;
     }
     ESP_LOGE(TAG, "Unknown ASIC id %d — cannot compute job frequency", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
     return 500;

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -26,6 +26,32 @@ unsigned char _reverse_bits(unsigned char num)
     return reversed;
 }
 
+int _largest_power_of_two(int num)
+{
+    int power = 0;
+
+    while (num > 1) {
+        num = num >> 1;
+        power++;
+    }
+
+    return 1 << power;
+}
+
+int _next_power_of_two(int num)
+{
+    if (num <= 1)
+        return 1;
+
+    int power = 1;
+
+    while (power < num) {
+        power <<= 1;
+    }
+
+    return power;
+}
+
 int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response_length)
 {
     uint8_t buffer[11] = {0};
@@ -152,9 +178,9 @@ void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask)
 double calculate_bm_timeout_ms(float freq, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent)
 {
     // calulate the fractional asic timeout for (nonce,version) of BM1397+ chips
-    int cores_up = _largest_power_of_two(cores);
-    int small_cores_up = _largest_power_of_two(small_cores);
-    int asic_count_up = _largest_power_of_two(asic_count);
+    int cores_up = _next_power_of_two(cores);
+    int small_cores_up = _next_power_of_two(small_cores);
+    int asic_count_up = _next_power_of_two(asic_count);
 
     double midstates = small_cores_up / cores_up;
     double serial_versions = version_size / midstates;

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -197,7 +197,7 @@ double calculate_bm_timeout_ms(float frequency_mhz, size_t asic_count, size_t sm
     double serial_nonces = (double)NONCE_SPACE / (double)cores_up / (double)asic_count_up;
     double fullspace_timeout_ms = serial_versions * serial_nonces / ((double)frequency_mhz * 1000.0);
 
-    if (!(fullspace_timeout_s > 0.0))
+    if (!(fullspace_timeout_ms > 0.0))
         return default_time_ms;
 
     return (double)timeout_percent * fullspace_timeout_ms;

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -180,7 +180,7 @@ double calculate_bm_timeout_ms(float frequency_mhz, size_t asic_count, size_t sm
     if (asic_count <= 0)
         return default_time_ms;
 
-    // Round up to the nearest power of 2 some constants
+    // Round up to the nearest power of 2 some asic constants
     int cores_up = _next_power_of_two((int)cores);
     int small_cores_up = _next_power_of_two((int)small_cores);
     int asic_count_up = _next_power_of_two((int)asic_count);
@@ -189,7 +189,7 @@ double calculate_bm_timeout_ms(float frequency_mhz, size_t asic_count, size_t sm
         return default_time_ms;
 
     // Calulate the time to scan the full nonce * version space
-    // effectivly how many iterations we have to do
+    // effectively how many iterations we have to do
     // First we remove the paralell nonces/versions
     // then we end up with `time = space / frequency`
     double midstates = (double)small_cores_up / (double)cores_up;

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -200,6 +200,5 @@ double calculate_bm_timeout_ms(float frequency_mhz, size_t asic_count, size_t sm
     if (!(fullspace_timeout_s > 0.0))
         return default_time_ms;
 
-    float s_to_ms = 1000.0;
-    return (double)timeout_percent * fullspace_timeout_s * s_to_ms;
+    return (double)timeout_percent * fullspace_timeout_ms;
 }

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -175,17 +175,18 @@ void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask)
     job_difficulty_mask[5] = _reverse_bits( mask        & 0xFF);
 }
 
-double calculate_bm_timeout_ms(float freq, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent)
+double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent)
 {
     // calulate the fractional asic timeout for (nonce,version) of BM1397+ chips
     int cores_up = _next_power_of_two(cores);
     int small_cores_up = _next_power_of_two(small_cores);
     int asic_count_up = _next_power_of_two(asic_count);
 
-    double midstates = small_cores_up / cores_up;
+    // assumes small cores ~= cores * midstates
+    double midstates = (double)small_cores_up / (double)cores_up;
     double serial_versions = version_size / midstates;
     double serial_nonces = NONCE_SPACE / (double)cores_up / (double)asic_count_up;
-    double fullspace_timeout_ms = serial_versions * serial_nonces / freq / 1000.0;
+    double fullspace_timeout_ms = serial_versions * serial_nonces / frequency_mhz / 1000.0;
 
     return timeout_percent * ASIC_SET_NONCE_SPACE_PERCENT * fullspace_timeout_ms;
 }

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -177,12 +177,15 @@ void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask)
 
 double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent, double default_time_ms)
 {
+    if (asic_count_up <= 0)
+        return default_time_ms;
+
     int cores_up = _next_power_of_two((int)cores);
     int small_cores_up = _next_power_of_two((int)small_cores);
     int asic_count_up = _next_power_of_two((int)asic_count);
 
     // some checks
-    if ((small_cores_up < cores_up) || (frequency_mhz <= 0.0f) || (small_cores_up <= 0) || (cores_up <= 0) || (asic_count_up <= 0))
+    if ((small_cores_up < cores_up) || (frequency_mhz <= 0.0f))
         return default_time_ms;
 
     // calulate the time to scan the full nonce * version space

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -180,7 +180,7 @@ double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_
     if (asic_count <= 0)
         return default_time_ms;
 
-    // round up to the nearest power of 2
+    // Round up to the nearest power of 2 some constants
     int cores_up = _next_power_of_two((int)cores);
     int small_cores_up = _next_power_of_two((int)small_cores);
     int asic_count_up = _next_power_of_two((int)asic_count);
@@ -188,10 +188,10 @@ double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_
     if ((small_cores_up < cores_up) || (frequency_mhz <= 0.0f))
         return default_time_ms;
 
-    // calulate the time to scan the full nonce * version space
-    // effectivly how many iterations do we have to do
-    // so we remove the parralell nonces/versions
-    // we end up with time = space / frequency
+    // Calulate the time to scan the full nonce * version space
+    // effectivly how many iterations we have to do
+    // First we remove the paralell nonces/versions
+    // then we end up with `time = space / frequency`
     double midstates = (double)small_cores_up / (double)cores_up;
     double serial_versions = (double)version_size / midstates;
     double serial_nonces = (double)NONCE_SPACE / (double)cores_up / (double)asic_count_up;

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -195,7 +195,7 @@ double calculate_bm_timeout_ms(float frequency_mhz, size_t asic_count, size_t sm
     double midstates = (double)small_cores_up / (double)cores_up;
     double serial_versions = (double)version_size / midstates;
     double serial_nonces = (double)NONCE_SPACE / (double)cores_up / (double)asic_count_up;
-    double fullspace_timeout_s = serial_versions * serial_nonces / ((double)frequency_mhz * 1000.0 * 1000.0);
+    double fullspace_timeout_ms = serial_versions * serial_nonces / ((double)frequency_mhz * 1000.0);
 
     if (!(fullspace_timeout_s > 0.0))
         return default_time_ms;

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -175,19 +175,28 @@ void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask)
     job_difficulty_mask[5] = _reverse_bits( mask        & 0xFF);
 }
 
-double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent)
+double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent, double default_time_ms)
 {
-    // calulate the fractional asic timeout for (nonce,version) of BM1397+ chips
-    int cores_up = _next_power_of_two(cores);
-    int small_cores_up = _next_power_of_two(small_cores);
-    int asic_count_up = _next_power_of_two(asic_count);
+    int cores_up = _next_power_of_two((int)cores);
+    int small_cores_up = _next_power_of_two((int)small_cores);
+    int asic_count_up = _next_power_of_two((int)asic_count);
 
-    // assumes small cores ~= cores * midstates
+    // some checks
+    if ((small_cores_up < cores_up) || (frequency_mhz <= 0.0f) || (small_cores_up <= 0) || (cores_up <= 0) || (asic_count_up <= 0))
+        return default_time_ms;
+
+    // calulate the time to scan the full nonce * version space
+    // effectivly how many iterations do we have to do
+    // so we remove the parralell nonces/versions
+    // we end up with time = space / frequency
     double midstates = (double)small_cores_up / (double)cores_up;
-    double serial_versions = version_size / midstates;
-    double serial_nonces = NONCE_SPACE / (double)cores_up / (double)asic_count_up;
-    double fullspace_timeout_ms = serial_versions * serial_nonces / frequency_mhz / 1000.0;
+    double serial_versions = (double)version_size / midstates;
+    double serial_nonces = (double)NONCE_SPACE / (double)cores_up / (double)asic_count_up;
+    double fullspace_timeout_s = serial_versions * serial_nonces / ((double)frequency_mhz * 1000.0 * 1000.0);
 
-    return timeout_percent * ASIC_SET_NONCE_SPACE_PERCENT * fullspace_timeout_ms;
+    if (!(fullspace_timeout_s > 0.0))
+        return default_time_ms;
+
+    float s_to_ms = 1000.0;
+    return (double)timeout_percent * (double)ASIC_SET_NONCE_SPACE_PERCENT * fullspace_timeout_s * s_to_ms;
 }
-

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -175,7 +175,7 @@ void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask)
     job_difficulty_mask[5] = _reverse_bits( mask        & 0xFF);
 }
 
-double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent, double default_time_ms)
+double calculate_bm_timeout_ms(float frequency_mhz, size_t asic_count, size_t small_cores, size_t cores, size_t version_size, float timeout_percent, double default_time_ms)
 {
     if (asic_count <= 0)
         return default_time_ms;

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -159,8 +159,8 @@ double calculate_bm_timeout_ms(float freq, uint16_t asic_count, uint16_t small_c
     double midstates = small_cores_up / cores_up;
     double serial_versions = version_size / midstates;
     double serial_nonces = NONCE_SPACE / (double)cores_up / (double)asic_count_up;
-    double fullspace_timeout = serial_versions * serial_nonces / freq;
+    double fullspace_timeout_ms = serial_versions * serial_nonces / freq / 1000.0;
 
-    return timeout_percent * ASIC_SET_NONCE_SPACE_PERCENT * fullspace_timeout;
+    return timeout_percent * ASIC_SET_NONCE_SPACE_PERCENT * fullspace_timeout_ms;
 }
 

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -177,7 +177,7 @@ void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask)
 
 double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent, double default_time_ms)
 {
-    if (asic_count_up <= 0)
+    if (asic_count <= 0)
         return default_time_ms;
 
     int cores_up = _next_power_of_two((int)cores);

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -201,5 +201,5 @@ double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_
         return default_time_ms;
 
     float s_to_ms = 1000.0;
-    return (double)timeout_percent * (double)ASIC_SET_NONCE_SPACE_PERCENT * fullspace_timeout_s * s_to_ms;
+    return (double)timeout_percent * fullspace_timeout_s * s_to_ms;
 }

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -180,11 +180,11 @@ double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_
     if (asic_count <= 0)
         return default_time_ms;
 
+    // round up to the nearest power of 2
     int cores_up = _next_power_of_two((int)cores);
     int small_cores_up = _next_power_of_two((int)small_cores);
     int asic_count_up = _next_power_of_two((int)asic_count);
 
-    // some checks
     if ((small_cores_up < cores_up) || (frequency_mhz <= 0.0f))
         return default_time_ms;
 

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -148,3 +148,19 @@ void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask)
     job_difficulty_mask[4] = _reverse_bits((mask >>  8) & 0xFF);
     job_difficulty_mask[5] = _reverse_bits( mask        & 0xFF);
 }
+
+double calculate_bm_timeout_ms(float freq, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent)
+{
+    // calulate the fractional asic timeout for (nonce,version) of BM1397+ chips
+    int cores_up = _largest_power_of_two(cores);
+    int small_cores_up = _largest_power_of_two(small_cores);
+    int asic_count_up = _largest_power_of_two(asic_count);
+
+    double midstates = small_cores_up / cores_up;
+    double serial_versions = version_size / midstates;
+    double serial_nonces = NONCE_SPACE / (double)cores_up / (double)asic_count_up;
+    double fullspace_timeout = serial_versions * serial_nonces / freq;
+
+    return timeout_percent * ASIC_SET_NONCE_SPACE_PERCENT * fullspace_timeout;
+}
+

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -147,7 +147,7 @@ void BM1366_set_version_mask(uint32_t version_mask)
     _send_BM1366(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1366_SERIALTX_DEBUG);
 }
 
-void BM1366_set_hash_counting_number(int hcn) {
+void BM1366_set_hash_counting_number(uint32_t hcn) {
     uint8_t set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x00, 0x00};
     set_10_hash_counting[2] = (hcn >> 24) & 0xFF;
     set_10_hash_counting[3] = (hcn >> 16) & 0xFF;

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -158,8 +158,8 @@ void BM1366_set_hash_counting_number(int hcn) {
 
 void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
 {   
-    int big_cores_up = _largest_power_of_two(big_cores);
-    int asic_count_up =  _largest_power_of_two(asic_count);
+    int big_cores_up = _next_power_of_two(big_cores);
+    int asic_count_up =  _next_power_of_two(asic_count);
 
     // HCN hash counting number (the size of the nonce space)
     float hcn_space = (float)NONCE_SPACE / big_cores_up / asic_count_up;

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -156,13 +156,13 @@ void BM1366_set_hash_counting_number(uint32_t hcn) {
     _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, BM1366_SERIALTX_DEBUG);
 }
 
-void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
+void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores) 
 {   
-    int big_cores_up = _next_power_of_two(big_cores);
+    int cores_up = _next_power_of_two(cores);
     int asic_count_up =  _next_power_of_two(asic_count);
 
     // HCN hash counting number (the size of the nonce space)
-    float hcn_space = (float)NONCE_SPACE / big_cores_up / asic_count_up;
+    float hcn_space = (float)NONCE_SPACE / cores_up / asic_count_up;
     double hcn_max = hcn_space * (double)FREQ_MULT / frequency * 0.5f; 
     double hcn_frac = nonce_percent * hcn_max;
     uint32_t hcn_register_value = (uint32_t)hcn_frac;

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -162,9 +162,9 @@ void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic
     int asic_count_up =  _largest_power_of_two(asic_count);
 
     // HCN hash counting number (the size of the nonce space)
-    float hcn_space = (float)NONCE_SPACE/big_cores_up/asic_count_up;
-    double hcn_max = hcn_space * (double)FREQ_MULT/frequency * 0.5f; 
-    double hcn_frac = nonce_percent*hcn_max;
+    float hcn_space = (float)NONCE_SPACE / big_cores_up / asic_count_up;
+    double hcn_max = hcn_space * (double)FREQ_MULT / frequency * 0.5f; 
+    double hcn_frac = nonce_percent * hcn_max;
     uint32_t hcn_register_value = (uint32_t)hcn_frac;
 
     BM1366_set_hash_counting_number(hcn_register_value);

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -147,21 +147,27 @@ void BM1366_set_version_mask(uint32_t version_mask)
     _send_BM1366(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1366_SERIALTX_DEBUG);
 }
 
-void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count) 
-{   
-    // HCN hash counting number (the size of the nonce space)
-    double hcn_max = 2^17f/(double)FREQ_MULT; 
-    double hcn_frac = nonce_percent*hcn_max;
-    uint32_t hcn_register_value = (uint32_t)hcn_frac
-
-    //register 10 is still a bit of a mystery. discussion: https://github.com/bitaxeorg/ESP-Miner/pull/167
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x11, 0x5A}; //S19k Pro Default
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x14, 0x46}; //S19XP-Luxos Default
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0x1C}; //S19XP-Stock Default
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x0F, 0x00, 0x00}; //supposedly the "full" 32bit nonce range
-    
-    unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0x1C}; //S19XP-Stock Default
+void BM1366_set_hash_counting_number(int hcn) {
+    uint8_t set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x00, 0x00};
+    set_10_hash_counting[2] = (hcn >> 24) & 0xFF;
+    set_10_hash_counting[3] = (hcn >> 16) & 0xFF;
+    set_10_hash_counting[4] = (hcn >> 8) & 0xFF;
+    set_10_hash_counting[5] = hcn & 0xFF;
     _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, BM1366_SERIALTX_DEBUG);
+}
+
+void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
+{   
+    int big_cores_up = _largest_power_of_two(big_cores);
+    int asic_count_up =  _largest_power_of_two(asic_count);
+
+    // HCN hash counting number (the size of the nonce space)
+    float hcn_space = (float)NONCE_SPACE/big_cores_up/asic_count_up;
+    double hcn_max = hcn_space * (double)FREQ_MULT/frequency * 0.5f; 
+    double hcn_frac = nonce_percent*hcn_max;
+    uint32_t hcn_register_value = (uint32_t)hcn_frac;
+
+    BM1366_set_hash_counting_number(hcn_register_value);
 }
 
 void BM1366_send_hash_frequency(float target_freq)
@@ -257,7 +263,7 @@ uint8_t BM1366_init(void * pvParameters)
 
     do_frequency_transition(GLOBAL_STATE, BM1366_send_hash_frequency);
 
-    BM1366_set_nonce_space(nonce_percent,frequency,asic_count);
+    BM1366_set_nonce_space(ASIC_SET_NONCE_SPACE_PERCENT, frequency, asic_count, big_cores);
 
     unsigned char init795[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
     _send_simple(init795, 11);

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -263,7 +263,7 @@ uint8_t BM1366_init(void * pvParameters)
 
     do_frequency_transition(GLOBAL_STATE, BM1366_send_hash_frequency);
 
-    BM1366_set_nonce_space(1.0, frequency, asic_count, cores);
+    BM1366_set_nonce_space(1.0, BM1366_send_hash_frequency, asic_count, GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count);
 
     unsigned char init795[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
     _send_simple(init795, 11);

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -262,7 +262,11 @@ uint8_t BM1366_init(void * pvParameters)
     }
 
     do_frequency_transition(GLOBAL_STATE, BM1366_send_hash_frequency);
-    ASIC_set_nonce_space(GLOBAL_STATE);
+
+    float frequency = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
+    int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
+
+    BM1366_set_nonce_space(1.0, frequency, asic_count, cores);
 
     unsigned char init795[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
     _send_simple(init795, 11);

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -263,7 +263,10 @@ uint8_t BM1366_init(void * pvParameters)
 
     do_frequency_transition(GLOBAL_STATE, BM1366_send_hash_frequency);
 
-    BM1366_set_nonce_space(1.0, BM1366_send_hash_frequency, asic_count, GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count);
+    float frequency = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
+    int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
+
+    BM1366_set_nonce_space(1.0, frequency, asic_count, cores);
 
     unsigned char init795[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
     _send_simple(init795, 11);

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -147,6 +147,23 @@ void BM1366_set_version_mask(uint32_t version_mask)
     _send_BM1366(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1366_SERIALTX_DEBUG);
 }
 
+void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count) 
+{   
+    // HCN hash counting number (the size of the nonce space)
+    double hcn_max = 2^17f/(double)FREQ_MULT; 
+    double hcn_frac = nonce_percent*hcn_max;
+    uint32_t hcn_register_value = (uint32_t)hcn_frac
+
+    //register 10 is still a bit of a mystery. discussion: https://github.com/bitaxeorg/ESP-Miner/pull/167
+    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x11, 0x5A}; //S19k Pro Default
+    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x14, 0x46}; //S19XP-Luxos Default
+    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0x1C}; //S19XP-Stock Default
+    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x0F, 0x00, 0x00}; //supposedly the "full" 32bit nonce range
+    
+    unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0x1C}; //S19XP-Stock Default
+    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, BM1366_SERIALTX_DEBUG);
+}
+
 void BM1366_send_hash_frequency(float target_freq)
 {
     uint8_t fb_divider, refdiv, postdiv1, postdiv2;
@@ -240,13 +257,7 @@ uint8_t BM1366_init(void * pvParameters)
 
     do_frequency_transition(GLOBAL_STATE, BM1366_send_hash_frequency);
 
-    //register 10 is still a bit of a mystery. discussion: https://github.com/bitaxeorg/ESP-Miner/pull/167
-
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x11, 0x5A}; //S19k Pro Default
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x14, 0x46}; //S19XP-Luxos Default
-    unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0x1C}; //S19XP-Stock Default
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x0F, 0x00, 0x00}; //supposedly the "full" 32bit nonce range
-    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, BM1366_SERIALTX_DEBUG);
+    BM1366_set_nonce_space(nonce_percent,frequency,asic_count);
 
     unsigned char init795[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
     _send_simple(init795, 11);

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -262,11 +262,7 @@ uint8_t BM1366_init(void * pvParameters)
     }
 
     do_frequency_transition(GLOBAL_STATE, BM1366_send_hash_frequency);
-
-    float frequency = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
-    int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
-
-    BM1366_set_nonce_space(1.0, frequency, asic_count, cores);
+    ASIC_set_nonce_space(GLOBAL_STATE);
 
     unsigned char init795[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
     _send_simple(init795, 11);

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -263,7 +263,7 @@ uint8_t BM1366_init(void * pvParameters)
 
     do_frequency_transition(GLOBAL_STATE, BM1366_send_hash_frequency);
 
-    BM1366_set_nonce_space(1.0, frequency, asic_count, big_cores);
+    BM1366_set_nonce_space(1.0, frequency, asic_count, cores);
 
     unsigned char init795[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
     _send_simple(init795, 11);

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -263,7 +263,7 @@ uint8_t BM1366_init(void * pvParameters)
 
     do_frequency_transition(GLOBAL_STATE, BM1366_send_hash_frequency);
 
-    BM1366_set_nonce_space(ASIC_SET_NONCE_SPACE_PERCENT, frequency, asic_count, big_cores);
+    BM1366_set_nonce_space(1.0, frequency, asic_count, big_cores);
 
     unsigned char init795[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF, 0x1C};
     _send_simple(init795, 11);

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -135,8 +135,8 @@ void BM1368_set_hash_counting_number(int hcn) {
 
 void BM1368_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
 {   
-    int big_cores_up = _largest_power_of_two(big_cores);
-    int asic_count_up =  _largest_power_of_two(asic_count);
+    int big_cores_up = _next_power_of_two(big_cores);
+    int asic_count_up =  _next_power_of_two(asic_count);
 
     // HCN hash counting number (the size of the nonce space)
     float hcn_space = (float)NONCE_SPACE / big_cores_up / asic_count_up;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -139,9 +139,9 @@ void BM1368_set_nonce_space(double nonce_percent, float frequency, uint16_t asic
     int asic_count_up =  _largest_power_of_two(asic_count);
 
     // HCN hash counting number (the size of the nonce space)
-    float hcn_space = (float)NONCE_SPACE/big_cores_up/asic_count_up;
-    double hcn_max = hcn_space * (double)FREQ_MULT/frequency * 0.5f; 
-    double hcn_frac = nonce_percent*hcn_max;
+    float hcn_space = (float)NONCE_SPACE / big_cores_up / asic_count_up;
+    double hcn_max = hcn_space * (double)FREQ_MULT / frequency * 0.5f; 
+    double hcn_frac = nonce_percent * hcn_max;
     uint32_t hcn_register_value = (uint32_t)hcn_frac;
 
     BM1368_set_hash_counting_number(hcn_register_value);

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -124,7 +124,7 @@ void BM1368_set_version_mask(uint32_t version_mask)
     _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1368_SERIALTX_DEBUG);
 }
 
-void BM1368_set_hash_counting_number(int hcn) {
+void BM1368_set_hash_counting_number(uint32_t hcn) {
     uint8_t set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x00, 0x00};
     set_10_hash_counting[2] = (hcn >> 24) & 0xFF;
     set_10_hash_counting[3] = (hcn >> 16) & 0xFF;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -133,13 +133,13 @@ void BM1368_set_hash_counting_number(uint32_t hcn) {
     _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, BM1368_SERIALTX_DEBUG);
 }
 
-void BM1368_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
+void BM1368_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores) 
 {   
-    int big_cores_up = _next_power_of_two(big_cores);
+    int cores_up = _next_power_of_two(cores);
     int asic_count_up =  _next_power_of_two(asic_count);
 
     // HCN hash counting number (the size of the nonce space)
-    float hcn_space = (float)NONCE_SPACE / big_cores_up / asic_count_up;
+    float hcn_space = (float)NONCE_SPACE / cores_up / asic_count_up;
     double hcn_max = hcn_space * (double)FREQ_MULT / frequency * 0.5f; 
     double hcn_frac = nonce_percent * hcn_max;
     uint32_t hcn_register_value = (uint32_t)hcn_frac;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -225,7 +225,7 @@ uint8_t BM1368_init(void * pvParameters)
 
     do_frequency_transition(GLOBAL_STATE, BM1368_send_hash_frequency);
 
-    BM1368_set_nonce_space(1.0, frequency, asic_count, cores);
+    BM1368_set_nonce_space(1.0, BM1368_send_hash_frequency, asic_count, GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count);
     BM1368_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
 
     return chip_counter;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -224,8 +224,11 @@ uint8_t BM1368_init(void * pvParameters)
     _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), difficulty_mask, 6, BM1368_SERIALTX_DEBUG);    
 
     do_frequency_transition(GLOBAL_STATE, BM1368_send_hash_frequency);
-    ASIC_set_nonce_space(GLOBAL_STATE);
 
+    float frequency = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
+    int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
+
+    BM1368_set_nonce_space(1.0, frequency, asic_count,cores);
     BM1368_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
 
     return chip_counter;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -225,7 +225,7 @@ uint8_t BM1368_init(void * pvParameters)
 
     do_frequency_transition(GLOBAL_STATE, BM1368_send_hash_frequency);
 
-    BM1368_set_nonce_space(1.0, frequency, asic_count, big_cores);
+    BM1368_set_nonce_space(1.0, frequency, asic_count, cores);
     BM1368_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
 
     return chip_counter;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -225,7 +225,7 @@ uint8_t BM1368_init(void * pvParameters)
 
     do_frequency_transition(GLOBAL_STATE, BM1368_send_hash_frequency);
 
-    BM1368_set_nonce_space(ASIC_SET_NONCE_SPACE_PERCENT, frequency, asic_count, big_cores);
+    BM1368_set_nonce_space(1.0, frequency, asic_count, big_cores);
     BM1368_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
 
     return chip_counter;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -225,7 +225,10 @@ uint8_t BM1368_init(void * pvParameters)
 
     do_frequency_transition(GLOBAL_STATE, BM1368_send_hash_frequency);
 
-    BM1368_set_nonce_space(1.0, BM1368_send_hash_frequency, asic_count, GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count);
+    float frequency = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
+    int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
+
+    BM1368_set_nonce_space(1.0, frequency, asic_count,cores);
     BM1368_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
 
     return chip_counter;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -124,6 +124,29 @@ void BM1368_set_version_mask(uint32_t version_mask)
     _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1368_SERIALTX_DEBUG);
 }
 
+void BM1368_set_hash_counting_number(int hcn) {
+    uint8_t set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x00, 0x00};
+    set_10_hash_counting[2] = (hcn >> 24) & 0xFF;
+    set_10_hash_counting[3] = (hcn >> 16) & 0xFF;
+    set_10_hash_counting[4] = (hcn >> 8) & 0xFF;
+    set_10_hash_counting[5] = hcn & 0xFF;
+    _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, BM1368_SERIALTX_DEBUG);
+}
+
+void BM1368_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
+{   
+    int big_cores_up = _largest_power_of_two(big_cores);
+    int asic_count_up =  _largest_power_of_two(asic_count);
+
+    // HCN hash counting number (the size of the nonce space)
+    float hcn_space = (float)NONCE_SPACE/big_cores_up/asic_count_up;
+    double hcn_max = hcn_space * (double)FREQ_MULT/frequency * 0.5f; 
+    double hcn_frac = nonce_percent*hcn_max;
+    uint32_t hcn_register_value = (uint32_t)hcn_frac;
+
+    BM1368_set_hash_counting_number(hcn_register_value);
+}
+
 void BM1368_send_hash_frequency(float target_freq) 
 {
     uint8_t fb_divider, refdiv, postdiv1, postdiv2;
@@ -202,7 +225,7 @@ uint8_t BM1368_init(void * pvParameters)
 
     do_frequency_transition(GLOBAL_STATE, BM1368_send_hash_frequency);
 
-    _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, (uint8_t[]){0x00, 0x10, 0x00, 0x00, 0x15, 0xa4}, 6, false);
+    BM1368_set_nonce_space(ASIC_SET_NONCE_SPACE_PERCENT, frequency, asic_count, big_cores);
     BM1368_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
 
     return chip_counter;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -224,11 +224,8 @@ uint8_t BM1368_init(void * pvParameters)
     _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_WRITE), difficulty_mask, 6, BM1368_SERIALTX_DEBUG);    
 
     do_frequency_transition(GLOBAL_STATE, BM1368_send_hash_frequency);
+    ASIC_set_nonce_space(GLOBAL_STATE);
 
-    float frequency = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
-    int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
-
-    BM1368_set_nonce_space(1.0, frequency, asic_count,cores);
     BM1368_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
 
     return chip_counter;

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -151,13 +151,13 @@ void BM1370_set_hash_counting_number(uint32_t hcn) {
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, BM1370_SERIALTX_DEBUG);
 }
 
-void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
+void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores) 
 {   
-    int big_cores_up = _next_power_of_two(big_cores);
+    int cores_up = _next_power_of_two(cores);
     int asic_count_up =  _next_power_of_two(asic_count);
 
     // HCN hash counting number (the size of the nonce space)
-    float hcn_space = (float)NONCE_SPACE / big_cores_up / asic_count_up;
+    float hcn_space = (float)NONCE_SPACE / cores_up / asic_count_up;
     double hcn_max = hcn_space * (double)FREQ_MULT / frequency * 0.5f; 
     double hcn_frac = nonce_percent * hcn_max;
     uint32_t hcn_register_value = (uint32_t)hcn_frac;

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -153,8 +153,8 @@ void BM1370_set_hash_counting_number(int hcn) {
 
 void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
 {   
-    int big_cores_up = _largest_power_of_two(big_cores);
-    int asic_count_up =  _largest_power_of_two(asic_count);
+    int big_cores_up = _next_power_of_two(big_cores);
+    int asic_count_up =  _next_power_of_two(asic_count);
 
     // HCN hash counting number (the size of the nonce space)
     float hcn_space = (float)NONCE_SPACE / big_cores_up / asic_count_up;

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -142,7 +142,7 @@ void BM1370_set_version_mask(uint32_t version_mask)
     _send_BM1370(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1370_SERIALTX_DEBUG);
 }
 
-void BM1370_set_hash_counting_number(int hcn) {
+void BM1370_set_hash_counting_number(uint32_t hcn) {
     uint8_t set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x00, 0x00};
     set_10_hash_counting[2] = (hcn >> 24) & 0xFF;
     set_10_hash_counting[3] = (hcn >> 16) & 0xFF;

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -157,9 +157,9 @@ void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic
     int asic_count_up =  _largest_power_of_two(asic_count);
 
     // HCN hash counting number (the size of the nonce space)
-    float hcn_space = (float)NONCE_SPACE/big_cores_up/asic_count_up;
-    double hcn_max = hcn_space * (double)FREQ_MULT/frequency * 0.5f; 
-    double hcn_frac = nonce_percent*hcn_max;
+    float hcn_space = (float)NONCE_SPACE / big_cores_up / asic_count_up;
+    double hcn_max = hcn_space * (double)FREQ_MULT / frequency * 0.5f; 
+    double hcn_frac = nonce_percent * hcn_max;
     uint32_t hcn_register_value = (uint32_t)hcn_frac;
 
     //register 10 is still a bit of a mystery. discussion: https://github.com/bitaxeorg/ESP-Miner/pull/167

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -162,11 +162,6 @@ void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic
     double hcn_frac = nonce_percent * hcn_max;
     uint32_t hcn_register_value = (uint32_t)hcn_frac;
 
-    //register 10 is still a bit of a mystery. discussion: https://github.com/bitaxeorg/ESP-Miner/pull/167
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x11, 0x5A}; //S19k Pro Default
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x14, 0x46}; //S19XP-Luxos Default
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0x1C}; //S19XP-Stock Default
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x0F, 0x00, 0x00}; //supposedly the "full" 32bit nonce range
     BM1370_set_hash_counting_number(hcn_register_value);
 }
 

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -142,6 +142,34 @@ void BM1370_set_version_mask(uint32_t version_mask)
     _send_BM1370(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1370_SERIALTX_DEBUG);
 }
 
+void BM1370_set_hash_counting_number(int hcn) {
+    uint8_t set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x00, 0x00};
+    set_10_hash_counting[2] = (hcn >> 24) & 0xFF;
+    set_10_hash_counting[3] = (hcn >> 16) & 0xFF;
+    set_10_hash_counting[4] = (hcn >> 8) & 0xFF;
+    set_10_hash_counting[5] = hcn & 0xFF;
+    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, BM1370_SERIALTX_DEBUG);
+}
+
+void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
+{   
+    int big_cores_up = _largest_power_of_two(big_cores);
+    int asic_count_up =  _largest_power_of_two(asic_count);
+
+    // HCN hash counting number (the size of the nonce space)
+    float hcn_space = (float)NONCE_SPACE/big_cores_up/asic_count_up;
+    double hcn_max = hcn_space * (double)FREQ_MULT/frequency * 0.5f; 
+    double hcn_frac = nonce_percent*hcn_max;
+    uint32_t hcn_register_value = (uint32_t)hcn_frac;
+
+    //register 10 is still a bit of a mystery. discussion: https://github.com/bitaxeorg/ESP-Miner/pull/167
+    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x11, 0x5A}; //S19k Pro Default
+    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x14, 0x46}; //S19XP-Luxos Default
+    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0x1C}; //S19XP-Stock Default
+    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x0F, 0x00, 0x00}; //supposedly the "full" 32bit nonce range
+    BM1370_set_hash_counting_number(hcn_register_value);
+}
+
 void BM1370_send_hash_frequency(float target_freq) 
 {
     uint8_t fb_divider, refdiv, postdiv1, postdiv2;
@@ -260,15 +288,7 @@ uint8_t BM1370_init(void * pvParameters)
     //ramp up the hash frequency
     do_frequency_transition(GLOBAL_STATE, BM1370_send_hash_frequency);
 
-    //register 10 is still a bit of a mystery. discussion: https://github.com/bitaxeorg/ESP-Miner/pull/167
-
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x11, 0x5A}; //S19k Pro Default
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x14, 0x46}; //S19XP-Luxos Default
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0x1C}; //S19XP-Stock Default
-    //unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0xA4}; //S21-Stock Default
-    unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x1E, 0xB5}; //S21 Pro-Stock Default
-    // unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x0F, 0x00, 0x00}; //supposedly the "full" 32bit nonce range
-    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), set_10_hash_counting, 6, BM1370_SERIALTX_DEBUG);
+    BM1370_set_nonce_space(ASIC_SET_NONCE_SPACE_PERCENT, frequency, asic_count, big_cores);
 
     return chip_counter;
 }

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -159,7 +159,10 @@ void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic
     // HCN hash counting number (the size of the nonce space)
     float hcn_space = (float)NONCE_SPACE / cores_up / asic_count_up;
     double hcn_max = hcn_space * (double)FREQ_MULT / frequency * 0.5f; 
-    double hcn_frac = nonce_percent * hcn_max;
+    // BM1370 has a HW errata of 134 per clock cycle
+    // use 2x value overwise we can get duplicates
+    int hcn_error = 2 * 134;
+    double hcn_frac = nonce_percent * (hcn_max - hcn_error);
     uint32_t hcn_register_value = (uint32_t)hcn_frac;
 
     BM1370_set_hash_counting_number(hcn_register_value);

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -286,7 +286,10 @@ uint8_t BM1370_init(void * pvParameters)
     //ramp up the hash frequency
     do_frequency_transition(GLOBAL_STATE, BM1370_send_hash_frequency);
 
-    BM1370_set_nonce_space(1.0, BM1370_send_hash_frequency, asic_count, GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count);
+    float frequency = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
+    int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
+
+    BM1370_set_nonce_space(1.0, frequency, asic_count, cores);
 
     return chip_counter;
 }

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -285,11 +285,7 @@ uint8_t BM1370_init(void * pvParameters)
 
     //ramp up the hash frequency
     do_frequency_transition(GLOBAL_STATE, BM1370_send_hash_frequency);
-
-    float frequency = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
-    int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
-
-    BM1370_set_nonce_space(1.0, frequency, asic_count, cores);
+    ASIC_set_nonce_space(GLOBAL_STATE);
 
     return chip_counter;
 }

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -286,7 +286,7 @@ uint8_t BM1370_init(void * pvParameters)
     //ramp up the hash frequency
     do_frequency_transition(GLOBAL_STATE, BM1370_send_hash_frequency);
 
-    BM1370_set_nonce_space(1.0, frequency, asic_count, cores);
+    BM1370_set_nonce_space(1.0, BM1370_send_hash_frequency, asic_count, GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count);
 
     return chip_counter;
 }

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -285,7 +285,11 @@ uint8_t BM1370_init(void * pvParameters)
 
     //ramp up the hash frequency
     do_frequency_transition(GLOBAL_STATE, BM1370_send_hash_frequency);
-    ASIC_set_nonce_space(GLOBAL_STATE);
+
+    float frequency = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value;
+    int cores = GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count;
+
+    BM1370_set_nonce_space(1.0, frequency, asic_count, cores);
 
     return chip_counter;
 }

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -288,7 +288,7 @@ uint8_t BM1370_init(void * pvParameters)
     //ramp up the hash frequency
     do_frequency_transition(GLOBAL_STATE, BM1370_send_hash_frequency);
 
-    BM1370_set_nonce_space(ASIC_SET_NONCE_SPACE_PERCENT, frequency, asic_count, big_cores);
+    BM1370_set_nonce_space(1.0, frequency, asic_count, big_cores);
 
     return chip_counter;
 }

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -283,7 +283,7 @@ uint8_t BM1370_init(void * pvParameters)
     //ramp up the hash frequency
     do_frequency_transition(GLOBAL_STATE, BM1370_send_hash_frequency);
 
-    BM1370_set_nonce_space(1.0, frequency, asic_count, big_cores);
+    BM1370_set_nonce_space(1.0, frequency, asic_count, cores);
 
     return chip_counter;
 }

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -149,9 +149,12 @@ void BM1397_set_version_mask(uint32_t version_mask) {
     // placeholder
 }
 
+void BM1397_set_hash_counting_number(uint32_t hcn) {
+    // HCN for BM1397 is register 0x14, but seemingly it doesnt do anything
+}
+
 void BM1397_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
 {   
-    // HCN for BM1397 is register 0x14, but seemingly it doesnt do anything
     // placeholder
 }
 

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -131,7 +131,6 @@ static void _send_read_address(void)
 
 static void _send_chain_inactive(void)
 {
-
     unsigned char read_address[2] = {0x00, 0x00};
     // send serial data
     _send_BM1397((TYPE_CMD | GROUP_ALL | CMD_INACTIVE), read_address, 2, BM1397_SERIALTX_DEBUG);
@@ -139,25 +138,15 @@ static void _send_chain_inactive(void)
 
 static void _set_chip_address(uint8_t chipAddr)
 {
-
     unsigned char read_address[2] = {chipAddr, 0x00};
     // send serial data
     _send_BM1397((TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS), read_address, 2, BM1397_SERIALTX_DEBUG);
 }
 
-void BM1397_set_version_mask(uint32_t version_mask) {
+void BM1397_set_version_mask(uint32_t version_mask) 
+{
     // placeholder
 }
-
-void BM1397_set_hash_counting_number(uint32_t hcn) {
-    // HCN for BM1397 is register 0x14, but seemingly it doesnt do anything
-}
-
-void BM1397_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores) 
-{   
-    // placeholder
-}
-
 
 void BM1397_send_hash_frequency(float target_freq)
 {

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -153,7 +153,7 @@ void BM1397_set_hash_counting_number(uint32_t hcn) {
     // HCN for BM1397 is register 0x14, but seemingly it doesnt do anything
 }
 
-void BM1397_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
+void BM1397_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores) 
 {   
     // placeholder
 }

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -149,6 +149,13 @@ void BM1397_set_version_mask(uint32_t version_mask) {
     // placeholder
 }
 
+void BM1397_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores) 
+{   
+    // HCN for BM1397 is register 0x14, but seemingly it doesnt do anything
+    // placeholder
+}
+
+
 void BM1397_send_hash_frequency(float target_freq)
 {
     uint8_t fb_divider, refdiv, postdiv1, postdiv2;

--- a/components/asic/include/asic.h
+++ b/components/asic/include/asic.h
@@ -11,6 +11,7 @@ int ASIC_set_max_baud(GlobalState * GLOBAL_STATE);
 void ASIC_send_work(GlobalState * GLOBAL_STATE, void * next_job);
 void ASIC_set_version_mask(GlobalState * GLOBAL_STATE, uint32_t mask);
 void ASIC_set_frequency(GlobalState * GLOBAL_STATE);
+void ASIC_set_nonce_space(GlobalState * GLOBAL_STATE);
 double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE);
 void ASIC_read_registers(GlobalState * GLOBAL_STATE);
 

--- a/components/asic/include/asic_common.h
+++ b/components/asic/include/asic_common.h
@@ -6,8 +6,6 @@
 #include "esp_err.h"
 
 static const double NONCE_SPACE = 4294967296.0; //  2^32
-static const double ASIC_SET_NONCE_SPACE_PERCENT = 1.0;
-static const double ASIC_SET_TIMEOUT_PERCENT = 1.0;
 
 typedef enum
 {

--- a/components/asic/include/asic_common.h
+++ b/components/asic/include/asic_common.h
@@ -7,6 +7,7 @@
 
 static const double NONCE_SPACE = 4294967296.0; //  2^32
 static const double ASIC_SET_NONCE_SPACE_PERCENT = 1.0;
+static const double ASIC_SET_TIMEOUT_PERCENT = 1.0;
 
 typedef enum
 {
@@ -43,5 +44,6 @@ int _largest_power_of_two(int num);
 int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response_length);
 esp_err_t receive_work(uint8_t * buffer, int buffer_size, uint64_t *out_timestamp_us);
 void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask);
+double calculate_bm_timeout_ms(float freq, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent);
 
 #endif /* ASIC_COMMON_H_ */

--- a/components/asic/include/asic_common.h
+++ b/components/asic/include/asic_common.h
@@ -5,6 +5,9 @@
 #include <stdbool.h>
 #include "esp_err.h"
 
+static const double NONCE_SPACE = 4294967296.0; //  2^32
+static const double ASIC_SET_NONCE_SPACE_PERCENT = 1.0;
+
 typedef enum
 {
     REGISTER_INVALID = 0,
@@ -33,9 +36,6 @@ typedef struct
     // ---- timestamp
     uint64_t timestamp_us;
 } task_result;
-
-static const double NONCE_SPACE = 4294967296.0; //  2^32
-static const double ASIC_SET_NONCE_SPACE_PERCENT = 1.0; // used by BM1362+
 
 unsigned char _reverse_bits(unsigned char num);
 int _largest_power_of_two(int num);

--- a/components/asic/include/asic_common.h
+++ b/components/asic/include/asic_common.h
@@ -40,7 +40,7 @@ typedef struct
 
 unsigned char _reverse_bits(unsigned char num);
 int _largest_power_of_two(int num);
-
+int _next_power_of_two(int num);
 int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response_length);
 esp_err_t receive_work(uint8_t * buffer, int buffer_size, uint64_t *out_timestamp_us);
 void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask);

--- a/components/asic/include/asic_common.h
+++ b/components/asic/include/asic_common.h
@@ -44,6 +44,6 @@ int _largest_power_of_two(int num);
 int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response_length);
 esp_err_t receive_work(uint8_t * buffer, int buffer_size, uint64_t *out_timestamp_us);
 void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask);
-double calculate_bm_timeout_ms(float freq, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent);
+double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent, double default_time_ms);=======
 
 #endif /* ASIC_COMMON_H_ */

--- a/components/asic/include/asic_common.h
+++ b/components/asic/include/asic_common.h
@@ -42,6 +42,6 @@ int _next_power_of_two(int num);
 int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response_length);
 esp_err_t receive_work(uint8_t * buffer, int buffer_size, uint64_t *out_timestamp_us);
 void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask);
-double calculate_bm_timeout_ms(float frequency_mhz, uint16_t asic_count, uint16_t small_cores, uint16_t cores, float version_size, float timeout_percent, double default_time_ms);=======
+double calculate_bm_timeout_ms(float frequency_mhz, size_t asic_count, size_t small_cores, size_t cores, size_t version_size, float timeout_percent, double default_time_ms);
 
 #endif /* ASIC_COMMON_H_ */

--- a/components/asic/include/asic_common.h
+++ b/components/asic/include/asic_common.h
@@ -34,6 +34,8 @@ typedef struct
     uint64_t timestamp_us;
 } task_result;
 
+static const double NONCE_SPACE = 4294967296.0; //  2^32
+static const double ASIC_SET_NONCE_SPACE_PERCENT = 1.0; // used by BM1362+
 
 unsigned char _reverse_bits(unsigned char num);
 int _largest_power_of_two(int num);

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -24,7 +24,7 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1366_init(void * GLOBAL_STATE);
 void BM1366_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1366_set_version_mask(uint32_t version_mask);
-void BM1366_set_hash_counting_number(int hcn);
+void BM1366_set_hash_counting_number(uint32_t hcn);
 void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1366_set_max_baud(void);
 int BM1366_set_default_baud(void);

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -29,6 +29,6 @@ int BM1366_set_default_baud(void);
 void BM1366_send_hash_frequency(float frequency);
 task_result * BM1366_process_work(void * GLOBAL_STATE);
 void BM1366_read_registers(void);
-void BM1366_set_nonce_space(void * GLOBAL_STATE);
+void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores);
 
 #endif /* BM1366_H_ */

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -29,5 +29,6 @@ int BM1366_set_default_baud(void);
 void BM1366_send_hash_frequency(float frequency);
 task_result * BM1366_process_work(void * GLOBAL_STATE);
 void BM1366_read_registers(void);
+void BM1366_set_nonce_space(void * GLOBAL_STATE);
 
 #endif /* BM1366_H_ */

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -24,8 +24,6 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1366_init(void * GLOBAL_STATE);
 void BM1366_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1366_set_version_mask(uint32_t version_mask);
-void BM1366_set_hash_counting_number(uint32_t hcn);
-void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1366_set_max_baud(void);
 int BM1366_set_default_baud(void);
 void BM1366_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -24,6 +24,8 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1366_init(void * GLOBAL_STATE);
 void BM1366_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1366_set_version_mask(uint32_t version_mask);
+void BM1366_set_hash_counting_number(int hcn);
+void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1366_set_max_baud(void);
 int BM1366_set_default_baud(void);
 void BM1366_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -29,5 +29,6 @@ int BM1368_set_default_baud(void);
 void BM1368_send_hash_frequency(float frequency);
 task_result * BM1368_process_work(void * GLOBAL_STATE);
 void BM1368_read_registers(void);
+void BM1368_set_nonce_space(void * GLOBAL_STATE);
 
 #endif /* BM1368_H_ */

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -24,8 +24,6 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1368_init(void * GLOBAL_STATE);
 void BM1368_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1368_set_version_mask(uint32_t version_mask);
-void BM1368_set_hash_counting_number(uint32_t hcn);
-void BM1368_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1368_set_max_baud(void);
 int BM1368_set_default_baud(void);
 void BM1368_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -24,7 +24,7 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1368_init(void * GLOBAL_STATE);
 void BM1368_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1368_set_version_mask(uint32_t version_mask);
-void BM1368_set_hash_counting_number(int hcn);
+void BM1368_set_hash_counting_number(uint32_t hcn);
 void BM1368_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1368_set_max_baud(void);
 int BM1368_set_default_baud(void);

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -24,6 +24,8 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1368_init(void * GLOBAL_STATE);
 void BM1368_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1368_set_version_mask(uint32_t version_mask);
+void BM1368_set_hash_counting_number(int hcn);
+void BM1368_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1368_set_max_baud(void);
 int BM1368_set_default_baud(void);
 void BM1368_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -29,6 +29,6 @@ int BM1368_set_default_baud(void);
 void BM1368_send_hash_frequency(float frequency);
 task_result * BM1368_process_work(void * GLOBAL_STATE);
 void BM1368_read_registers(void);
-void BM1368_set_nonce_space(void * GLOBAL_STATE);
+void BM1368_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores);
 
 #endif /* BM1368_H_ */

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -24,7 +24,7 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1370_init(void * GLOBAL_STATE);
 void BM1370_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1370_set_version_mask(uint32_t version_mask);
-void BM1370_set_hash_counting_number(int hcn);
+void BM1370_set_hash_counting_number(uint32_t hcn);
 void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1370_set_max_baud(void);
 int BM1370_set_default_baud(void);

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -24,8 +24,6 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1370_init(void * GLOBAL_STATE);
 void BM1370_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1370_set_version_mask(uint32_t version_mask);
-void BM1370_set_hash_counting_number(uint32_t hcn);
-void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1370_set_max_baud(void);
 int BM1370_set_default_baud(void);
 void BM1370_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -29,6 +29,6 @@ int BM1370_set_default_baud(void);
 void BM1370_send_hash_frequency(float frequency);
 task_result * BM1370_process_work(void * GLOBAL_STATE);
 void BM1370_read_registers(void);
-void BM1370_set_nonce_space(void * GLOBAL_STATE);
+void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores);
 
 #endif /* BM1370_H_ */

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -24,6 +24,8 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1370_init(void * GLOBAL_STATE);
 void BM1370_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1370_set_version_mask(uint32_t version_mask);
+void BM1370_set_hash_counting_number(int hcn);
+void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1370_set_max_baud(void);
 int BM1370_set_default_baud(void);
 void BM1370_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -29,5 +29,6 @@ int BM1370_set_default_baud(void);
 void BM1370_send_hash_frequency(float frequency);
 task_result * BM1370_process_work(void * GLOBAL_STATE);
 void BM1370_read_registers(void);
+void BM1370_set_nonce_space(void * GLOBAL_STATE);
 
 #endif /* BM1370_H_ */

--- a/components/asic/include/bm1397.h
+++ b/components/asic/include/bm1397.h
@@ -26,8 +26,6 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1397_init(void * GLOBAL_STATE);
 void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1397_set_version_mask(uint32_t version_mask);
-void BM1397_set_hash_counting_number(uint32_t hcn);
-void BM1397_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1397_set_max_baud(void);
 int BM1397_set_default_baud(void);
 void BM1397_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1397.h
+++ b/components/asic/include/bm1397.h
@@ -26,6 +26,8 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1397_init(void * GLOBAL_STATE);
 void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1397_set_version_mask(uint32_t version_mask);
+void BM1397_set_hash_counting_number(int hcn);
+void BM1397_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1397_set_max_baud(void);
 int BM1397_set_default_baud(void);
 void BM1397_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1397.h
+++ b/components/asic/include/bm1397.h
@@ -26,7 +26,7 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1397_init(void * GLOBAL_STATE);
 void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1397_set_version_mask(uint32_t version_mask);
-void BM1397_set_hash_counting_number(int hcn);
+void BM1397_set_hash_counting_number(uint32_t hcn);
 void BM1397_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t big_cores);
 int BM1397_set_max_baud(void);
 int BM1397_set_default_baud(void);

--- a/components/asic/test/test_timeout.c
+++ b/components/asic/test/test_timeout.c
@@ -13,7 +13,7 @@ TEST_CASE("Check asic timeout 1x BM1397", "[common]")
     float default_timeout_ms = 20;
 
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, default_timeout_ms);
-    double expected_ms = timeout_percent * ( 1<<24 ) / (frequency * 1000) / asic_count;
+    double expected_ms = 27.962;
 
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }
@@ -29,7 +29,7 @@ TEST_CASE("Check asic timeout 2x BM1370", "[common]")
     float default_timeout_ms = 500;
 
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, default_timeout_ms);
-    double expected_ms = timeout_percent * (version_size / 16.0) * (1 << 25) / (frequency * 1000) / asic_count;
+    double expected_ms = 76354.974;
 
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }
@@ -60,7 +60,7 @@ TEST_CASE("Check asic timeout 3x BM1370", "[common]")
     float default_timeout_ms = 500;
 
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, default_timeout_ms);
-    double expected_ms = timeout_percent * (version_size / 16.0) * (1 << 25) / (frequency * 1000) / (asic_count+1);
+    double expected_ms = 149.131;
 
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }
@@ -76,7 +76,7 @@ TEST_CASE("Check max asic timeout 1x BM1370", "[common]")
     float default_timeout_ms = 500;
 
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, default_timeout_ms);
-    double expected_ms = timeout_percent * (version_size / 16.0) * (1 << 25) / (frequency * 1000) / (asic_count);
+    double expected_ms = 305419.897;
 
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }

--- a/components/asic/test/test_timeout.c
+++ b/components/asic/test/test_timeout.c
@@ -1,6 +1,6 @@
 #include "unity.h"
 
-#include "common.h"
+#include "asic_common.h"
 
 TEST_CASE("Check asic timeout BM1397", "[common]")
 {
@@ -14,7 +14,7 @@ TEST_CASE("Check asic timeout BM1397", "[common]")
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent);
     double expected_ms = timeout_percent * (1<<24) / (frequency*1000) / asic_count;
 
-    TEST_ASSERT_FLOAT_WITHIN(expected_ms-0.01, exexpected_msected+0.01, timeout_ms);
+    TEST_ASSERT_FLOAT_WITHIN(expected_ms-0.01, expected_ms+0.01, timeout_ms);
 }
 
 TEST_CASE("Check asic timeout BM1370", "[common]")

--- a/components/asic/test/test_timeout.c
+++ b/components/asic/test/test_timeout.c
@@ -14,7 +14,7 @@ TEST_CASE("Check asic timeout BM1397", "[common]")
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent);
     double expected_ms = timeout_percent * (1<<24) / (frequency*1000) / asic_count;
 
-    TEST_ASSERT_FLOAT_WITHIN(expected_ms-0.01, expected_ms+0.01, timeout_ms);
+    TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }
 
 TEST_CASE("Check asic timeout BM1370", "[common]")
@@ -29,5 +29,5 @@ TEST_CASE("Check asic timeout BM1370", "[common]")
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent);
     double expected_ms = timeout_percent * (version_size>>4) * (1<<25) / (frequency*1000) / asic_count;
 
-    TEST_ASSERT_FLOAT_WITHIN(expected_ms-0.01, expected_ms+0.01, timeout_ms);
+    TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }

--- a/components/asic/test/test_timeout.c
+++ b/components/asic/test/test_timeout.c
@@ -12,7 +12,7 @@ TEST_CASE("Check asic timeout BM1397", "[common]")
     float timeout_percent = 0.75;
 
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent);
-    double expected_ms = timeout_percent * (1<<24) / (frequency*1000) / asic_count
+    double expected_ms = timeout_percent * (1<<24) / (frequency*1000) / asic_count;
 
     TEST_ASSERT_FLOAT_WITHIN(expected_ms-0.01, exexpected_msected+0.01, timeout_ms);
 }
@@ -27,7 +27,7 @@ TEST_CASE("Check asic timeout BM1370", "[common]")
     float timeout_percent = 0.5;
 
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent);
-    double expected_ms = timeout_percent * (version_size>>4) * (1<<25) / (frequency*1000) / asic_count
+    double expected_ms = timeout_percent * (version_size>>4) * (1<<25) / (frequency*1000) / asic_count;
 
     TEST_ASSERT_FLOAT_WITHIN(expected_ms-0.01, expected_ms+0.01, timeout_ms);
 }

--- a/components/asic/test/test_timeout.c
+++ b/components/asic/test/test_timeout.c
@@ -11,7 +11,7 @@ TEST_CASE("Check asic timeout BM1397", "[common]")
     uint16_t version_size = 4;
     float timeout_percent = 0.75;
 
-    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent);
+    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, 20);
     double expected_ms = timeout_percent * (1<<24) / (frequency*1000) / asic_count;
 
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
@@ -26,8 +26,23 @@ TEST_CASE("Check asic timeout BM1370", "[common]")
     uint16_t version_size = 0xFFFF;
     float timeout_percent = 0.5;
 
-    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent);
+    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, 500);
     double expected_ms = timeout_percent * (version_size>>4) * (1<<25) / (frequency*1000) / asic_count;
 
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
+}
+
+TEST_CASE("Check asic timeout BM1370 fallback", "[common]")
+{
+    float frequency = 450.0; // MHz
+    uint16_t asic_count = 0;
+    uint16_t small_cores = 2040;
+    uint16_t cores = 128;
+    uint16_t version_size = 0xFFFF;
+    float timeout_percent = 0.5;
+    float default_timeout_ms = 500;
+
+    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, default_timeout_ms);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.01, default_timeout_ms, timeout_ms);
 }

--- a/components/asic/test/test_timeout.c
+++ b/components/asic/test/test_timeout.c
@@ -10,9 +10,10 @@ TEST_CASE("Check asic timeout BM1397", "[common]")
     uint16_t cores = 168;
     uint16_t version_size = 4;
     float timeout_percent = 0.75;
+    float default_timeout_ms = 20;
 
-    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, 20);
-    double expected_ms = timeout_percent * (1<<24) / (frequency*1000) / asic_count;
+    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, default_timeout_ms);
+    double expected_ms = timeout_percent * ( 1<<24 ) / (frequency * 1000) / asic_count;
 
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }
@@ -25,17 +26,18 @@ TEST_CASE("Check asic timeout BM1370", "[common]")
     uint16_t cores = 128;
     uint16_t version_size = 0xFFFF;
     float timeout_percent = 0.5;
+    float default_timeout_ms = 500;
 
-    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, 500);
-    double expected_ms = timeout_percent * (version_size>>4) * (1<<25) / (frequency*1000) / asic_count;
+    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, default_timeout_ms);
+    double expected_ms = timeout_percent * (version_size / 16.0) * (1 << 25) / (frequency * 1000) / asic_count;
 
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }
 
-TEST_CASE("Check asic timeout BM1370 fallback", "[common]")
+TEST_CASE("Check default asic timeout BM1370", "[common]")
 {
     float frequency = 450.0; // MHz
-    uint16_t asic_count = 0;
+    uint16_t asic_count = 0; // 0 chip example
     uint16_t small_cores = 2040;
     uint16_t cores = 128;
     uint16_t version_size = 0xFFFF;

--- a/components/asic/test/test_timeout.c
+++ b/components/asic/test/test_timeout.c
@@ -12,22 +12,22 @@ TEST_CASE("Check asic timeout BM1397", "[common]")
     float timeout_percent = 0.75;
 
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent);
-    double expected = timeout_percent * (1<<24) / (frequency*1000000)
+    double expected_ms = timeout_percent * (1<<24) / (frequency*1000) / asic_count
 
-    TEST_ASSERT_FLOAT_WITHIN(expected-0.01, expected+0.01, timeout_ms);
+    TEST_ASSERT_FLOAT_WITHIN(expected_ms-0.01, exexpected_msected+0.01, timeout_ms);
 }
 
 TEST_CASE("Check asic timeout BM1370", "[common]")
 {
     float frequency = 450.0; // MHz
-    uint16_t asic_count = 1;
+    uint16_t asic_count = 2;
     uint16_t small_cores = 2040;
     uint16_t cores = 128;
     uint16_t version_size = 0xFFFF;
     float timeout_percent = 0.5;
 
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent);
-    double expected = timeout_percent * (version_size>>4) * (1<<25) / (frequency*1000000)
+    double expected_ms = timeout_percent * (version_size>>4) * (1<<25) / (frequency*1000) / asic_count
 
-    TEST_ASSERT_FLOAT_WITHIN(expected-0.01, expected+0.01, timeout_ms);
+    TEST_ASSERT_FLOAT_WITHIN(expected_ms-0.01, expected_ms+0.01, timeout_ms);
 }

--- a/components/asic/test/test_timeout.c
+++ b/components/asic/test/test_timeout.c
@@ -1,0 +1,33 @@
+#include "unity.h"
+
+#include "common.h"
+
+TEST_CASE("Check asic timeout BM1397", "[common]")
+{
+    float frequency = 450.0; // MHz
+    uint16_t asic_count = 1;
+    uint16_t small_cores = 672;
+    uint16_t cores = 168;
+    uint16_t version_size = 4;
+    float timeout_percent = 0.75;
+
+    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent);
+    double expected = timeout_percent * (1<<24) / (frequency*1000000)
+
+    TEST_ASSERT_FLOAT_WITHIN(expected-0.01, expected+0.01, timeout_ms);
+}
+
+TEST_CASE("Check asic timeout BM1370", "[common]")
+{
+    float frequency = 450.0; // MHz
+    uint16_t asic_count = 1;
+    uint16_t small_cores = 2040;
+    uint16_t cores = 128;
+    uint16_t version_size = 0xFFFF;
+    float timeout_percent = 0.5;
+
+    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent);
+    double expected = timeout_percent * (version_size>>4) * (1<<25) / (frequency*1000000)
+
+    TEST_ASSERT_FLOAT_WITHIN(expected-0.01, expected+0.01, timeout_ms);
+}

--- a/components/asic/test/test_timeout.c
+++ b/components/asic/test/test_timeout.c
@@ -5,10 +5,10 @@
 TEST_CASE("Check asic timeout 1x BM1397", "[common]")
 {
     float frequency = 450.0; // MHz
-    uint16_t asic_count = 1;
-    uint16_t small_cores = 672;
-    uint16_t cores = 168;
-    float version_size = 4.0;
+    size_t asic_count = 1;
+    size_t small_cores = 672;
+    size_t cores = 168;
+    size_t version_size = 4;
     float timeout_percent = 0.75;
     float default_timeout_ms = 20;
 
@@ -21,10 +21,10 @@ TEST_CASE("Check asic timeout 1x BM1397", "[common]")
 TEST_CASE("Check asic timeout 2x BM1370", "[common]")
 {
     float frequency = 450.0; // MHz
-    uint16_t asic_count = 2;
-    uint16_t small_cores = 2040;
-    uint16_t cores = 128;
-    float version_size = 65536.0;
+    size_t asic_count = 2;
+    size_t small_cores = 2040;
+    size_t cores = 128;
+    size_t version_size = 65536;
     float timeout_percent = 0.5;
     float default_timeout_ms = 500;
 
@@ -37,10 +37,10 @@ TEST_CASE("Check asic timeout 2x BM1370", "[common]")
 TEST_CASE("Check default asic timeout 0x BM1370", "[common]")
 {
     float frequency = 450.0; // MHz
-    uint16_t asic_count = 0; // 0 chip example
-    uint16_t small_cores = 2040;
-    uint16_t cores = 128;
-    float version_size = 65536.0;
+    size_t asic_count = 0; // 0 chip example
+    size_t small_cores = 2040;
+    size_t cores = 128;
+    size_t version_size = 65536;
     float timeout_percent = 0.5;
     float default_timeout_ms = 500;
 
@@ -52,10 +52,10 @@ TEST_CASE("Check default asic timeout 0x BM1370", "[common]")
 TEST_CASE("Check asic timeout 3x BM1370", "[common]")
 {
     float frequency = 450.0; // MHz
-    uint16_t asic_count = 3; // not power of 2 chain length
-    uint16_t small_cores = 2040;
-    uint16_t cores = 128;
-    float version_size = 256.0;
+    size_t asic_count = 3; // not power of 2 chain length
+    size_t small_cores = 2040;
+    size_t cores = 128;
+    size_t version_size = 256;
     float timeout_percent = 0.5;
     float default_timeout_ms = 500;
 
@@ -68,10 +68,10 @@ TEST_CASE("Check asic timeout 3x BM1370", "[common]")
 TEST_CASE("Check max asic timeout 1x BM1370", "[common]")
 {
     float frequency = 450.0; // MHz
-    uint16_t asic_count = 1;
-    uint16_t small_cores = 2040;
-    uint16_t cores = 128;
-    float version_size = 65536.0;
+    size_t asic_count = 1;
+    size_t small_cores = 2040;
+    size_t cores = 128;
+    size_t version_size = 65536;
     float timeout_percent = 1.0;
     float default_timeout_ms = 500;
 

--- a/components/asic/test/test_timeout.c
+++ b/components/asic/test/test_timeout.c
@@ -8,7 +8,7 @@ TEST_CASE("Check asic timeout 1x BM1397", "[common]")
     uint16_t asic_count = 1;
     uint16_t small_cores = 672;
     uint16_t cores = 168;
-    uint16_t version_size = 4;
+    float version_size = 4.0;
     float timeout_percent = 0.75;
     float default_timeout_ms = 20;
 
@@ -24,7 +24,7 @@ TEST_CASE("Check asic timeout 2x BM1370", "[common]")
     uint16_t asic_count = 2;
     uint16_t small_cores = 2040;
     uint16_t cores = 128;
-    uint16_t version_size = 0xFFFF;
+    float version_size = 65536.0;
     float timeout_percent = 0.5;
     float default_timeout_ms = 500;
 
@@ -40,7 +40,7 @@ TEST_CASE("Check default asic timeout 0x BM1370", "[common]")
     uint16_t asic_count = 0; // 0 chip example
     uint16_t small_cores = 2040;
     uint16_t cores = 128;
-    uint16_t version_size = 0xFFFF;
+    float version_size = 65536.0;
     float timeout_percent = 0.5;
     float default_timeout_ms = 500;
 
@@ -52,10 +52,10 @@ TEST_CASE("Check default asic timeout 0x BM1370", "[common]")
 TEST_CASE("Check asic timeout 3x BM1370", "[common]")
 {
     float frequency = 450.0; // MHz
-    uint16_t asic_count = 3;
+    uint16_t asic_count = 3; // not power of 2 chain length
     uint16_t small_cores = 2040;
     uint16_t cores = 128;
-    uint16_t version_size = 0xFF;
+    float version_size = 256.0;
     float timeout_percent = 0.5;
     float default_timeout_ms = 500;
 
@@ -71,12 +71,12 @@ TEST_CASE("Check max asic timeout 1x BM1370", "[common]")
     uint16_t asic_count = 1;
     uint16_t small_cores = 2040;
     uint16_t cores = 128;
-    uint16_t version_size = 0xFFFF;
+    float version_size = 65536.0;
     float timeout_percent = 1.0;
     float default_timeout_ms = 500;
 
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, default_timeout_ms);
-    double expected_ms = 4096.0 * (1 << 25) / (frequency * 1000) / (asic_count);
+    double expected_ms = timeout_percent * (version_size / 16.0) * (1 << 25) / (frequency * 1000) / (asic_count);
 
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }

--- a/components/asic/test/test_timeout.c
+++ b/components/asic/test/test_timeout.c
@@ -2,7 +2,7 @@
 
 #include "asic_common.h"
 
-TEST_CASE("Check asic timeout BM1397", "[common]")
+TEST_CASE("Check asic timeout 1x BM1397", "[common]")
 {
     float frequency = 450.0; // MHz
     uint16_t asic_count = 1;
@@ -18,7 +18,7 @@ TEST_CASE("Check asic timeout BM1397", "[common]")
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }
 
-TEST_CASE("Check asic timeout BM1370", "[common]")
+TEST_CASE("Check asic timeout 2x BM1370", "[common]")
 {
     float frequency = 450.0; // MHz
     uint16_t asic_count = 2;
@@ -34,7 +34,7 @@ TEST_CASE("Check asic timeout BM1370", "[common]")
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }
 
-TEST_CASE("Check default asic timeout BM1370", "[common]")
+TEST_CASE("Check default asic timeout 0x BM1370", "[common]")
 {
     float frequency = 450.0; // MHz
     uint16_t asic_count = 0; // 0 chip example
@@ -47,4 +47,36 @@ TEST_CASE("Check default asic timeout BM1370", "[common]")
     double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, default_timeout_ms);
 
     TEST_ASSERT_FLOAT_WITHIN(0.01, default_timeout_ms, timeout_ms);
+}
+
+TEST_CASE("Check asic timeout 3x BM1370", "[common]")
+{
+    float frequency = 450.0; // MHz
+    uint16_t asic_count = 3;
+    uint16_t small_cores = 2040;
+    uint16_t cores = 128;
+    uint16_t version_size = 0xFF;
+    float timeout_percent = 0.5;
+    float default_timeout_ms = 500;
+
+    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, default_timeout_ms);
+    double expected_ms = timeout_percent * (version_size / 16.0) * (1 << 25) / (frequency * 1000) / (asic_count+1);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
+}
+
+TEST_CASE("Check max asic timeout 1x BM1370", "[common]")
+{
+    float frequency = 450.0; // MHz
+    uint16_t asic_count = 1;
+    uint16_t small_cores = 2040;
+    uint16_t cores = 128;
+    uint16_t version_size = 0xFFFF;
+    float timeout_percent = 1.0;
+    float default_timeout_ms = 500;
+
+    double timeout_ms = calculate_bm_timeout_ms(frequency, asic_count, small_cores, cores, version_size, timeout_percent, default_timeout_ms);
+    double expected_ms = 4096.0 * (1 << 25) / (frequency * 1000) / (asic_count);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.01, expected_ms, timeout_ms);
 }

--- a/main/bap/bap_handlers.c
+++ b/main/bap/bap_handlers.c
@@ -315,7 +315,7 @@ void BAP_handle_settings(const char *parameter, const char *value) {
                 bap_global_state->POWER_MANAGEMENT_MODULE.frequency_value = target_frequency;
 
                 ASIC_set_frequency(bap_global_state);
-                ASIC_set_nonce_space(GLOBAL_STATE);
+                ASIC_set_nonce_space(bap_global_state);
 
                 //ESP_LOGI(TAG, "Frequency successfully set to %.2f MHz", target_frequency);
 

--- a/main/bap/bap_handlers.c
+++ b/main/bap/bap_handlers.c
@@ -315,6 +315,7 @@ void BAP_handle_settings(const char *parameter, const char *value) {
                 bap_global_state->POWER_MANAGEMENT_MODULE.frequency_value = target_frequency;
 
                 ASIC_set_frequency(bap_global_state);
+                ASIC_set_nonce_space(GLOBAL_STATE);
 
                 //ESP_LOGI(TAG, "Frequency successfully set to %.2f MHz", target_frequency);
 

--- a/main/device_config.h
+++ b/main/device_config.h
@@ -28,6 +28,7 @@ typedef struct {
     uint16_t core_count;
     uint16_t small_core_count;
     uint8_t hash_domains;
+    uint16_t default_asic_timeout;
     // test values
     float hashrate_test_percentage_target;
 } AsicConfig;
@@ -88,11 +89,11 @@ static const uint16_t BM1366_VOLTAGE_OPTIONS[] = {1100, 1150, 1200, 1250, 1300, 
 static const uint16_t BM1368_VOLTAGE_OPTIONS[] = {1100, 1150, 1166, 1200, 1250, 1300,                   0};
 static const uint16_t BM1370_VOLTAGE_OPTIONS[] = {1000, 1060, 1100, 1150, 1200, 1250,                   0};
 
-static const AsicConfig ASIC_BM1397   = { .id = BM1397, .name = "BM1397", .chip_id = 1397, .default_frequency_mhz = 425, .frequency_options = BM1397_FREQUENCY_OPTIONS,   .default_voltage_mv = 1400, .voltage_options = BM1397_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 168, .small_core_count =  672, .hash_domains = 1, .hashrate_test_percentage_target = 0.85, };
-static const AsicConfig ASIC_BM1366   = { .id = BM1366, .name = "BM1366", .chip_id = 1366, .default_frequency_mhz = 485, .frequency_options = BM1366_FREQUENCY_OPTIONS,   .default_voltage_mv = 1200, .voltage_options = BM1366_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 112, .small_core_count =  894, .hash_domains = 4, .hashrate_test_percentage_target = 0.85, };
-static const AsicConfig ASIC_BM1368   = { .id = BM1368, .name = "BM1368", .chip_id = 1368, .default_frequency_mhz = 490, .frequency_options = BM1368_FREQUENCY_OPTIONS,   .default_voltage_mv = 1166, .voltage_options = BM1368_VOLTAGE_OPTIONS, .difficulty = 256, .core_count =  80, .small_core_count = 1276, .hash_domains = 4, .hashrate_test_percentage_target = 0.80, };
-static const AsicConfig ASIC_BM1370   = { .id = BM1370, .name = "BM1370", .chip_id = 1370, .default_frequency_mhz = 525, .frequency_options = BM1370_FREQUENCY_OPTIONS,   .default_voltage_mv = 1150, .voltage_options = BM1370_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 128, .small_core_count = 2040, .hash_domains = 4, .hashrate_test_percentage_target = 0.85, };
-static const AsicConfig ASIC_BM1370XP = { .id = BM1370, .name = "BM1370", .chip_id = 1370, .default_frequency_mhz = 400, .frequency_options = BM1370_FRQUENCY_XP_OPTIONS, .default_voltage_mv = 1150, .voltage_options = BM1370_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 128, .small_core_count = 2040, .hash_domains = 4, .hashrate_test_percentage_target = 0.85, };
+static const AsicConfig ASIC_BM1397 = { .id = BM1397, .name = "BM1397", .chip_id = 1397, .default_frequency_mhz = 425, .frequency_options = BM1397_FREQUENCY_OPTIONS, .default_voltage_mv = 1400, .voltage_options = BM1397_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 168, .small_core_count =  672, .hash_domains = 1, .hashrate_test_percentage_target = 0.85, .default_asic_timeout = 20};
+static const AsicConfig ASIC_BM1366 = { .id = BM1366, .name = "BM1366", .chip_id = 1366, .default_frequency_mhz = 485, .frequency_options = BM1366_FREQUENCY_OPTIONS, .default_voltage_mv = 1200, .voltage_options = BM1366_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 112, .small_core_count =  894, .hash_domains = 4, .hashrate_test_percentage_target = 0.85, .default_asic_timeout = 2000};
+static const AsicConfig ASIC_BM1368 = { .id = BM1368, .name = "BM1368", .chip_id = 1368, .default_frequency_mhz = 490, .frequency_options = BM1368_FREQUENCY_OPTIONS, .default_voltage_mv = 1166, .voltage_options = BM1368_VOLTAGE_OPTIONS, .difficulty = 256, .core_count =  80, .small_core_count = 1276, .hash_domains = 4, .hashrate_test_percentage_target = 0.80, .default_asic_timeout = 500};
+static const AsicConfig ASIC_BM1370 = { .id = BM1370, .name = "BM1370", .chip_id = 1370, .default_frequency_mhz = 525, .frequency_options = BM1370_FREQUENCY_OPTIONS, .default_voltage_mv = 1150, .voltage_options = BM1370_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 128, .small_core_count = 2040, .hash_domains = 4, .hashrate_test_percentage_target = 0.85, .default_asic_timeout = 500};
+static const AsicConfig ASIC_BM1370XP = { .id = BM1370, .name = "BM1370", .chip_id = 1370, .default_frequency_mhz = 400, .frequency_options = BM1370_FRQUENCY_XP_OPTIONS, .default_voltage_mv = 1150, .voltage_options = BM1370_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 128, .small_core_count = 2040, .hash_domains = 4, .hashrate_test_percentage_target = 0.85, .default_asic_timeout = 500};
 
 static const AsicConfig default_asic_configs[] = {
     ASIC_BM1397,

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "asic_common.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "freertos/portmacro.h"

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -47,6 +47,7 @@ static void mining_stop(GlobalState * GLOBAL_STATE)
     GLOBAL_STATE->POWER_MANAGEMENT_MODULE.expected_hashrate = 0;
 
     ASIC_set_frequency(GLOBAL_STATE);
+    ASIC_set_nonce_space(GLOBAL_STATE);
 
     // Cut ASIC power and hold in reset
     VCORE_set_voltage(GLOBAL_STATE, 0.0f);
@@ -249,6 +250,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
             power_management->expected_hashrate = expected_hashrate(GLOBAL_STATE);
 
             ASIC_set_frequency(GLOBAL_STATE);
+            ASIC_set_nonce_space(GLOBAL_STATE);
             
             last_asic_frequency = asic_frequency;
         }


### PR DESCRIPTION
**depends on**
* https://github.com/bitaxeorg/ESP-Miner/pull/1576


**closes**
* https://github.com/skot/ESP-Miner/issues/248


**relavent**
* https://github.com/bitaxeorg/ESP-Miner/issues/514
* https://github.com/bitaxeorg/ESP-Miner/pull/1553
* https://github.com/skot/ESP-Miner/pull/167
* https://github.com/bitaxeorg/ESP-Miner/issues/1507, 
* https://github.com/bitaxeorg/ESP-Miner/issues/939 
* https://github.com/bitaxeorg/ESP-Miner/issues/824

Goals
* to set the nonce space to 100% for configurations that allow
* support extended jobs for SV2

Search Space
there is the nonce space 32 bits
there is the version space 16 bits (BIP320)
there is ntime space ~12 bits (mpt, current time + 7200)
there is extranonce2 space  ~64+bits

General mining info for ASICS
Typically ASICs will mine nonces first, but now they are so fast they have to mine more things,
in terms of cheapness ntime is good and versions are good due to ASICBOOST.

The general hierarchy is
hash boards -> chips -> cores

The older chips (Bitaxe Max), were supplied midstates
BM1397
the bitcoin header is to big to fit in 1 SHA compression so its split into 2

block0     block1
[midstate0][0,2,3,....]
[midstate1][0,2,3,....]
[midstate2][0,2,3,....]
[midstate3][0,2,3,....]
the purpose is share the message scheduler of SHA1 (first sha second block)
but this budens the controller to send work very fast to the chips

anyway there were 4 midstates and 672 small cores
so that means 168 cores on the chip each core does a independant search on the nonce range
core0    [0,2,3,....]
core1    [0,2,3,....] * offset1
...
core167  [0,2,3,....] * offset167

but how do we divide 168 cores into 2^32, we cant so this means there is a hole in the search.
168/256 = ~62.5% of the nonce space is covered due to the HW cores

in more recent BITMAIN chips
BM1370 we have version rolling

with version rolling
we manipulate the nversion field so we have more space to search, we have 2^16 available values
the BM1370 has 128 cores and 2040 small cores, there are 8 cores missing, 4 cores are missing on core 15 and 4 on core 127
these are the version generators

now our pipeline is more advanced
we generate 16 versions and supply then to each core
core 0   [0,1,2,3,....]
...
core 127 [0,1,2,3,....] * offset128
then we repeat, until 2^16 have run out or 4096 iterations.

Finally these ideas easily extend to multiple chips
when we have multiple chips we must also divide the nonce/version space per chip, then we can parellize.

CHIP 0 
core n CHIP0 offset + [0,1,2,3,....] * n

CHIP 1
core n CHIP1 offset + [0,1,2,3,....] * n

In a simple system we have the following equation
`time = size / freq`
the PR tries to figure out the above timeout equation for different configurations

Finally, the nonce and version space is configurable as well.
currently in ESP-miner the nonce range is roughly 1/64 

To control nonces we need hash counting number register
The hcn is a nonce limiter, and after it completes and restarts a new version is generated

figuring out the Maximum HCN is a solution to a dynamic equation, this enables setting the whole nonce space for different frequencies, chip length chains and core counts.

```c
float hcn_space = (float)NONCE_SPACE / big_cores_up / asic_count_up;
double hcn_max = hcn_space * (double)FREQ_MULT / frequency * 0.5f; 
```
Note:  The size is dependent on frequency which is odd.

after calculating the HCN max which is the equivalent to nonce space 100%, the timeout is easy, you just need non parallel space of the chip and frequency
```c
double fullspace_timeout_s = serial_versions * serial_nonces / ((double)frequency_mhz * 1000.0 * 1000.0);
```

Additional Note
* The CNO allows 16 bit division in the BM1370 of a chain of chips

comments for retention
```c
//register 10 is still a bit of a mystery. discussion: https://github.com/bitaxeorg/ESP-Miner/pull/167
// unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x11, 0x5A}; //S19k Pro Default
// unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x14, 0x46}; //S19XP-Luxos Default
// unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x15, 0x1C}; //S19XP-Stock Default
// unsigned char set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x0F, 0x00, 0x00}; //supposedly the "full" 32bit nonce range
```
This should work for any versions/hcn value/frequency/chip count

Testing TODO
hex
gammaturbo
gamma
supra
ultra
max
naja