### PR TITLE
Fix scientific notation in best session diff

### DIFF
--- a/main/system.c
+++ b/main/system.c
@@ -319,7 +319,7 @@ static void _suffix_string(uint64_t val, char * buf, size_t bufsiz, int sigdigit
 
     if (!sigdigits) {
         if (decimal)
-            snprintf(buf, bufsiz, "%.3g%s", dval, suffix);
+            snprintf(buf, bufsiz, "%.3f%s", dval, suffix);
         else
             snprintf(buf, bufsiz, "%d%s", (unsigned int) dval, suffix);
     } else {


### PR DESCRIPTION
Fixes #893

As far as I could determine, this happened when the diff has 3 decimal zeros.