### PR TITLE
Update gitignore, simplify layout, fix refresh button UI, unify headlines/margins, improve modal responsiveness and theme color selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ components/components/*
 config.bin
 config.cvs
 managed_components/*
+
+# System files
+.DS_Store
+Thumbs.db

--- a/main/http_server/axe-os/src/app/components/design/design-component.scss
+++ b/main/http_server/axe-os/src/app/components/design/design-component.scss
@@ -1,0 +1,21 @@
+.theme-color{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.color-dot {
+  position: relative;
+
+  .selected-icon {
+    color: white;
+    font-size: 1rem;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+  }
+}

--- a/main/http_server/axe-os/src/app/components/design/theme-config.component.ts
+++ b/main/http_server/axe-os/src/app/components/design/theme-config.component.ts
@@ -32,14 +32,15 @@ interface ThemeOption {
           </div>
         </div>
 
-        <div class="col-12">
+        <div class="col-12 mt-4">
           <h6>Theme Colors</h6>
           <div class="grid gap-2">
-            <div *ngFor="let theme of themes" class="col-2">
+            <div *ngFor="let theme of themes" class="col-2 theme-color">
               <button pButton [class]="'p-button-rounded p-button-text color-dot'"
                       [style.backgroundColor]="theme.primaryColor"
                       style="width: 2rem; height: 2rem; border: none;"
                       (click)="changeTheme(theme)">
+                <i *ngIf="theme.primaryColor === currentColor" class="pi pi-check selected-icon"></i>
               </button>
               <div class="text-sm mt-1">{{theme.name}}</div>
             </div>
@@ -47,10 +48,12 @@ interface ThemeOption {
         </div>
       </div>
     </div>
-  `
+  `,
+  styleUrls: ['./design-component.scss']
 })
 export class ThemeConfigComponent implements OnInit {
   selectedScheme: string;
+  currentColor: string = '';
   themes: ThemeOption[] = [
     {
       name: 'Orange',
@@ -227,6 +230,7 @@ export class ThemeConfigComponent implements OnInit {
       settings => {
         if (settings && settings.accentColors) {
           this.applyThemeColors(settings.accentColors);
+          this.currentColor = settings.accentColors['--primary-color'];
         }
       },
       error => console.error('Error loading theme settings:', error)
@@ -249,6 +253,7 @@ export class ThemeConfigComponent implements OnInit {
   changeTheme(theme: ThemeOption) {
     // Update CSS variables
     this.applyThemeColors(theme.accentColors);
+    this.currentColor = theme.primaryColor;
     // Save theme settings to NVS
     this.themeService.saveThemeSettings({
       colorScheme: this.selectedScheme,

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -16,8 +16,6 @@
     </p-message>
 
     <div class="grid" *ngIf="info$ | async as info; else loading">
-        <div class="col-12">
-            <div class="grid">
                 <div class="col-12 md:col-6 xl:col-3">
                     <div class="card mb-0">
                         <div class="flex justify-content-between mb-3">
@@ -114,9 +112,7 @@
                     </div>
                 </div>
 
-            </div>
-        </div>
-        <div class="col-12 mb-4" *ngIf="!info.power_fault">
+        <div class="col-12" *ngIf="!info.power_fault">
             <div class="card">
                 <p-chart [data]="chartData" [options]="chartOptions"></p-chart>
             </div>

--- a/main/http_server/axe-os/src/app/components/logs/logs.component.html
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.html
@@ -1,7 +1,7 @@
 <div class="grid">
     <div class="col-12 lg:col-6">
         <div class="card">
-            <h5>Overview</h5>
+            <h2>Overview</h2>
             <table *ngIf="info$ | async as info">
                 <tr>
                     <td>Model:</td>

--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -1,7 +1,7 @@
 <div class="grid">
     <div class="col-12">
         <div class="card">
-            <h5>Pool Configuration</h5>
+            <h2>Pool Configuration</h2>
             <form [formGroup]="form" *ngIf="form != null">
         <div class="field grid p-fluid">
             <label htmlFor="stratumURL" class="col-12 mb-2 md:col-2 md:mb-0">Stratum Host:</label>

--- a/main/http_server/axe-os/src/app/components/settings/settings.component.html
+++ b/main/http_server/axe-os/src/app/components/settings/settings.component.html
@@ -10,7 +10,7 @@
             <h2>Latest Release: <p-button (onClick)="checkLatestRelease = true">Check</p-button></h2>
             <small>Clicking this button will connect to GitHub to check for recent updates</small>
         </div>
-        <div class="card" *ngIf="checkLatestRelease == true">
+        <div class="card h-full" *ngIf="checkLatestRelease == true">
             <ng-container *ngIf="latestRelease$ | async as latestRelease">
             <h5>Current Version: {{(info$ | async)?.version}}</h5>
             <h2>Latest Release: {{latestRelease.name}}</h2>
@@ -29,7 +29,7 @@
         </div>
     </div>
     <div class="col-12 lg:col-12 xl:col-4">
-      <div class="card">
+      <div class="card h-full">
           <h2>Update Website <span *ngIf="websiteUpdateProgress != null">{{websiteUpdateProgress}}%</span></h2>
 
           <p-fileUpload #websiteUpload [customUpload]="true" mode="basic" accept=".bin" (uploadHandler)="otaWWWUpdate($event)"
@@ -39,7 +39,7 @@
       </div>
     </div>
     <div class="col-12 lg:col-6 xl:col-4">
-        <div class="card">
+        <div class="card h-full">
             <h2>Update Firmware <span *ngIf="firmwareUpdateProgress != null">{{firmwareUpdateProgress}}%</span></h2>
             <!-- <input type="file" id="file" (change)="otaUpdate($event)" accept=".bin"> -->
             <p-fileUpload #firmwareUpload [customUpload]="true" mode="basic" accept=".bin" (uploadHandler)="otaUpdate($event)"

--- a/main/http_server/axe-os/src/app/components/settings/settings.component.html
+++ b/main/http_server/axe-os/src/app/components/settings/settings.component.html
@@ -4,7 +4,7 @@
 </div>
 
 <div class="grid">
-    <div class="col-12 lg:col-6 xl:col-4">
+    <div class="col-12 xl:col-4">
         <div class="card" *ngIf="checkLatestRelease == false">
             <h5>Current Version: {{(info$ | async)?.version}}</h5>
             <h2>Latest Release: <p-button (onClick)="checkLatestRelease = true">Check</p-button></h2>
@@ -28,7 +28,7 @@
         </ng-container>
         </div>
     </div>
-    <div class="col-12 lg:col-12 xl:col-4">
+    <div class="col-12 lg:col-6 xl:col-4">
       <div class="card h-full">
           <h2>Update Website <span *ngIf="websiteUpdateProgress != null">{{websiteUpdateProgress}}%</span></h2>
 

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -17,8 +17,9 @@
 <div class="flex flex-column sm:flex-row gap-4 justify-content-between">
     <div class="flex gap-1 sm:gap-3 text-sm md:text-base">
         <button pButton (click)="scanNetwork()" [disabled]="scanning">{{scanning ? 'Scanning...' : 'Automatic Scan'}}</button>
-        <button pButton severity="secondary" (click)="refreshList()" [disabled]="scanning || isRefreshing">
-            {{isRefreshing ? 'Refreshing...' : 'Refresh List (' + refreshIntervalTime + ')'}}
+        <button pButton severity="secondary" (click)="refreshList()" [disabled]="scanning || isRefreshing" class="refresh-button">
+          <span aria-hidden="true">Refresh List (30)</span>
+          <span>{{ isRefreshing ? 'Refreshing...' : 'Refresh List (' + refreshIntervalTime + ')' }}</span>
         </button>
     </div>
     <div class="flex align-items-center gap-2">

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -50,7 +50,7 @@
     <table cellspacing="0" cellpadding="0" class="text-sm md:text-base">
         <tr>
             <th>
-                <div class="flex items-center cursor-pointer select-none h-full" (click)="sortBy('IP')">
+                <div class="flex align-items-center cursor-pointer select-none h-full" (click)="sortBy('IP')">
                     <span class="flex-1">IP</span>
                     <i class="pi text-xs flex items-center" [ngClass]="{
                         'pi-sort-alt': sortField !== 'IP',
@@ -60,7 +60,7 @@
                 </div>
             </th>
             <th>
-                <div class="flex items-center cursor-pointer select-none h-full" (click)="sortBy('hostname')">
+                <div class="flex align-items-center cursor-pointer select-none h-full" (click)="sortBy('hostname')">
                     <span class="flex-1">Hostname</span>
                     <i class="pi text-xs flex items-center" [ngClass]="{
                         'pi-sort-alt': sortField !== 'hostname',

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
@@ -7,18 +7,18 @@ th {
     text-align: left;
     background-color: #1f2d40;
     padding: 0;
-    
+
     > div {
         height: 100%;
         padding: 0.5rem 1rem;
         gap: 0.75rem;
     }
-    
+
     .pi {
         opacity: 0.7;
         height: 1em;
         line-height: 1;
-        
+
         &.pi-sort-amount-up-alt,
         &.pi-sort-amount-down {
             opacity: 1;
@@ -36,7 +36,7 @@ td {
 }
 
 th > div {
-    min-width: 100px; 
+    min-width: 100px;
     padding-right: 0.5rem;
 }
 
@@ -77,11 +77,11 @@ a {
     width: 100%;
     overflow-x: auto;
     margin: 0;
-    
+
     table {
         min-width: 100%;
         white-space: nowrap;
-        
+
         th, td {
             padding: 0.75rem;
             text-align: left;
@@ -91,4 +91,18 @@ a {
             }
         }
     }
+}
+
+.refresh-button {
+  display: grid;
+  place-items: center;
+
+  > span:first-child {
+    visibility: hidden;
+    grid-area: 1 / 1;
+  }
+
+  > span:last-child {
+    grid-area: 1 / 1;
+  }
 }

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
@@ -56,14 +56,26 @@ a {
 
 .modal {
     position: fixed;
-    max-height: 70vh;
-    width: 50vw;
+    max-height: 80dvh;
+    width: 90dvw;
     z-index: 999;
-    top: 0;
-    left: 0;
-    margin: 12vh 25vw;
-    padding: 50px;
+    top: 10vh;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 2rem;
     overflow-y: auto;
+}
+
+@media (min-width: 768px) {
+  .modal {
+    width: 70dvw;
+  }
+}
+
+@media (min-width: 1024px) {
+  .modal {
+    width: 50dvw;
+  }
 }
 
 .close {

--- a/main/http_server/axe-os/src/app/layout/styles/layout/_content.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/layout/_content.scss
@@ -7,6 +7,10 @@
     transition: margin-left $transitionDuration;
 
     @media (max-width: 991px) {
+        padding: 7rem 2rem 2rem 2rem;
+    }
+
+    @media (max-width: 768px) {
         padding: 7rem 1rem 1rem 1rem;
     }
 }

--- a/main/http_server/axe-os/src/app/layout/styles/layout/_content.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/layout/_content.scss
@@ -6,7 +6,7 @@
     padding: 7rem 2rem 2rem 4rem;
     transition: margin-left $transitionDuration;
 
-    @media (max-width: 768px) {
+    @media (max-width: 991px) {
         padding: 7rem 1rem 1rem 1rem;
     }
 }

--- a/main/http_server/axe-os/src/app/layout/styles/layout/_utils.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/layout/_utils.scss
@@ -2,7 +2,7 @@
     background: var(--surface-card);
     border: 1px solid var(--surface-border);
     padding: 2rem;
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
     box-shadow: var(--card-shadow);
     border-radius: $borderRadius;
 


### PR DESCRIPTION
- chore: copied system files `.gitignore` entries from `/axe-os/.gitignore` to globally ignore system files (like  `.DS_Store`, since my mac added those)

- fix: reduced left padding on tablets

before on tablet: 

![image](https://github.com/user-attachments/assets/cdccf79c-44ee-45cd-87fa-6347735f27cc)

after on tablet:

![image](https://github.com/user-attachments/assets/2a9d1fad-d82d-4449-8837-318fc7626c06)


- fix (home): cleaned up grid, removed a grid and some margins

before:

![image](https://github.com/user-attachments/assets/429b14ce-c1be-496e-8df4-7cd345354720)

after:

![image](https://github.com/user-attachments/assets/c2799458-92ef-4b10-8611-90172516d873)

- style: refresh button width grid stacking.
I noticed the refresh button's width changed based on the countdown seconds, I used grid stacking to preserve a consistent width.

before:

![before](https://github.com/user-attachments/assets/79fbb10a-50cb-4c67-87b9-a67a65d47b80)

after:

![after](https://github.com/user-attachments/assets/890d9c42-2e62-4745-972b-ecb24a861281)

