### PR TITLE
GT Fan polarity fix

### DIFF
--- a/main/thermal/EMC2103.c
+++ b/main/thermal/EMC2103.c
@@ -24,10 +24,7 @@ esp_err_t EMC2103_init() {
 
     // Configure the fan setting
     ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(EMC2103_dev_handle, EMC2103_CONFIGURATION1, 0));
-
-    // //if (invertPolarity) {
-    ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(EMC2103_dev_handle, EMC2103_PWM_CONFIG, 0x01));
-    // //}
+    ESP_ERROR_CHECK(i2c_bitaxe_register_write_byte(EMC2103_dev_handle, EMC2103_PWM_CONFIG, 0x00));
 
     return ESP_OK;
 


### PR DESCRIPTION
EMC2103 on the Bitaxe Gamma Turbo needs to have the fan polarity set to 0