### PR TITLE
Expose Wifi RSSI to API endpoint

### DIFF
--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -58,6 +58,20 @@ static bool is_scanning = false;
 static uint16_t ap_number = 0;
 static wifi_ap_record_t ap_info[MAX_AP_COUNT];
 
+
+esp_err_t get_wifi_current_rssi(int8_t *rssi)
+{
+    wifi_ap_record_t current_ap_info;
+    esp_err_t err = esp_wifi_sta_get_ap_info(&current_ap_info);
+
+    if (err == ESP_OK) {
+        *rssi = current_ap_info.rssi;
+        return ERR_OK;
+    }
+
+    return err;
+}
+
 // Function to scan for available WiFi networks
 esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count)
 {

--- a/components/connect/include/connect.h
+++ b/components/connect/include/connect.h
@@ -41,3 +41,4 @@ void wifi_init(const char * wifi_ssid, const char * wifi_pass, const char * host
 EventBits_t wifi_connect(void);
 void generate_ssid(char * ssid);
 esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count);
+esp_err_t get_wifi_current_rssi(int8_t *rssi);

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -534,7 +534,10 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     esp_wifi_get_mac(WIFI_IF_STA, mac);
     snprintf(formattedMac, 18, "%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
-        cJSON * root = cJSON_CreateObject();
+    int8_t wifi_rssi = -90;
+    get_wifi_current_rssi(&wifi_rssi);
+
+    cJSON * root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "power", GLOBAL_STATE->POWER_MANAGEMENT_MODULE.power);
     cJSON_AddNumberToObject(root, "voltage", GLOBAL_STATE->POWER_MANAGEMENT_MODULE.voltage);
     cJSON_AddNumberToObject(root, "current", GLOBAL_STATE->POWER_MANAGEMENT_MODULE.current);
@@ -557,6 +560,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddStringToObject(root, "macAddr", formattedMac);
     cJSON_AddStringToObject(root, "hostname", hostname);
     cJSON_AddStringToObject(root, "wifiStatus", GLOBAL_STATE->SYSTEM_MODULE.wifi_status);
+    cJSON_AddNumberToObject(root, "wifiRSSI", wifi_rssi);
     cJSON_AddNumberToObject(root, "apEnabled", GLOBAL_STATE->SYSTEM_MODULE.ap_enabled);
     cJSON_AddNumberToObject(root, "sharesAccepted", GLOBAL_STATE->SYSTEM_MODULE.shares_accepted);
     cJSON_AddNumberToObject(root, "sharesRejected", GLOBAL_STATE->SYSTEM_MODULE.shares_rejected);


### PR DESCRIPTION
This commit adds Wi-Fi RSSI to the API endpoint, keeping the implementation minimal to allow the front end to handle advanced logic (e.g., a user-friendly indicator for signal strength).

If the device is not connected to Wi-Fi, the endpoint returns `-90` (representing "poor connectivity"). This approach was chosen because API access inherently requires a working Wi-Fi connection, making this an acceptable fallback.