### PR TITLE
Fix typo in home.component.html

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -120,7 +120,7 @@
                             valueTemplate="{value}"></p-knob>
                         ASIC Frequency (MHz) -->
 
-                        <h6>ASIC Frequency <span style="float: right;">{{info.frequency}} Mhz</span></h6>
+                        <h6>ASIC Frequency <span style="float: right;">{{info.frequency}} MHz</span></h6>
                         <p-progressBar [value]="(info.frequency / maxFrequency) * 100" [style]="{ height: '6px' }" >
                             <ng-template pTemplate="content" let-value></ng-template>
                         </p-progressBar>


### PR DESCRIPTION
Fix typo.
The unit is Hz with capital H. The prefix doesn't affect the capitalization of the unit.