### PR TITLE
Statistics task for previous chart data

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -22,6 +22,7 @@ SRCS
     "./tasks/asic_task.c"
     "./tasks/asic_result_task.c"
     "./tasks/power_management_task.c"
+    "./tasks/statistics_task.c"
     "./thermal/EMC2101.c"
     "./thermal/EMC2103.c"
     "./thermal/TMP1075.c"

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -6,6 +6,7 @@
 #include "asic_task.h"
 #include "common.h"
 #include "power_management_task.h"
+#include "statistics_task.h"
 #include "serial.h"
 #include "stratum_api.h"
 #include "work_queue.h"
@@ -86,6 +87,7 @@ typedef struct
     AsicTaskModule ASIC_TASK_MODULE;
     PowerManagementModule POWER_MANAGEMENT_MODULE;
     SelfTestModule SELF_TEST_MODULE;
+    StatisticsModule STATISTICS_MODULE;
 
     char * extranonce_str;
     int extranonce_2_len;

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -114,6 +114,17 @@
 
         <br/>
 
+        <div class="col-12">
+              <label>Statistics Limit: {{form.controls['statsLimit'].value}} previous data points
+                  <b *ngIf="form.controls['statsLimit'].value == 0"> (live data points only)</b></label>
+              <p-slider [min]="0" [max]="720" [step]="60" formControlName="statsLimit"></p-slider>
+        </div>
+
+        <div class="col-12">
+              <label>Statistics Duration: {{form.controls['statsDuration'].value}} hour(s)</label>
+              <p-slider [min]="1" [max]="720" formControlName="statsDuration"></p-slider>
+        </div>
+
         <div class="mt-2">
             <button pButton [disabled]="!form.dirty || form.invalid" (click)="updateSystem()"
                 class="btn btn-primary mr-2">Save</button>

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -125,6 +125,8 @@ export class EditComponent implements OnInit, OnDestroy {
           fanspeed: [info.fanspeed, [Validators.required]],
           temptarget: [info.temptarget, [Validators.required]],
           overheat_mode: [info.overheat_mode, [Validators.required]],
+          statsLimit: [info.statsLimit, [Validators.required]],
+          statsDuration: [info.statsDuration, [Validators.required]],
         });
 
       this.form.controls['autofanspeed'].valueChanges.pipe(

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -39,7 +39,7 @@
                 <ng-container *ngIf="!info.power_fault">
                     Average:
                     <span class="text-green-500 font-medium">
-                        {{calculateAverage(hashrateData) | hashSuffix}}
+                        {{calculateAverage(previousHashrateData.concat(hashrateData)) | hashSuffix}}
                     </span>
                 </ng-container>
 
@@ -67,7 +67,7 @@
                 <ng-container *ngIf="!info.power_fault">
                     Average:
                     <span class="text-green-500 font-medium">
-                        {{calculateEfficiencyAverage(hashrateData, powerData) | number: '1.2-2'}} <small>J/TH</small>
+                        {{calculateEfficiencyAverage(previousHashrateData.concat(hashrateData), previousPowerData.concat(powerData)) | number: '1.2-2'}} <small>J/TH</small>
                     </span>
                 </ng-container>
 

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -198,10 +198,15 @@ export class HomeComponent {
     this.stats$ = this.systemService.getStatistics().pipe(shareReplay({refCount: true, bufferSize: 1}));
     this.stats$.subscribe(stats => {
       stats.statistics.forEach(element => {
-        this.previousHashrateData.push(element.hash * 1000000000);
-        this.previousTemperatureData.push(element.temp);
-        this.previousPowerData.push(element.power);
-        this.previousDataLabel.push(new Date().getTime() - stats.currentTimestamp + element.timestamp);
+        const idxHashrate = 0;
+        const idxTemperature = 1;
+        const idxPower = 2;
+        const idxTimestamp = 3;
+
+        this.previousHashrateData.push(element[idxHashrate] * 1000000000);
+        this.previousTemperatureData.push(element[idxTemperature]);
+        this.previousPowerData.push(element[idxPower]);
+        this.previousDataLabel.push(new Date().getTime() - stats.currentTimestamp + element[idxTimestamp]);
 
         if (this.previousHashrateData.length >= 720) {
           this.previousHashrateData.shift();

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -231,11 +231,18 @@ export class HomeComponent {
           this.powerData.push(info.power);
           this.dataLabel.push(new Date().getTime());
 
-          if (this.hashrateData.length >= 720) {
-            this.hashrateData.shift();
-            this.temperatureData.shift();
-            this.powerData.shift();
-            this.dataLabel.shift();
+          if ((this.previousHashrateData.length + this.hashrateData.length) >= 720) {
+            if (this.previousHashrateData.length > 0) {
+              this.previousHashrateData.shift();
+              this.previousTemperatureData.shift();
+              this.previousPowerData.shift();
+              this.previousDataLabel.shift();
+            } else {
+              this.hashrateData.shift();
+              this.temperatureData.shift();
+              this.powerData.shift();
+              this.dataLabel.shift();
+            }
           }
 
           this.chartData.labels = this.previousDataLabel.concat(this.dataLabel);

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -6,6 +6,7 @@ import { ShareRejectionExplanationService } from 'src/app/services/share-rejecti
 import { SystemService } from 'src/app/services/system.service';
 import { ThemeService } from 'src/app/services/theme.service';
 import { ISystemInfo } from 'src/models/ISystemInfo';
+import { ISystemStatistics } from 'src/models/ISystemStatistics';
 
 
 @Component({
@@ -16,6 +17,7 @@ import { ISystemInfo } from 'src/models/ISystemInfo';
 export class HomeComponent {
 
   public info$!: Observable<ISystemInfo>;
+  public stats$!: Observable<ISystemStatistics>;
   public expectedHashRate$!: Observable<number | undefined>;
 
   public chartOptions: any;
@@ -23,6 +25,10 @@ export class HomeComponent {
   public hashrateData: number[] = [];
   public temperatureData: number[] = [];
   public powerData: number[] = [];
+  public previousDataLabel: number[] = [];
+  public previousHashrateData: number[] = [];
+  public previousTemperatureData: number[] = [];
+  public previousPowerData: number[] = [];
   public chartData?: any;
 
   public maxPower: number = 0;
@@ -188,7 +194,25 @@ export class HomeComponent {
       }
     };
 
+    // load previous data
+    this.stats$ = this.systemService.getStatistics().pipe(shareReplay({refCount: true, bufferSize: 1}));
+    this.stats$.subscribe(stats => {
+      stats.statistics.forEach(element => {
+        this.previousHashrateData.push(element.hash * 1000000000);
+        this.previousTemperatureData.push(element.temp);
+        this.previousPowerData.push(element.power);
+        this.previousDataLabel.push(new Date().getTime() - stats.currentTimestamp + element.timestamp);
 
+        if (this.previousHashrateData.length >= 720) {
+          this.previousHashrateData.shift();
+          this.previousTemperatureData.shift();
+          this.previousPowerData.shift();
+          this.previousDataLabel.shift();
+        }
+      });
+    });
+
+    // live data
     this.info$ = interval(5000).pipe(
       startWith(() => this.systemService.getInfo()),
       switchMap(() => {
@@ -200,7 +224,6 @@ export class HomeComponent {
           this.hashrateData.push(info.hashRate * 1000000000);
           this.temperatureData.push(info.temp);
           this.powerData.push(info.power);
-
           this.dataLabel.push(new Date().getTime());
 
           if (this.hashrateData.length >= 720) {
@@ -210,9 +233,9 @@ export class HomeComponent {
             this.dataLabel.shift();
           }
 
-          this.chartData.labels = this.dataLabel;
-          this.chartData.datasets[0].data = this.hashrateData;
-          this.chartData.datasets[1].data = this.temperatureData;
+          this.chartData.labels = this.previousDataLabel.concat(this.dataLabel);
+          this.chartData.datasets[0].data = this.previousHashrateData.concat(this.hashrateData);
+          this.chartData.datasets[1].data = this.previousTemperatureData.concat(this.temperatureData);
 
           this.chartData = {
             ...this.chartData
@@ -281,7 +304,11 @@ export class HomeComponent {
     // Calculate efficiency for each data point and average them
     const efficiencies = hashrateData.map((hashrate, index) => {
       const power = powerData[index] || 0;
-      return power / (hashrate/1000000000000); // Convert to J/TH
+      if (hashrate > 0) {
+        return power / (hashrate/1000000000000); // Convert to J/TH
+      } else {
+        return power; // in this case better than infinity or NaN
+      }
     });
 
     return this.calculateAverage(efficiencies);

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { delay, Observable, of } from 'rxjs';
 import { eASICModel } from 'src/models/enum/eASICModel';
 import { ISystemInfo } from 'src/models/ISystemInfo';
+import { ISystemStatistics } from 'src/models/ISystemStatistics';
 
 import { environment } from '../../environments/environment';
 
@@ -66,6 +67,8 @@ export class SystemService {
           autofanspeed: 1,
           fanspeed: 100,
           temptarget: 60,
+          statsLimit: 360,
+          statsDuration: 2,
           fanrpm: 0,
 
           boardtemp1: 30,
@@ -73,6 +76,30 @@ export class SystemService {
           overheat_mode: 0
         }
       ).pipe(delay(1000));
+    }
+  }
+
+  public getStatistics(uri: string = ''): Observable<ISystemStatistics> {
+    if (environment.production) {
+      return this.httpClient.get(`${uri}/api/system/statistics`) as Observable<ISystemStatistics>;
+    } else {
+      // Mock data for development
+      return of({
+        maxTimeConfig: 3,
+        currentTimestamp: 61125,
+        statistics: [
+          {"hash":0,"temp":-1,"power":14.45068359375,"timestamp":13131},
+          {"hash":413.4903744405481,"temp":58.5,"power":14.86083984375,"timestamp":18126},
+          {"hash":410.7764830376959,"temp":59.625,"power":15.03173828125,"timestamp":23125},
+          {"hash":440.100549473198,"temp":60.125,"power":15.1171875,"timestamp":28125},
+          {"hash":430.5816012914026,"temp":60.75,"power":15.1171875,"timestamp":33125},
+          {"hash":452.5464981767163,"temp":61.5,"power":15.1513671875,"timestamp":38125},
+          {"hash":414.9564271189586,"temp":61.875,"power":15.185546875,"timestamp":43125},
+          {"hash":498.7294609150379,"temp":62.125,"power":15.27099609375,"timestamp":48125},
+          {"hash":411.1671601439723,"temp":62.5,"power":15.30517578125,"timestamp":53125},
+          {"hash":491.327834852684,"temp":63,"power":15.33935546875,"timestamp":58125}
+        ]
+      }).pipe(delay(1000));
     }
   }
 

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -81,23 +81,22 @@ export class SystemService {
 
   public getStatistics(uri: string = ''): Observable<ISystemStatistics> {
     if (environment.production) {
-      return this.httpClient.get(`${uri}/api/system/statistics`) as Observable<ISystemStatistics>;
+      return this.httpClient.get(`${uri}/api/system/statistics/dashboard`) as Observable<ISystemStatistics>;
     } else {
       // Mock data for development
       return of({
-        maxTimeConfig: 3,
         currentTimestamp: 61125,
         statistics: [
-          {"hash":0,"temp":-1,"power":14.45068359375,"timestamp":13131},
-          {"hash":413.4903744405481,"temp":58.5,"power":14.86083984375,"timestamp":18126},
-          {"hash":410.7764830376959,"temp":59.625,"power":15.03173828125,"timestamp":23125},
-          {"hash":440.100549473198,"temp":60.125,"power":15.1171875,"timestamp":28125},
-          {"hash":430.5816012914026,"temp":60.75,"power":15.1171875,"timestamp":33125},
-          {"hash":452.5464981767163,"temp":61.5,"power":15.1513671875,"timestamp":38125},
-          {"hash":414.9564271189586,"temp":61.875,"power":15.185546875,"timestamp":43125},
-          {"hash":498.7294609150379,"temp":62.125,"power":15.27099609375,"timestamp":48125},
-          {"hash":411.1671601439723,"temp":62.5,"power":15.30517578125,"timestamp":53125},
-          {"hash":491.327834852684,"temp":63,"power":15.33935546875,"timestamp":58125}
+          [0,-1,14.45068359375,13131],
+          [413.4903744405481,58.5,14.86083984375,18126],
+          [410.7764830376959,59.625,15.03173828125,23125],
+          [440.100549473198,60.125,15.1171875,28125],
+          [430.5816012914026,60.75,15.1171875,33125],
+          [452.5464981767163,61.5,15.1513671875,38125],
+          [414.9564271189586,61.875,15.185546875,43125],
+          [498.7294609150379,62.125,15.27099609375,48125],
+          [411.1671601439723,62.5,15.30517578125,53125],
+          [491.327834852684,63,15.33935546875,58125]
         ]
       }).pipe(delay(1000));
     }

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -19,87 +19,88 @@ export class SystemService {
   public getInfo(uri: string = ''): Observable<ISystemInfo> {
     if (environment.production) {
       return this.httpClient.get(`${uri}/api/system/info`) as Observable<ISystemInfo>;
-    } else {
-      return of(
-        {
-          power: 11.670000076293945,
-          voltage: 5208.75,
-          current: 2237.5,
-          temp: 60,
-          vrTemp: 45,
-          maxPower: 25,
-          nominalVoltage: 5,
-          hashRate: 475,
-          expectedHashrate: 420,
-          bestDiff: "0",
-          bestSessionDiff: "0",
-          freeHeap: 200504,
-          coreVoltage: 1200,
-          coreVoltageActual: 1200,
-          hostname: "Bitaxe",
-          macAddr: "2C:54:91:88:C9:E3",
-          ssid: "default",
-          wifiPass: "password",
-          wifiStatus: "Connected!",
-          apEnabled: 0,
-          sharesAccepted: 1,
-          sharesRejected: 0,
-          sharesRejectedReasons: [],
-          uptimeSeconds: 38,
-          asicCount: 1,
-          smallCoreCount: 672,
-          ASICModel: eASICModel.BM1366,
-          stratumURL: "public-pool.io",
-          stratumPort: 21496,
-          fallbackStratumURL: "test.public-pool.io",
-          fallbackStratumPort: 21497,
-          stratumUser: "bc1q99n3pu025yyu0jlywpmwzalyhm36tg5u37w20d.bitaxe-U1",
-          fallbackStratumUser: "bc1q99n3pu025yyu0jlywpmwzalyhm36tg5u37w20d.bitaxe-U1",
-          isUsingFallbackStratum: true,
-          frequency: 485,
-          version: "2.0",
-          idfVersion: "v5.1.2",
-          boardVersion: "204",
-          display: "SSD1306 (128x32)",
-          flipscreen: 1,
-          invertscreen: 0,
-          displayTimeout: 0,
-          autofanspeed: 1,
-          fanspeed: 100,
-          temptarget: 60,
-          statsLimit: 360,
-          statsDuration: 2,
-          fanrpm: 0,
-
-          boardtemp1: 30,
-          boardtemp2: 40,
-          overheat_mode: 0
-        }
-      ).pipe(delay(1000));
     }
+
+    // Mock data for development
+    return of(
+      {
+        power: 11.670000076293945,
+        voltage: 5208.75,
+        current: 2237.5,
+        temp: 60,
+        vrTemp: 45,
+        maxPower: 25,
+        nominalVoltage: 5,
+        hashRate: 475,
+        expectedHashrate: 420,
+        bestDiff: "0",
+        bestSessionDiff: "0",
+        freeHeap: 200504,
+        coreVoltage: 1200,
+        coreVoltageActual: 1200,
+        hostname: "Bitaxe",
+        macAddr: "2C:54:91:88:C9:E3",
+        ssid: "default",
+        wifiPass: "password",
+        wifiStatus: "Connected!",
+        apEnabled: 0,
+        sharesAccepted: 1,
+        sharesRejected: 0,
+        sharesRejectedReasons: [],
+        uptimeSeconds: 38,
+        asicCount: 1,
+        smallCoreCount: 672,
+        ASICModel: eASICModel.BM1366,
+        stratumURL: "public-pool.io",
+        stratumPort: 21496,
+        fallbackStratumURL: "test.public-pool.io",
+        fallbackStratumPort: 21497,
+        stratumUser: "bc1q99n3pu025yyu0jlywpmwzalyhm36tg5u37w20d.bitaxe-U1",
+        fallbackStratumUser: "bc1q99n3pu025yyu0jlywpmwzalyhm36tg5u37w20d.bitaxe-U1",
+        isUsingFallbackStratum: true,
+        frequency: 485,
+        version: "2.0",
+        idfVersion: "v5.1.2",
+        boardVersion: "204",
+        display: "SSD1306 (128x32)",
+        flipscreen: 1,
+        invertscreen: 0,
+        displayTimeout: 0,
+        autofanspeed: 1,
+        fanspeed: 100,
+        temptarget: 60,
+        statsLimit: 360,
+        statsDuration: 2,
+        fanrpm: 0,
+
+        boardtemp1: 30,
+        boardtemp2: 40,
+        overheat_mode: 0
+      }
+    ).pipe(delay(1000));
   }
 
   public getStatistics(uri: string = ''): Observable<ISystemStatistics> {
     if (environment.production) {
       return this.httpClient.get(`${uri}/api/system/statistics/dashboard`) as Observable<ISystemStatistics>;
-    } else {
-      // Mock data for development
-      return of({
-        currentTimestamp: 61125,
-        statistics: [
-          [0,-1,14.45068359375,13131],
-          [413.4903744405481,58.5,14.86083984375,18126],
-          [410.7764830376959,59.625,15.03173828125,23125],
-          [440.100549473198,60.125,15.1171875,28125],
-          [430.5816012914026,60.75,15.1171875,33125],
-          [452.5464981767163,61.5,15.1513671875,38125],
-          [414.9564271189586,61.875,15.185546875,43125],
-          [498.7294609150379,62.125,15.27099609375,48125],
-          [411.1671601439723,62.5,15.30517578125,53125],
-          [491.327834852684,63,15.33935546875,58125]
-        ]
-      }).pipe(delay(1000));
     }
+
+    // Mock data for development
+    return of({
+      currentTimestamp: 61125,
+      statistics: [
+        [0,-1,14.45068359375,13131],
+        [413.4903744405481,58.5,14.86083984375,18126],
+        [410.7764830376959,59.625,15.03173828125,23125],
+        [440.100549473198,60.125,15.1171875,28125],
+        [430.5816012914026,60.75,15.1171875,33125],
+        [452.5464981767163,61.5,15.1513671875,38125],
+        [414.9564271189586,61.875,15.185546875,43125],
+        [498.7294609150379,62.125,15.27099609375,48125],
+        [411.1671601439723,62.5,15.30517578125,53125],
+        [491.327834852684,63,15.33935546875,58125]
+      ]
+    }).pipe(delay(1000));
   }
 
   public restart(uri: string = '') {
@@ -164,16 +165,16 @@ export class SystemService {
         defaultVoltage: number;
         voltageOptions: number[];
       }>;
-    } else {
-      // Mock data for development
-      return of({
-        ASICModel: eASICModel.BM1366,
-        defaultFrequency: 485,
-        frequencyOptions: [400, 425, 450, 475, 485, 500, 525, 550, 575],
-        defaultVoltage: 1200,
-        voltageOptions: [1100, 1150, 1200, 1250, 1300]
-      }).pipe(delay(1000));
     }
+
+    // Mock data for development
+    return of({
+      ASICModel: eASICModel.BM1366,
+      defaultFrequency: 485,
+      frequencyOptions: [400, 425, 450, 475, 485, 500, 525, 550, 575],
+      defaultVoltage: 1200,
+      voltageOptions: [1100, 1150, 1200, 1250, 1300]
+    }).pipe(delay(1000));
   }
 
   public getSwarmInfo(uri: string = ''): Observable<{ ip: string }[]> {

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -51,6 +51,8 @@ export interface ISystemInfo {
     fanspeed: number,
     temptarget: number,
     fanrpm: number,
+    statsLimit: number,
+    statsDuration: number,
     coreVoltageActual: number,
 
     boardtemp1?: number,

--- a/main/http_server/axe-os/src/models/ISystemStatistics.ts
+++ b/main/http_server/axe-os/src/models/ISystemStatistics.ts
@@ -1,0 +1,11 @@
+interface IStatistic {
+    hash: number;
+    temp: number;
+    power: number;
+    timestamp: number;
+}
+
+export interface ISystemStatistics {
+    currentTimestamp: number;
+    statistics: IStatistic[];
+}

--- a/main/http_server/axe-os/src/models/ISystemStatistics.ts
+++ b/main/http_server/axe-os/src/models/ISystemStatistics.ts
@@ -1,11 +1,4 @@
-interface IStatistic {
-    hash: number;
-    temp: number;
-    power: number;
-    timestamp: number;
-}
-
 export interface ISystemStatistics {
     currentTimestamp: number;
-    statistics: IStatistic[];
+    statistics: number[][];
 }

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -136,6 +136,9 @@ components:
         - vrTemp
         - wifiStatus
         - wifiRSSI
+        - displayTimeout
+        - statisticsLimit
+        - statisticsDuration
       properties:
         ASICModel:
           type: string
@@ -286,6 +289,15 @@ components:
         wifiRSSI:
           type: number
           description: WiFi signal strength
+        displayTimeout:
+          type: number
+          description: Turn off display after timeout
+        statsLimit:
+          type: number
+          description: Max limit data points for statistics
+        statsDuration:
+          type: number
+          description: Statistics duration in hours
 
     Settings:
       type: object
@@ -413,6 +425,27 @@ components:
           maximum: 100
           examples:
             - 66
+        displayTimeout:
+          type: integer
+          description: Set display timeout time in minutes (-1=display on, 0=display off)
+          minimum: -1
+          maximum: 71582
+          examples:
+            - 10
+        statsLimit:
+          type: integer
+          description: Set max limit data points for statistics (0=live data points only)
+          minimum: 0
+          maximum: 720
+          examples:
+            - 0
+        statsDuration:
+          type: integer
+          description: Set statistics duration in hours
+          minimum: 1
+          maximum: 720
+          examples:
+            - 1
       additionalProperties: true
 
   responses:
@@ -523,6 +556,55 @@ paths:
                       type: number
                     examples:
                       - [1100, 1150, 1200, 1250, 1300]
+        '401':
+          description: Unauthorized - Client not in allowed network range
+        '500':
+          description: Internal server error
+
+  /api/system/statistics:
+    get:
+      summary: Get system statistics
+      description: Returns system statistics
+      operationId: getSystemStatistics
+      tags:
+        - system
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - currentTimestamp
+                  - statistics
+                properties:
+                  currentTimestamp:
+                    type: number
+                    description: Current timestamp as a reference
+                  statistics:
+                    type: array
+                    description: Statistics data point(s)
+                    items:
+                      type: object
+                      required:
+                        - hash
+                        - temp
+                        - power
+                        - timestamp
+                      properties:
+                        hash:
+                          type: number
+                          description: Hash rate
+                        temp:
+                          type: number
+                          description: Average chip temperature
+                        power:
+                          type: number
+                          description: Power consumption in watts
+                        timestamp:
+                          type: number
+                          description: Timestamp for data point
         '401':
           description: Unauthorized - Client not in allowed network range
         '500':

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -577,6 +577,46 @@ paths:
                 type: object
                 required:
                   - currentTimestamp
+                  - labels
+                  - statistics
+                properties:
+                  currentTimestamp:
+                    type: number
+                    description: Current timestamp as a reference
+                  labels:
+                    type: array
+                    description: Labels for statistics data value index
+                    items:
+                      type: string
+                  statistics:
+                    type: array
+                    description: Statistics data point(s)
+                    items:
+                      type: array
+                      description: Statistics data values(s)
+                      items:
+                        type: number
+        '401':
+          description: Unauthorized - Client not in allowed network range
+        '500':
+          description: Internal server error
+
+  /api/system/statistics/dashboard:
+    get:
+      summary: Get system statistics for dashboard
+      description: Returns system statistics for dashboard
+      operationId: getSystemStatisticsDashboard
+      tags:
+        - system
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - currentTimestamp
                   - statistics
                 properties:
                   currentTimestamp:
@@ -586,25 +626,10 @@ paths:
                     type: array
                     description: Statistics data point(s)
                     items:
-                      type: object
-                      required:
-                        - hash
-                        - temp
-                        - power
-                        - timestamp
-                      properties:
-                        hash:
-                          type: number
-                          description: Hash rate
-                        temp:
-                          type: number
-                          description: Average chip temperature
-                        power:
-                          type: number
-                          description: Power consumption in watts
-                        timestamp:
-                          type: number
-                          description: Timestamp for data point
+                      type: array
+                      description: Statistics data values(s)
+                      items:
+                        type: number
         '401':
           description: Unauthorized - Client not in allowed network range
         '500':

--- a/main/main.c
+++ b/main/main.c
@@ -8,6 +8,7 @@
 #include "asic_result_task.h"
 #include "asic_task.h"
 #include "create_jobs_task.h"
+#include "statistics_task.h"
 #include "system.h"
 #include "http_server.h"
 #include "nvs_config.h"
@@ -72,6 +73,7 @@ void app_main(void)
     }
 
     SYSTEM_init_system(&GLOBAL_STATE);
+    statistics_init(&GLOBAL_STATE);
 
     // init AP and connect to wifi
     wifi_init(&GLOBAL_STATE);
@@ -117,4 +119,5 @@ void app_main(void)
     xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 10, NULL);
     xTaskCreate(ASIC_task, "asic", 8192, (void *) &GLOBAL_STATE, 10, NULL);
     xTaskCreate(ASIC_result_task, "asic result", 8192, (void *) &GLOBAL_STATE, 15, NULL);
+    xTaskCreate(statistics_task, "statistics", 8192, (void *) &GLOBAL_STATE, 3, NULL);
 }

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -33,6 +33,8 @@
 #define NVS_CONFIG_OVERHEAT_MODE "overheat_mode"
 #define NVS_CONFIG_OVERCLOCK_ENABLED "oc_enabled"
 #define NVS_CONFIG_SWARM "swarmconfig"
+#define NVS_CONFIG_STATISTICS_LIMIT "statsLimit"
+#define NVS_CONFIG_STATISTICS_DURATION "statsDuration"
 
 // Theme configuration
 #define NVS_CONFIG_THEME_SCHEME "themescheme"

--- a/main/tasks/statistics_task.c
+++ b/main/tasks/statistics_task.c
@@ -1,0 +1,139 @@
+#include <stdint.h>
+#include <pthread.h>
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "statistics_task.h"
+#include "global_state.h"
+#include "nvs_config.h"
+
+#define DEFAULT_POLL_RATE 5000
+
+static const char * TAG = "statistics_task";
+
+static StatisticsNodePtr statisticsDataStart = NULL;
+static StatisticsNodePtr statisticsDataEnd = NULL;
+static pthread_mutex_t statisticsDataLock = PTHREAD_MUTEX_INITIALIZER;
+
+static uint16_t maxDataCount = 0;
+static uint16_t currentDataCount = 0;
+static uint16_t duration = 0;
+
+StatisticsNodePtr addStatisticData(double hashrate, float temperature, float power, int64_t timestamp)
+{
+    if (0 == maxDataCount) {
+        return NULL;
+    }
+
+    StatisticsNodePtr newData = NULL;
+
+    // create new data block or reuse first data block
+    if (currentDataCount < maxDataCount) {
+        newData = (StatisticsNodePtr)malloc(sizeof(struct StatisticsData));
+        currentDataCount++;
+    } else {
+        newData = statisticsDataStart;
+    }
+
+    // set data
+    if (NULL != newData) {
+        pthread_mutex_lock(&statisticsDataLock);
+
+        if (NULL == statisticsDataStart) {
+            statisticsDataStart = newData; // set first new data block
+        } else {
+            if ((statisticsDataStart == newData) && (NULL != statisticsDataStart->next)) {
+                statisticsDataStart = statisticsDataStart->next; // move DataStart to next (first data block reused)
+            }
+        }
+
+        newData->hashrate = hashrate;
+        newData->temperature = temperature;
+        newData->power = power;
+        newData->timestamp = timestamp;
+        newData->next = NULL;
+
+        if ((NULL != statisticsDataEnd) && (newData != statisticsDataEnd)) {
+            statisticsDataEnd->next = newData; // link data block
+        }
+        statisticsDataEnd = newData; // set DataEnd to new data
+
+        pthread_mutex_unlock(&statisticsDataLock);
+    }
+
+    return newData;
+}
+
+StatisticsNextNodePtr statisticData(StatisticsNodePtr node, double * hashrate, float * temperature, float * power, int64_t * timestamp)
+{
+    if ((NULL == node) || (0 == maxDataCount)) {
+        return NULL;
+    }
+
+    StatisticsNextNodePtr nextNode = NULL;
+
+    pthread_mutex_lock(&statisticsDataLock);
+
+    if (NULL != hashrate) {
+        *hashrate = node->hashrate;
+    }
+    if (NULL != temperature) {
+        *temperature = node->temperature;
+    }
+    if (NULL != power) {
+        *power = node->power;
+    }
+    if (NULL != timestamp) {
+        *timestamp = node->timestamp;
+    }
+    nextNode = node->next;
+
+    pthread_mutex_unlock(&statisticsDataLock);
+
+    return nextNode;
+}
+
+void statistics_init(void * pvParameters)
+{
+    GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
+    GLOBAL_STATE->STATISTICS_MODULE.statisticsList = &statisticsDataStart;
+}
+
+void statistics_task(void * pvParameters)
+{
+    ESP_LOGI(TAG, "Starting");
+
+    GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
+    SystemModule * sys_module = &GLOBAL_STATE->SYSTEM_MODULE;
+    PowerManagementModule * power_management = &GLOBAL_STATE->POWER_MANAGEMENT_MODULE;
+
+    maxDataCount = nvs_config_get_u16(NVS_CONFIG_STATISTICS_LIMIT, 0);
+    if (720 < maxDataCount) {
+        maxDataCount = 720;
+        nvs_config_set_u16(NVS_CONFIG_STATISTICS_LIMIT, maxDataCount);
+    }
+    duration = nvs_config_get_u16(NVS_CONFIG_STATISTICS_DURATION, 1);
+    if (720 < duration) {
+        duration = 720;
+        nvs_config_set_u16(NVS_CONFIG_STATISTICS_DURATION, duration);
+    }
+    if (1 > duration) {
+        duration = 1;
+        nvs_config_set_u16(NVS_CONFIG_STATISTICS_DURATION, duration);
+    }
+
+    const uint32_t pollRate = DEFAULT_POLL_RATE * duration;
+
+    ESP_LOGI(TAG, "Ready!");
+
+    while (1) {
+        addStatisticData(sys_module->current_hashrate,
+                         power_management->chip_temp_avg,
+                         power_management->power,
+                         esp_timer_get_time() / 1000);
+
+        // looper:
+        vTaskDelay(pollRate / portTICK_PERIOD_MS);
+    }
+}

--- a/main/tasks/statistics_task.h
+++ b/main/tasks/statistics_task.h
@@ -1,0 +1,28 @@
+#ifndef STATISTICS_TASK_H_
+#define STATISTICS_TASK_H_
+
+typedef struct StatisticsData * StatisticsNodePtr;
+typedef struct StatisticsData * StatisticsNextNodePtr;
+
+struct StatisticsData
+{
+    double hashrate;
+    float temperature;
+    float power;
+    int64_t timestamp;
+
+    StatisticsNextNodePtr next;
+};
+
+typedef struct
+{
+    StatisticsNodePtr * statisticsList;
+} StatisticsModule;
+
+StatisticsNodePtr addStatisticData(double hashrate, float temperature, float power, int64_t timestamp);
+StatisticsNextNodePtr statisticData(StatisticsNodePtr node, double * hashrate, float * temperature, float * power, int64_t * timestamp);
+
+void statistics_init(void * pvParameters);
+void statistics_task(void * pvParameters);
+
+#endif // STATISTICS_TASK_H_

--- a/main/tasks/statistics_task.h
+++ b/main/tasks/statistics_task.h
@@ -6,10 +6,18 @@ typedef struct StatisticsData * StatisticsNextNodePtr;
 
 struct StatisticsData
 {
-    double hashrate;
-    float temperature;
-    float power;
     int64_t timestamp;
+    double hashrate;
+    float chipTemperature;
+    float vrTemperature;
+    float power;
+    float voltage;
+    float current;
+    int16_t coreVoltageActual;
+    uint16_t fanSpeed;
+    uint16_t fanRPM;
+    int8_t wifiRSSI;
+    uint32_t freeHeap;
 
     StatisticsNextNodePtr next;
 };
@@ -19,8 +27,9 @@ typedef struct
     StatisticsNodePtr * statisticsList;
 } StatisticsModule;
 
-StatisticsNodePtr addStatisticData(double hashrate, float temperature, float power, int64_t timestamp);
-StatisticsNextNodePtr statisticData(StatisticsNodePtr node, double * hashrate, float * temperature, float * power, int64_t * timestamp);
+StatisticsNodePtr addStatisticData(StatisticsNodePtr data);
+
+StatisticsNextNodePtr statisticData(StatisticsNodePtr nodeIn, StatisticsNodePtr dataOut);
 
 void statistics_init(void * pvParameters);
 void statistics_task(void * pvParameters);


### PR DESCRIPTION
with new API endpoint for statistics.
The configuration with 0 data points is live data only (old behavior) with statistics disabled.
The poll rate is automatically set based on the configured duration.