### PR TITLE
fix: don't collect hashrate while in power_fault

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -24,21 +24,24 @@
                             <div>
                                 <span class="block text-500 font-medium mb-3">Hash Rate</span>
                                 <div class="text-900 font-medium text-2xl flex align-items-center gap-2">
-                                    <span>
+                                    <span *ngIf="!info.power_fault">
                                         {{info.hashRate * 1000000000 | hashSuffix}}
+                                    </span>
+                                    <span *ngIf="info.power_fault" class="text-red-500">
+                                        Not available - Power fault
                                     </span>
                                 </div>
                             </div>
                         </div>
 
-                        <ng-container>
+                        <ng-container *ngIf="!info.power_fault">
                             Average:
                             <span class="text-green-500 font-medium">
                                 {{calculateAverage(hashrateData) | hashSuffix}}
                             </span>
                         </ng-container>
 
-                        <div class="text-500 text-xs" *ngIf="expectedHashRate$ | async as expectedHashRate">
+                        <div class="text-500 text-xs" *ngIf="!info.power_fault && (expectedHashRate$ | async) as expectedHashRate">
                             Expected: {{expectedHashRate * 1000000000 | hashSuffix}}
                         </div>
                     </div>
@@ -49,21 +52,24 @@
                             <div>
                                 <span class="block text-500 font-medium mb-3">Efficiency</span>
                                 <div class="text-900 font-medium text-2xl flex align-items-center gap-2">
-                                    <span>
+                                    <span *ngIf="!info.power_fault">
                                         {{info.power / (info.hashRate/1000) | number: '1.2-2'}} <small>J/TH</small>
+                                    </span>
+                                    <span *ngIf="info.power_fault" class="text-red-500">
+                                        Not available - Power fault
                                     </span>
                                 </div>
                             </div>
                         </div>
 
-                        <ng-container>
+                        <ng-container *ngIf="!info.power_fault">
                             Average:
                             <span class="text-green-500 font-medium">
                                 {{calculateEfficiencyAverage(hashrateData, powerData) | number: '1.2-2'}} <small>J/TH</small>
                             </span>
                         </ng-container>
 
-                        <div class="text-500 text-xs " *ngIf="expectedHashRate$ | async as expectedHashRate" >
+                        <div class="text-500 text-xs" *ngIf="!info.power_fault && (expectedHashRate$ | async) as expectedHashRate">
                             Expected: {{info.power / (expectedHashRate/1000) | number: '1.2-2'}} J/TH
                         </div>
                     </div>
@@ -110,7 +116,7 @@
 
             </div>
         </div>
-        <div class="col-12  mb-4">
+        <div class="col-12 mb-4" *ngIf="!info.power_fault">
             <div class="card">
                 <p-chart [data]="chartData" [options]="chartOptions"></p-chart>
             </div>

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -189,26 +189,29 @@ export class HomeComponent {
         return this.systemService.getInfo()
       }),
       tap(info => {
-        this.hashrateData.push(info.hashRate * 1000000000);
-        this.temperatureData.push(info.temp);
-        this.powerData.push(info.power);
+        // Only collect and update chart data if there's no power fault
+        if (!info.power_fault) {
+          this.hashrateData.push(info.hashRate * 1000000000);
+          this.temperatureData.push(info.temp);
+          this.powerData.push(info.power);
 
-        this.dataLabel.push(new Date().getTime());
+          this.dataLabel.push(new Date().getTime());
 
-        if (this.hashrateData.length >= 720) {
-          this.hashrateData.shift();
-          this.temperatureData.shift();
-          this.powerData.shift();
-          this.dataLabel.shift();
+          if (this.hashrateData.length >= 720) {
+            this.hashrateData.shift();
+            this.temperatureData.shift();
+            this.powerData.shift();
+            this.dataLabel.shift();
+          }
+
+          this.chartData.labels = this.dataLabel;
+          this.chartData.datasets[0].data = this.hashrateData;
+          this.chartData.datasets[1].data = this.temperatureData;
+
+          this.chartData = {
+            ...this.chartData
+          };
         }
-
-        this.chartData.labels = this.dataLabel;
-        this.chartData.datasets[0].data = this.hashrateData;
-        this.chartData.datasets[1].data = this.temperatureData;
-
-        this.chartData = {
-          ...this.chartData
-        };
 
         this.maxPower = Math.max(info.maxPower, info.power);
         this.nominalVoltage = info.nominalVoltage;


### PR DESCRIPTION
closes #803 

This resolves the issue of showing hashrate that is incorrect or any data that would mislead the user the device is still hashing.
![image](https://github.com/user-attachments/assets/8c6154fc-04cf-4c17-a62c-3f2977490ce6)
