### PR TITLE
Change TPS546 undervoltage and shutdown voltage thresholds to better values.

### DIFF
--- a/main/TPS546.h
+++ b/main/TPS546.h
@@ -18,8 +18,8 @@
 
 /* vin voltage */
 #define TPS546_INIT_VIN_ON  4.8  /* V */
-#define TPS546_INIT_VIN_OFF 4.5  /* V */
-#define TPS546_INIT_VIN_UV_WARN_LIMIT 5.8 /* V */
+#define TPS546_INIT_VIN_OFF 4.0  /* V */
+#define TPS546_INIT_VIN_UV_WARN_LIMIT 4.2 /* V */
 #define TPS546_INIT_VIN_OV_FAULT_LIMIT 6.0 /* V */
 #define TPS546_INIT_VIN_OV_FAULT_RESPONSE 0xB7  /* retry 6 times */
 


### PR DESCRIPTION
Change the UV_WARN limit cuz 5.8V is not make sense for Ultra and Supra and Gamma which input voltage is 5V