### PR TITLE
Serial Buffer Alignment for non zero preamble offset

### DIFF
--- a/components/asic/common.c
+++ b/components/asic/common.c
@@ -88,6 +88,36 @@ int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response
     return chip_counter;
 }
 
+void shift_buffer_left(uint8_t *buffer, size_t len) {
+    if (len < 1) return;
+    memmove(buffer, buffer + 1, len - 1);
+}
+
+int find_preamble_offset(uint8_t *buffer, int buffer_size) {
+    int preamble_offset  = -1;
+    for (int i = 0; i < buffer_size; i++) {
+        uint16_t received_preamble = (buffer[i] << 8) | buffer[i+1];
+        if (received_preamble == PREAMBLE)  {
+            preamble_offset = i;
+            break;
+        }
+    }
+
+    return preamble_offset; // -1 not found, >=0 location
+}
+
+esp_err_t serial_alignment(uint8_t * buffer, int buffer_size, int preamble_offset) {
+    shift_buffer_left(buffer,preamble_offset);
+    uint8_t reserve_buf[11] = {0};
+    int reserve_received = SERIAL_rx(reserve_buf, preamble_offset, 10);
+    bool reserve_buf_size_test_ok = reserve_received == preamble_offset;
+    if (reserve_buf_size_test_ok) {
+        for (int i=0; i < preamble_offset; i++) buffer[buffer_size-preamble_offset+i] = reserve_buf[i];
+        return ESP_OK;
+    }
+    return ESP_FAIL;
+}
+
 esp_err_t receive_work(uint8_t * buffer, int buffer_size)
 {
     int received = SERIAL_rx(buffer, buffer_size, 10000);
@@ -109,12 +139,22 @@ esp_err_t receive_work(uint8_t * buffer, int buffer_size)
         return ESP_FAIL;
     }
 
-    uint16_t received_preamble = (buffer[0] << 8) | buffer[1];
-    if (received_preamble != PREAMBLE) {
-        ESP_LOGE(TAG, "Preamble mismatch: got 0x%04x, expected 0x%04x", received_preamble, PREAMBLE);
+    int preamble_offset = find_preamble_offset(buffer, buffer_size);
+    if (preamble_offset == -1) {
+        ESP_LOGE(TAG, "Preamble not found");
         ESP_LOG_BUFFER_HEX(TAG, buffer, received);
         SERIAL_clear_buffer();
         return ESP_FAIL;
+    }
+
+    if (preamble_offset > 0) {
+        ESP_LOGW(TAG, "Non zero preamble located at %i", preamble_offset);
+        if (serial_alignment(buffer, buffer_size, preamble_offset)==ESP_FAIL) {
+            ESP_LOGE(TAG, "Serial alignment recovery failed");
+            ESP_LOG_BUFFER_HEX(TAG, buffer, received);
+            SERIAL_clear_buffer();
+            return ESP_FAIL;
+        }
     }
 
     if (crc5(buffer + 2, buffer_size - 2) != 0) {


### PR DESCRIPTION
**Links**
Fixes https://github.com/bitaxeorg/ESP-Miner/issues/24
Refs https://github.com/bitaxeorg/ESP-Miner/issues/350

**Problem Definition**

What happens currently
consider this toy example 
our expected message is in the format  55 AA XX XX XX XX CC with length 7

the following uart buffer
UART BUF = 00 55 AA XX XX XX XX CC
**Currently**
1. we request size 7
2. we get 
UART BUF = CC
buffer = 00 55 AA XX XX XX XX
4. we fail the preamble test
5. clear the UART BUF

result a lost nonce


**this change does**
UART BUF = 00 55 AA XX XX XX XX CC
1. request size 7
2. we get 
UART BUF = CC
buffer = 00 55 AA XX XX XX XX
4. find offset of 55 aa, in this case its 1
5. offset the buffer by 1 
6. UART BUF = CC
buffer = 55 AA XX XX XX XX

7. request the offset in this case 1
UART BUF = 
buffer = 55 AA XX XX XX XX CC
8. complete tests

in this case we have overcome a serial offset error
in the normal case where everything works 
we dont have an increase of buffer reads
in the case where we have an offset we increase the reads by 1


**Status** Untested