### PR TITLE
Fix increased power reported on bitaxeGamma

### DIFF
--- a/main/power/power.c
+++ b/main/power/power.c
@@ -112,12 +112,18 @@ float Power_get_power(GlobalState * GLOBAL_STATE) {
         
             break;
         case DEVICE_GAMMA:
+            current = TPS546_get_iout() * 1000.0;
+            // calculate regulator power (in milliwatts)
+            power = (TPS546_get_vout() * current) / 1000.0;
+            // The power reading from the TPS546 is only it's output power. So the rest of the Bitaxe power is not accounted for.
+            power += GAMMA_POWER_OFFSET; // Add offset for the rest of the Bitaxe power. TODO: this better.
+            break;
         case DEVICE_GAMMATURBO:
-                current = TPS546_get_iout() * 1000.0;
-                // calculate regulator power (in milliwatts)
-                power = (TPS546_get_vout() * current) / 1000.0;
-                // The power reading from the TPS546 is only it's output power. So the rest of the Bitaxe power is not accounted for.
-                power += GAMMATURBO_POWER_OFFSET; // Add offset for the rest of the Bitaxe power. TODO: this better.
+            current = TPS546_get_iout() * 1000.0;
+            // calculate regulator power (in milliwatts)
+            power = (TPS546_get_vout() * current) / 1000.0;
+            // The power reading from the TPS546 is only it's output power. So the rest of the Bitaxe power is not accounted for.
+            power += GAMMATURBO_POWER_OFFSET; // Add offset for the rest of the Bitaxe power. TODO: this better.
             break;
         default:
     }


### PR DESCRIPTION
the power.c Power_get_power() function switch statement was falling through and returning GT power for gamma also.

fixes #872 