### PR TITLE
re-order code in _check_for_best_diff() method in system.c file to prevent missing block found notification

### DIFF
--- a/main/system.c
+++ b/main/system.c
@@ -266,6 +266,12 @@ static void _check_for_best_diff(GlobalState * GLOBAL_STATE, double diff, uint8_
         _suffix_string((uint64_t) diff, module->best_session_diff_string, DIFF_STRING_SIZE, 0);
     }
 
+    double network_diff = _calculate_network_difficulty(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->target);
+    if (diff > network_diff) {
+        module->FOUND_BLOCK = true;
+        ESP_LOGI(TAG, "FOUND BLOCK!!!!!!!!!!!!!!!!!!!!!! %f > %f", diff, network_diff);
+    }
+
     if ((uint64_t) diff <= module->best_nonce_diff) {
         return;
     }
@@ -276,11 +282,6 @@ static void _check_for_best_diff(GlobalState * GLOBAL_STATE, double diff, uint8_
     // make the best_nonce_diff into a string
     _suffix_string((uint64_t) diff, module->best_diff_string, DIFF_STRING_SIZE, 0);
 
-    double network_diff = _calculate_network_difficulty(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->target);
-    if (diff > network_diff) {
-        module->FOUND_BLOCK = true;
-        ESP_LOGI(TAG, "FOUND BLOCK!!!!!!!!!!!!!!!!!!!!!! %f > %f", diff, network_diff);
-    }
     ESP_LOGI(TAG, "Network diff: %f", network_diff);
 }
 


### PR DESCRIPTION
I think we should move this part of code:
`double network_diff = _calculate_network_difficulty(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->target);
    if (diff > network_diff) {
        module->FOUND_BLOCK = true;
        ESP_LOGI(TAG, "FOUND BLOCK!!!!!!!!!!!!!!!!!!!!!! %f > %f", diff, network_diff);
    }`
before this return:
`if ((uint64_t) diff <= module->best_nonce_diff) {
        return;
    }`

consider this case:
1, if current newore diff is 120T, and then you find a solve with diff at 250T
2, then power off device and then trun on again;
3, then you find another solve with diff 150T. In this time, the orignal code will not notice a block found since the solved diff is less than `best_nonce_diff`