### PR TITLE
Improve AP mode stability by stopping unnecessary Wi-Fi reconnections

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -100,6 +100,7 @@ void app_main(void)
 
     //start the API for AxeOS
     start_rest_server((void *) &GLOBAL_STATE);
+
     EventBits_t result_bits = wifi_connect();
 
     if (result_bits & WIFI_CONNECTED_BIT) {


### PR DESCRIPTION
When the device is in AP mode, repeatedly attempting to connect to an incorrect or non-existent Wi-Fi network causes instability. This patch halts the reconnection process if a client is already connected to the AP, ensuring a stable connection.