### PR TITLE
set GAMMATURBO_POWER_OFFSET to 10W

### DIFF
--- a/main/power/power.c
+++ b/main/power/power.c
@@ -10,7 +10,7 @@
 
 #define SUPRA_POWER_OFFSET 5 //Watts
 #define GAMMA_POWER_OFFSET 5 //Watts
-#define GAMMATURBO_POWER_OFFSET 5 //Watts
+#define GAMMATURBO_POWER_OFFSET 10 //Watts
 
 // max power settings
 #define MAX_MAX_POWER 25 //watts


### PR DESCRIPTION
10W offset matches up with my power meter. 

I kinda suspect the actual TPS546 power reading is too low, and so this offset is too big, but that's a problem for another day.