### PR TITLE
Track rejection reasons to avoid flickering

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -90,7 +90,7 @@
                             <span class="text-500">rejected</span>
                         </div>
                         <div *ngIf="info.sharesRejected > 0">
-                            <div *ngFor="let sharesRejectedReason of getSortedRejectedReasons(info)">
+                            <div *ngFor="let sharesRejectedReason of getSortedRejectionReasons(info); trackBy: trackByReason">
                               <span
                                 class="inline-block"
                                 pTooltip="{{ getRejectionExplanation(sharesRejectedReason.message) }}"

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -261,8 +261,12 @@ export class HomeComponent {
     return this.shareRejectReasonsService.getExplanation(reason);
   }
 
-  getSortedRejectedReasons(info: ISystemInfo): ISystemInfo['sharesRejectedReasons'] {
+  getSortedRejectionReasons(info: ISystemInfo): ISystemInfo['sharesRejectedReasons'] {
     return [...(info.sharesRejectedReasons ?? [])].sort((a, b) => b.count - a.count);
+  }
+
+  trackByReason(_index: number, item: { message: string, count: number }) {
+    return item.message;
   }
 
   public calculateAverage(data: number[]): number {

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -266,7 +266,7 @@ export class HomeComponent {
   }
 
   trackByReason(_index: number, item: { message: string, count: number }) {
-    return `${item.message}-${item.count}`;
+    return item.message; //Track only by message
   }
 
   public calculateAverage(data: number[]): number {

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -266,7 +266,7 @@ export class HomeComponent {
   }
 
   trackByReason(_index: number, item: { message: string, count: number }) {
-    return item.message;
+    return `${item.message}-${item.count}`;
   }
 
   public calculateAverage(data: number[]): number {


### PR DESCRIPTION
Adds `trackBy`to the loop of rejectResaons to only redraw that part of the DOM if data really changes.