### PR TITLE
Remove under power failure

### DIFF
--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -112,7 +112,7 @@ static esp_err_t test_TPS546_power_consumption(int target_power, int margin)
     float current = TPS546_get_iout();
     float power = voltage * current;
     ESP_LOGI(TAG, "Power: %f, Voltage: %f, Current %f", power, voltage, current);
-    if (power > target_power -margin && power < target_power +margin) {
+    if (power < target_power +margin) {
         return ESP_OK;
     }
     return ESP_FAIL;


### PR DESCRIPTION
There can be a fair amount of variability in power consumpiton from chip to chip. I have had a few % perform significantly better than average and fail the consumption test. I don't think under consumption will be an issue as the test only runs AFTER a successful hashrate check.