### PR TITLE
fix: remove polarity bit

### DIFF
--- a/config-102.cvs
+++ b/config-102.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1397
 devicemodel,data,string,max
 boardversion,data,string,102
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/config-201.cvs
+++ b/config-201.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1366
 devicemodel,data,string,ultra
 boardversion,data,string,201
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/config-202.cvs
+++ b/config-202.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1366
 devicemodel,data,string,ultra
 boardversion,data,string,202
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/config-203.cvs
+++ b/config-203.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1366
 devicemodel,data,string,ultra
 boardversion,data,string,203
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/config-204.cvs
+++ b/config-204.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1366
 devicemodel,data,string,ultra
 boardversion,data,string,204
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/config-205.cvs
+++ b/config-205.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1366
 devicemodel,data,string,ultra
 boardversion,data,string,205
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/config-401.cvs
+++ b/config-401.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1368
 devicemodel,data,string,supra
 boardversion,data,string,401
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/config-402.cvs
+++ b/config-402.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1368
 devicemodel,data,string,supra
 boardversion,data,string,402
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/config-403.cvs
+++ b/config-403.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1368
 devicemodel,data,string,supra
 boardversion,data,string,403
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/config-601.cvs
+++ b/config-601.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1370
 devicemodel,data,string,gamma
 boardversion,data,string,601
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/config-602.cvs
+++ b/config-602.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1370
 devicemodel,data,string,gamma
 boardversion,data,string,602
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/config-800x.cvs
+++ b/config-800x.cvs
@@ -17,7 +17,6 @@ asicmodel,data,string,BM1370
 devicemodel,data,string,gammaturbo
 boardversion,data,string,800
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,0

--- a/config.cvs.example
+++ b/config.cvs.example
@@ -13,7 +13,6 @@ asicmodel,data,string,BM1366
 devicemodel,data,string,ultra
 boardversion,data,string,204
 flipscreen,data,u16,1
-invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,1

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -59,13 +59,6 @@
 
         <div class="col-12">
             <div class="field-checkbox">
-                <p-checkbox name="invertfanpolarity" formControlName="invertfanpolarity" inputId="invertfanpolarity"
-                    [binary]="true"></p-checkbox>
-                <label for="invertfanpolarity">Invert Fan Duty Cycle <i class="pi pi-info-circle" style="font-size: 0.8rem; margin-left: 0.2rem;" pTooltip="Inverting the polarity of the fan PWM signal"></i></label>
-            </div>
-        </div>
-        <div class="col-12">
-            <div class="field-checkbox">
                 <p-checkbox name="autofanspeed" formControlName="autofanspeed" inputId="autofanspeed"
                     [binary]="true"></p-checkbox>
                 <label for="autofanspeed">Automatic Fan Control</label>

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -189,7 +189,6 @@ export class EditComponent implements OnInit, OnDestroy {
           coreVoltage: [info.coreVoltage, [Validators.required]],
           frequency: [info.frequency, [Validators.required]],
           autofanspeed: [info.autofanspeed == 1, [Validators.required]],
-          invertfanpolarity: [info.invertfanpolarity == 1, [Validators.required]],
           fanspeed: [info.fanspeed, [Validators.required]],
           temptarget: [info.temptarget, [Validators.required]],
           overheat_mode: [info.overheat_mode, [Validators.required]]

--- a/main/http_server/axe-os/src/app/components/settings/settings.component.ts
+++ b/main/http_server/axe-os/src/app/components/settings/settings.component.ts
@@ -74,7 +74,6 @@ export class SettingsComponent {
           frequency: [info.frequency, [Validators.required]],
           autofanspeed: [info.autofanspeed == 1, [Validators.required]],
           temptarget: [info.temptarget, [Validators.required]],
-          invertfanpolarity: [info.invertfanpolarity == 1, [Validators.required]],
           fanspeed: [info.fanspeed, [Validators.required]],
         });
 
