### PR TITLE
Persist Swarm sort across updates

### DIFF
--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -49,7 +49,7 @@
     <table cellspacing="0" cellpadding="0" class="text-sm md:text-base">
         <tr>
             <th>
-                <div class="flex items-center cursor-pointer select-none h-full" (click)="sortBy('IP')">
+                <div class="flex items-center cursor-pointer select-none h-full" (click)="updateSort('IP')">
                     <span class="flex-1">IP</span>
                     <i class="pi text-xs flex items-center" [ngClass]="{
                         'pi-sort-alt': sortField !== 'IP',
@@ -59,7 +59,7 @@
                 </div>
             </th>
             <th>
-                <div class="flex items-center cursor-pointer select-none h-full" (click)="sortBy('hostname')">
+                <div class="flex items-center cursor-pointer select-none h-full" (click)="updateSort('hostname')">  
                     <span class="flex-1">Hostname</span>
                     <i class="pi text-xs flex items-center" [ngClass]="{
                         'pi-sort-alt': sortField !== 'hostname',

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@angular/core';
 import { delay, Observable, of } from 'rxjs';
 import { eASICModel } from 'src/models/enum/eASICModel';
 import { ISystemInfo } from 'src/models/ISystemInfo';
-
 import { environment } from '../../environments/environment';
 
 @Injectable({
@@ -32,7 +31,7 @@ export class SystemService {
           freeHeap: 200504,
           coreVoltage: 1200,
           coreVoltageActual: 1200,
-          hostname: "Bitaxe",
+          hostname: "Bitaxe " + Math.random().toString(36).substring(2, 15),
           macAddr: "2C:54:91:88:C9:E3",
           ssid: "default",
           wifiPass: "password",


### PR DESCRIPTION
Trying to make the least amount of changes since we're in beta test.  But I did update the swarm page so we get fake Bitaxe when running axeos in a local environment.  Needed some test Bitaxe for testing the sort on refresh.

Otherwise it's just persisting the sort field and direction anytime swarm refreshes or scans for new Bitaxe