### PR TITLE
added separate scrolling messages for selftest pass and fail

### DIFF
--- a/main/screen.c
+++ b/main/screen.c
@@ -66,7 +66,7 @@ static lv_obj_t * create_scr_self_test() {
     lv_obj_set_width(self_test_finished_fail_label, LV_HOR_RES);
     lv_obj_add_flag(self_test_finished_fail_label, LV_OBJ_FLAG_HIDDEN);
     lv_label_set_long_mode(self_test_finished_fail_label, LV_LABEL_LONG_SCROLL_CIRCULAR);
-    lv_label_set_text(self_test_finished_fail_label, "Hold BOOT button for 2 seconds to cancel self test, or press RESET to run again.");
+    lv_label_set_text(self_test_finished_fail_label, "Hold BOOT button for 2 seconds to exit self test, or press RESET to run again.");
 
     return scr;
 }

--- a/main/screen.c
+++ b/main/screen.c
@@ -30,7 +30,8 @@ static lv_obj_t *wifi_status_label;
 
 static lv_obj_t *self_test_message_label;
 static lv_obj_t *self_test_result_label;
-static lv_obj_t *self_test_finished_label;
+static lv_obj_t *self_test_finished_pass_label;
+static lv_obj_t *self_test_finished_fail_label;
 
 static double current_hashrate;
 static float current_power;
@@ -55,11 +56,17 @@ static lv_obj_t * create_scr_self_test() {
 
     self_test_result_label = lv_label_create(scr);
 
-    self_test_finished_label = lv_label_create(scr);
-    lv_obj_set_width(self_test_finished_label, LV_HOR_RES);
-    lv_obj_add_flag(self_test_finished_label, LV_OBJ_FLAG_HIDDEN);
-    lv_label_set_long_mode(self_test_finished_label, LV_LABEL_LONG_SCROLL_CIRCULAR);
-    lv_label_set_text(self_test_finished_label, "Hold BOOT button for 2 seconds to cancel self test, or press RESET to run again.");
+    self_test_finished_pass_label = lv_label_create(scr);
+    lv_obj_set_width(self_test_finished_pass_label, LV_HOR_RES);
+    lv_obj_add_flag(self_test_finished_pass_label, LV_OBJ_FLAG_HIDDEN);
+    lv_label_set_long_mode(self_test_finished_pass_label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    lv_label_set_text(self_test_finished_pass_label, "Press RESET to exit selftest.");
+
+    self_test_finished_fail_label = lv_label_create(scr);
+    lv_obj_set_width(self_test_finished_fail_label, LV_HOR_RES);
+    lv_obj_add_flag(self_test_finished_fail_label, LV_OBJ_FLAG_HIDDEN);
+    lv_label_set_long_mode(self_test_finished_fail_label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    lv_label_set_text(self_test_finished_fail_label, "Hold BOOT button for 2 seconds to cancel self test, or press RESET to run again.");
 
     return scr;
 }
@@ -228,9 +235,13 @@ static void screen_update_cb(lv_timer_t * timer)
         lv_label_set_text(self_test_message_label, self_test->message);
 
         if (self_test->finished) {
-            lv_label_set_text(self_test_result_label, self_test->result ? "TESTS PASS!" : "TESTS FAIL!");
-
-            lv_obj_remove_flag(self_test_finished_label, LV_OBJ_FLAG_HIDDEN);
+            if (self_test->result) {
+                lv_label_set_text(self_test_result_label, "TESTS PASS!");
+                lv_obj_remove_flag(self_test_finished_pass_label, LV_OBJ_FLAG_HIDDEN);
+            } else {
+                lv_label_set_text(self_test_result_label, "TESTS FAIL!");
+                lv_obj_remove_flag(self_test_finished_fail_label, LV_OBJ_FLAG_HIDDEN);
+            }
         }
 
         return;

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -28,6 +28,8 @@
 #define TESTS_FAILED 0
 #define TESTS_PASSED 1
 
+//#define MEGA_FAIL_BUS 1 // Set to fail
+
 /////Test Constants/////
 //Test Fan Speed
 #define FAN_SPEED_TARGET_MIN 1000 //RPM
@@ -529,6 +531,11 @@ void self_test(void * pvParameters)
 
 static void tests_done(GlobalState * GLOBAL_STATE, bool test_result) 
 {
+
+#if MEGA_FAIL_BUS
+    test_result = TESTS_FAILED;
+#endif
+
     switch (GLOBAL_STATE->device_model) {
         case DEVICE_MAX:
         case DEVICE_ULTRA:
@@ -541,7 +548,7 @@ static void tests_done(GlobalState * GLOBAL_STATE, bool test_result)
     }
 
     if (test_result == TESTS_FAILED) {
-        ESP_LOGI(TAG, "SELF TESTS FAIL -- Press RESET to continue");  
+        ESP_LOGE(TAG, "-- SELFTEST FAIL --");  
         while (1) {
             // Wait here forever until reset_self_test() gives the BootSemaphore
             if (xSemaphoreTake(BootSemaphore, portMAX_DELAY) == pdTRUE) {
@@ -553,7 +560,7 @@ static void tests_done(GlobalState * GLOBAL_STATE, bool test_result)
         }
     } else {
         nvs_config_set_u16(NVS_CONFIG_SELF_TEST, 0);
-        ESP_LOGI(TAG, "Self Tests Passed!!!");
+        ESP_LOGI(TAG, "-- SELFTEST PASS!!! --");
     }
 
 }


### PR DESCRIPTION
### If you have a failed selftest:
- scrolling message: "Hold BOOT button for 2 seconds to exit self test, or press RESET to run again."
- Pressing RESET should re-run the selftest.
- Pressing and holding BOOT for ~2sec should reset the bitaxe into the normal state (no selftest)

### if you have a passed selftest:
- scrolling message: "Press RESET to exit selftest."
- Pressing RESET should reset the bitaxe into the normal state (no selftest)