### PR TITLE
Make "Latest Release" into a link for the changelog

### DIFF
--- a/main/http_server/axe-os/src/app/components/settings/settings.component.html
+++ b/main/http_server/axe-os/src/app/components/settings/settings.component.html
@@ -13,7 +13,9 @@
         <div class="card" *ngIf="checkLatestRelease == true">
             <ng-container *ngIf="latestRelease$ | async as latestRelease">
             <h5>Current Version: {{(info$ | async)?.version}}</h5>
-            <h2>Latest Release: {{latestRelease.name}}</h2>
+            <h2>Latest Release
+                <a style="text-decoration: underline;" target="_blank"
+                [href]="latestRelease.html_url">{{latestRelease.name}}</a></h2>
 
             <div *ngFor="let asset of latestRelease.assets">
                 <div *ngIf="asset.name == 'esp-miner.bin'">


### PR DESCRIPTION
I like browsing changelog before updating some tools.


With this small change after checking for update, the latest release printed will be a link to the github release.
In this example (picture below): the link targets `https://github.com/bitaxeorg/ESP-Miner/releases/tag/v2.6.3` 

![image](https://github.com/user-attachments/assets/84885322-5f05-4508-b8ae-3b2d585b4844)

