### PR TITLE
fix: match hashrate y-axis tick colors to line

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -71,7 +71,7 @@ export class HomeComponent {
       this.chartOptions.plugins.legend.labels.color = textColor;
       this.chartOptions.scales.x.ticks.color = textColorSecondary;
       this.chartOptions.scales.x.grid.color = surfaceBorder;
-      this.chartOptions.scales.y.ticks.color = textColorSecondary;
+      this.chartOptions.scales.y.ticks.color = primaryColor;
       this.chartOptions.scales.y.grid.color = surfaceBorder;
       this.chartOptions.scales.y2.ticks.color = textColorSecondary;
       this.chartOptions.scales.y2.grid.color = surfaceBorder;


### PR DESCRIPTION
For issue #869 
<img width="1700" alt="image" src="https://github.com/user-attachments/assets/ea371afd-c249-4aa7-bee0-e45aa5400b3f" />