@@ -102,7 +101,6 @@ export class SettingsComponent {
     // bools to ints
     form.flipscreen = form.flipscreen == true ? 1 : 0;
     form.invertscreen = form.invertscreen == true ? 1 : 0;
-    form.invertfanpolarity = form.invertfanpolarity == true ? 1 : 0;
     form.autofanspeed = form.autofanspeed == true ? 1 : 0;
 
     if (form.stratumPassword === '*****') {

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -60,7 +60,6 @@ export class SystemService {
           boardVersion: "204",
           flipscreen: 1,
           invertscreen: 0,
-          invertfanpolarity: 1,
           autofanspeed: 1,
           fanspeed: 100,
           temptarget: 60,

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -44,7 +44,6 @@ export interface ISystemInfo {
     version: string,
     idfVersion: string,
     boardVersion: string,
-    invertfanpolarity: number,
     autofanspeed: number,
     fanspeed: number,
     temptarget: number,

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -466,9 +466,6 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     if ((item = cJSON_GetObjectItem(root, "invertscreen")) != NULL) {
         nvs_config_set_u16(NVS_CONFIG_INVERT_SCREEN, item->valueint);
     }
-    if ((item = cJSON_GetObjectItem(root, "invertfanpolarity")) != NULL) {
-        nvs_config_set_u16(NVS_CONFIG_INVERT_FAN_POLARITY, item->valueint);
-    }
     if ((item = cJSON_GetObjectItem(root, "autofanspeed")) != NULL) {
         nvs_config_set_u16(NVS_CONFIG_AUTO_FAN_SPEED, item->valueint);
     }
@@ -608,7 +605,6 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddNumberToObject(root, "overclockEnabled", nvs_config_get_u16(NVS_CONFIG_OVERCLOCK_ENABLED, 0));
     cJSON_AddNumberToObject(root, "invertscreen", nvs_config_get_u16(NVS_CONFIG_INVERT_SCREEN, 0));
 
-    cJSON_AddNumberToObject(root, "invertfanpolarity", nvs_config_get_u16(NVS_CONFIG_INVERT_FAN_POLARITY, 1));
     cJSON_AddNumberToObject(root, "autofanspeed", nvs_config_get_u16(NVS_CONFIG_AUTO_FAN_SPEED, 1));
 
     cJSON_AddNumberToObject(root, "fanspeed", GLOBAL_STATE->POWER_MANAGEMENT_MODULE.fan_perc);

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -109,7 +109,6 @@ components:
         - hashRate
         - hostname
         - idfVersion
-        - invertfanpolarity
         - invertscreen
         - isPSRAMAvailable
         - isUsingFallbackStratum
@@ -203,9 +202,6 @@ components:
         idfVersion:
           type: string
           description: ESP-IDF version
-        invertfanpolarity:
-          type: number
-          description: Fan polarity setting (0=normal, 1=inverted)
         invertscreen:
           type: number
           description: Screen invert setting (0=normal, 1=inverted)
@@ -393,12 +389,6 @@ components:
         invertscreen:
           type: integer
           description: Whether to invert screen colors (0=normal, 1=inverted)
-          enum: [0, 1]
-          examples:
-            - 0
-        invertfanpolarity:
-          type: integer
-          description: Whether to invert fan polarity (0=normal, 1=inverted)
           enum: [0, 1]
           examples:
             - 0

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -23,7 +23,6 @@
 #define NVS_CONFIG_BOARD_VERSION "boardversion"
 #define NVS_CONFIG_FLIP_SCREEN "flipscreen"
 #define NVS_CONFIG_INVERT_SCREEN "invertscreen"
-#define NVS_CONFIG_INVERT_FAN_POLARITY "invertfanpol"
 #define NVS_CONFIG_AUTO_FAN_SPEED "autofanspeed"
 #define NVS_CONFIG_FAN_SPEED "fanspeed"
 #define NVS_CONFIG_TEMP_TARGET "temptarget"

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -272,11 +272,11 @@ esp_err_t test_init_peripherals(GlobalState * GLOBAL_STATE) {
         case DEVICE_MAX:
         case DEVICE_ULTRA:
         case DEVICE_SUPRA:
-            ESP_RETURN_ON_ERROR(EMC2101_init(nvs_config_get_u16(NVS_CONFIG_INVERT_FAN_POLARITY, 1)), TAG, "EMC2101 init failed!");
+            ESP_RETURN_ON_ERROR(EMC2101_init(), TAG, "EMC2101 init failed!");
             EMC2101_set_fan_speed(1);
             break;
         case DEVICE_GAMMA:
-            ESP_RETURN_ON_ERROR(EMC2101_init(nvs_config_get_u16(NVS_CONFIG_INVERT_FAN_POLARITY, 1)), TAG, "EMC2101 init failed!");
+            ESP_RETURN_ON_ERROR(EMC2101_init(), TAG, "EMC2101 init failed!");
             EMC2101_set_fan_speed(1);
             EMC2101_set_ideality_factor(EMC2101_IDEALITY_1_0319);
             EMC2101_set_beta_compensation(EMC2101_BETA_11);

--- a/main/system.c
+++ b/main/system.c
@@ -96,7 +96,7 @@ esp_err_t SYSTEM_init_peripherals(GlobalState * GLOBAL_STATE) {
     ESP_RETURN_ON_ERROR(VCORE_init(GLOBAL_STATE), TAG, "VCORE init failed!");
     ESP_RETURN_ON_ERROR(VCORE_set_voltage(nvs_config_get_u16(NVS_CONFIG_ASIC_VOLTAGE, CONFIG_ASIC_VOLTAGE) / 1000.0, GLOBAL_STATE), TAG, "VCORE set voltage failed!");
 
-    ESP_RETURN_ON_ERROR(Thermal_init(GLOBAL_STATE->device_model, nvs_config_get_u16(NVS_CONFIG_INVERT_FAN_POLARITY, 1)), TAG, "Thermal init failed!");
+    ESP_RETURN_ON_ERROR(Thermal_init(GLOBAL_STATE->device_model), TAG, "Thermal init failed!");
 
     vTaskDelay(500 / portTICK_PERIOD_MS);
 

--- a/main/thermal/EMC2101.c
+++ b/main/thermal/EMC2101.c
@@ -13,7 +13,7 @@ static i2c_master_dev_handle_t emc2101_dev_handle;
  *
  * @return esp_err_t ESP_OK on success, or an error code on failure.
  */
-esp_err_t EMC2101_init(bool invertPolarity) {
+esp_err_t EMC2101_init() {
 
     if (i2c_bitaxe_add_device(EMC2101_I2CADDR_DEFAULT, &emc2101_dev_handle, TAG) != ESP_OK) {
         ESP_LOGE(TAG, "Failed to add device");
@@ -23,9 +23,20 @@ esp_err_t EMC2101_init(bool invertPolarity) {
     // set the TACH input
     ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2101_dev_handle, EMC2101_REG_CONFIG, 0x04));
 
-    if (invertPolarity) {
+
+    //! deprecated bit was never set successfully
+    // --- Configure Fan Settings (Register 0x4A) ---
+    // Start with a base configuration:
+    // Bit 7 (MASK) = 0: Tach Alert Enabled
+    // Bit 6 (EN)   = 1: *** FAN DRIVER ENABLED ***
+    // Bit 5 (LEVEL)= 1: Direct Setting Mode (use PWM Duty Cycle Reg 0x4C)
+    // Bit 4 (POL)  = 0: Normal Polarity (placeholder, set below)
+    // Bit 3:2(EDGES)=00: 2 Tach pulses per revolution (standard)
+    // Bit 1:0(RANGE)=00: PWM Frequency ~22.5 kHz (common setting)
+    // //if (invertPolarity) {
         ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(emc2101_dev_handle, EMC2101_FAN_CONFIG, 0b00100011));
-    }
+    // //}
+    
 
 
 

--- a/main/thermal/EMC2101.h
+++ b/main/thermal/EMC2101.h
@@ -163,7 +163,7 @@ typedef enum
 void EMC2101_set_fan_speed(float);
 // void EMC2101_read(void);
 uint16_t EMC2101_get_fan_speed(void);
-esp_err_t EMC2101_init(bool);
+esp_err_t EMC2101_init();
 float EMC2101_get_external_temp(void);
 uint8_t EMC2101_get_internal_temp(void);
 void EMC2101_set_ideality_factor(uint8_t);

--- a/main/thermal/EMC2103.c
+++ b/main/thermal/EMC2103.c
@@ -13,21 +13,21 @@ static i2c_master_dev_handle_t EMC2103_dev_handle;
  *
  * @return esp_err_t ESP_OK on success, or an error code on failure.
  */
-esp_err_t EMC2103_init(bool invertPolarity) {
+esp_err_t EMC2103_init() {
 
     if (i2c_bitaxe_add_device(EMC2103_I2CADDR_DEFAULT, &EMC2103_dev_handle, TAG) != ESP_OK) {
         ESP_LOGE(TAG, "Failed to add device");
         return ESP_FAIL;
     }
 
-    ESP_LOGI(TAG, "EMC2103 init with polarity %d", invertPolarity);
+    ESP_LOGI(TAG, "EMC2103 init");
 
     // Configure the fan setting
     ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(EMC2103_dev_handle, EMC2103_CONFIGURATION1, 0));
 
-    if (invertPolarity) {
-        ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(EMC2103_dev_handle, EMC2103_PWM_CONFIG, 0x01));
-    }
+    // //if (invertPolarity) {
+    ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(EMC2103_dev_handle, EMC2103_PWM_CONFIG, 0x01));
+    // //}
 
     return ESP_OK;
 

--- a/main/thermal/EMC2103.h
+++ b/main/thermal/EMC2103.h
@@ -65,7 +65,7 @@
 void EMC2103_set_fan_speed(float);
 // void EMC2103_read(void);
 uint16_t EMC2103_get_fan_speed(void);
-esp_err_t EMC2103_init(bool);
+esp_err_t EMC2103_init();
 float EMC2103_get_external_temp(void);
 float EMC2103_get_internal_temp(void);
 void EMC2103_set_ideality_factor(uint8_t);

--- a/main/thermal/thermal.c
+++ b/main/thermal/thermal.c
@@ -3,21 +3,21 @@
 #define INTERNAL_OFFSET 5 //degrees C
 
 
-esp_err_t Thermal_init(DeviceModel device_model, bool polarity) {
+esp_err_t Thermal_init(DeviceModel device_model) {
         //init the EMC2101, if we have one
     switch (device_model) {
         case DEVICE_MAX:
         case DEVICE_ULTRA:
         case DEVICE_SUPRA:
-            EMC2101_init(polarity);
+            EMC2101_init();
             break;
         case DEVICE_GAMMA:
-            EMC2101_init(polarity);
+            EMC2101_init();
             EMC2101_set_ideality_factor(EMC2101_IDEALITY_1_0319);
             EMC2101_set_beta_compensation(EMC2101_BETA_11);
             break;
         case DEVICE_GAMMATURBO:
-            EMC2103_init(polarity);
+            EMC2103_init();
             break;
         default:
     }

--- a/main/thermal/thermal.h
+++ b/main/thermal/thermal.h
@@ -8,7 +8,7 @@
 #include "EMC2103.h"
 #include "global_state.h"
 
-esp_err_t Thermal_init(DeviceModel device_model, bool polarity);
+esp_err_t Thermal_init(DeviceModel device_model);
 esp_err_t Thermal_set_fan_percent(DeviceModel device_model, float percent);
 uint16_t Thermal_get_fan_speed(DeviceModel device_model);
 


### PR DESCRIPTION
The polarity bit was never set correct before, it never worked. The UI button in this case was useless.
This PR removes the entire polarity bit code, keeps the last necessary comments if we decide to reintroduce it back again in emc2101.c 

this closes #844 

// --- Configure Fan Settings (Register 0x4A) ---
    // Start with a base configuration:
    // Bit 7 (MASK) = 0: Tach Alert Enabled
    // Bit 6 (EN)   = 1: *** FAN DRIVER ENABLED ***
    // Bit 5 (LEVEL)= 1: Direct Setting Mode (use PWM Duty Cycle Reg 0x4C)
    // Bit 4 (POL)  = 0: Normal Polarity (placeholder, set below)
    // Bit 3:2(EDGES)=00: 2 Tach pulses per revolution (standard)
    // Bit 1:0(RANGE)=00: PWM Frequency ~22.5 kHz (common setting)