### PR TITLE
Send mining.suggest_difficulty after authorization

### DIFF
--- a/components/stratum/include/mining.h
+++ b/components/stratum/include/mining.h
@@ -32,7 +32,7 @@ char *construct_coinbase_tx(const char *coinbase_1, const char *coinbase_2,
 
 char *calculate_merkle_root_hash(const char *coinbase_tx, const uint8_t merkle_branches[][32], const int num_merkle_branches);
 
-bm_job construct_bm_job(mining_notify *params, const char *merkle_root, const uint32_t version_mask);
+bm_job construct_bm_job(mining_notify *params, const char *merkle_root, const uint32_t version_mask, uint32_t difficulty);
 
 double test_nonce_value(const bm_job *job, const uint32_t nonce, const uint32_t rolled_version);
 

--- a/components/stratum/include/stratum_api.h
+++ b/components/stratum/include/stratum_api.h
@@ -35,10 +35,8 @@ typedef struct
     uint8_t *merkle_branches;
     size_t n_merkle_branches;
     uint32_t version;
-    uint32_t version_mask;
     uint32_t target;
     uint32_t ntime;
-    uint32_t difficulty;
 } mining_notify;
 
 typedef struct
@@ -72,7 +70,7 @@ void STRATUM_V1_parse(StratumApiV1Message *message, const char *stratum_json);
 
 void STRATUM_V1_free_mining_notify(mining_notify *params);
 
-int STRATUM_V1_authenticate(int socket, int send_uid, const char *username, const char *pass);
+int STRATUM_V1_authorize(int socket, int send_uid, const char *username, const char *pass);
 
 int STRATUM_V1_configure_version_rolling(int socket, int send_uid, uint32_t * version_mask);
 

--- a/components/stratum/mining.c
+++ b/components/stratum/mining.c
@@ -52,15 +52,15 @@ char *calculate_merkle_root_hash(const char *coinbase_tx, const uint8_t merkle_b
 }
 
 // take a mining_notify struct with ascii hex strings and convert it to a bm_job struct
-bm_job construct_bm_job(mining_notify *params, const char *merkle_root, const uint32_t version_mask)
+bm_job construct_bm_job(mining_notify *params, const char *merkle_root, const uint32_t version_mask, const uint32_t difficulty)
 {
     bm_job new_job;
 
     new_job.version = params->version;
-    new_job.starting_nonce = 0;
     new_job.target = params->target;
     new_job.ntime = params->ntime;
-    new_job.pool_diff = params->difficulty;
+    new_job.starting_nonce = 0;
+    new_job.pool_diff = difficulty;
 
     hex2bin(merkle_root, new_job.merkle_root, 32);
 

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -332,7 +332,7 @@ int STRATUM_V1_suggest_difficulty(int socket, int send_uid, uint32_t difficulty)
     return write(socket, difficulty_msg, strlen(difficulty_msg));
 }
 
-int STRATUM_V1_authenticate(int socket, int send_uid, const char * username, const char * pass)
+int STRATUM_V1_authorize(int socket, int send_uid, const char * username, const char * pass)
 {
     char authorize_msg[BUFFER_SIZE];
     sprintf(authorize_msg, "{\"id\": %d, \"method\": \"mining.authorize\", \"params\": [\"%s\", \"%s\"]}\n", send_uid, username,

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -128,6 +128,7 @@ typedef struct
     pthread_mutex_t valid_jobs_lock;
 
     uint32_t stratum_difficulty;
+    bool new_set_mining_difficulty_msg;
     uint32_t version_mask;
     bool new_stratum_version_rolling_msg;
 

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -423,10 +423,8 @@ void self_test(void * pvParameters)
     notify_message.job_id = 0;
     notify_message.prev_block_hash = "0c859545a3498373a57452fac22eb7113df2a465000543520000000000000000";
     notify_message.version = 0x20000004;
-    notify_message.version_mask = 0x1fffe000;
     notify_message.target = 0x1705ae3a;
     notify_message.ntime = 0x647025b5;
-    notify_message.difficulty = 1000000;
 
     const char * coinbase_tx = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4b0389130cfab"
                                "e6d6d5cbab26a2599e92916edec"
@@ -456,7 +454,7 @@ void self_test(void * pvParameters)
 
     char * merkle_root = calculate_merkle_root_hash(coinbase_tx, merkles, num_merkles);
 
-    bm_job job = construct_bm_job(&notify_message, merkle_root, 0x1fffe000);
+    bm_job job = construct_bm_job(&notify_message, merkle_root, 0x1fffe000, 1000000);
 
     uint8_t difficulty_mask = 8;
 

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -34,27 +34,25 @@ void ASIC_result_task(void *pvParameters)
             continue;
         }
 
+        bm_job *active_job = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id];
         // check the nonce difficulty
-        double nonce_diff = test_nonce_value(
-            GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id],
-            asic_result->nonce,
-            asic_result->rolled_version);
+        double nonce_diff = test_nonce_value(active_job, asic_result->nonce, asic_result->rolled_version);
 
         //log the ASIC response
-        ESP_LOGI(TAG, "Ver: %08" PRIX32 " Nonce %08" PRIX32 " diff %.1f of %ld.", asic_result->rolled_version, asic_result->nonce, nonce_diff, GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->pool_diff);
+        ESP_LOGI(TAG, "ID: %s, ver: %08" PRIX32 " Nonce %08" PRIX32 " diff %.1f of %ld.", active_job->jobid, asic_result->rolled_version, asic_result->nonce, nonce_diff, active_job->pool_diff);
 
-        if (nonce_diff >= GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->pool_diff)
+        if (nonce_diff >= active_job->pool_diff)
         {
             char * user = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_user : GLOBAL_STATE->SYSTEM_MODULE.pool_user;
             int ret = STRATUM_V1_submit_share(
                 GLOBAL_STATE->sock,
                 GLOBAL_STATE->send_uid++,
                 user,
-                GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->jobid,
-                GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->extranonce2,
-                GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->ntime,
+                active_job->jobid,
+                active_job->extranonce2,
+                active_job->ntime,
                 asic_result->nonce,
-                asic_result->rolled_version ^ GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->version);
+                asic_result->rolled_version ^ active_job->version);
 
             if (ret < 0) {
                 ESP_LOGI(TAG, "Unable to write share to socket. Closing connection. Ret: %d (errno %d: %s)", ret, errno, strerror(errno));

--- a/main/tasks/asic_task.c
+++ b/main/tasks/asic_task.c
@@ -34,14 +34,7 @@ void ASIC_task(void *pvParameters)
 
     while (1)
     {
-
         bm_job *next_bm_job = (bm_job *)queue_dequeue(&GLOBAL_STATE->ASIC_jobs_queue);
-
-        if (next_bm_job->pool_diff != GLOBAL_STATE->stratum_difficulty)
-        {
-            ESP_LOGI(TAG, "New pool difficulty %lu", next_bm_job->pool_diff);
-            GLOBAL_STATE->stratum_difficulty = next_bm_job->pool_diff;
-        }
 
         //(*GLOBAL_STATE->ASIC_functions.send_work_fn)(GLOBAL_STATE, next_bm_job); // send the job to the ASIC
         ASIC_send_work(GLOBAL_STATE, next_bm_job);

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -29,7 +29,6 @@
 static const char * TAG = "stratum_task";
 
 static StratumApiV1Message stratum_api_v1_message = {};
-static SystemTaskModule SYSTEM_TASK_MODULE = {.stratum_difficulty = 8192};
 
 static const char * primary_stratum_url;
 static uint16_t primary_stratum_port;
@@ -153,7 +152,7 @@ void stratum_primary_heartbeat(void * pvParameters)
 
         int send_uid = 1;
         STRATUM_V1_subscribe(sock, send_uid++, GLOBAL_STATE->asic_model_str);
-        STRATUM_V1_authenticate(sock, send_uid++, GLOBAL_STATE->SYSTEM_MODULE.pool_user, GLOBAL_STATE->SYSTEM_MODULE.pool_pass);
+        STRATUM_V1_authorize(sock, send_uid++, GLOBAL_STATE->SYSTEM_MODULE.pool_user, GLOBAL_STATE->SYSTEM_MODULE.pool_pass);
 
         char recv_buffer[BUFFER_SIZE];
         memset(recv_buffer, 0, BUFFER_SIZE);
@@ -293,11 +292,9 @@ void stratum_task(void * pvParameters)
         char * username = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_user : GLOBAL_STATE->SYSTEM_MODULE.pool_user;
         char * password = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_pass : GLOBAL_STATE->SYSTEM_MODULE.pool_pass;
 
+        int authorize_message_id = GLOBAL_STATE->send_uid++;
         //mining.authorize - ID: 3
-        STRATUM_V1_authenticate(GLOBAL_STATE->sock, GLOBAL_STATE->send_uid++, username, password);
-
-        //mining.suggest_difficulty - ID: 4
-        STRATUM_V1_suggest_difficulty(GLOBAL_STATE->sock, GLOBAL_STATE->send_uid++, STRATUM_DIFFICULTY);
+        STRATUM_V1_authorize(GLOBAL_STATE->sock, authorize_message_id, username, password);
 
         // Everything is set up, lets make sure we don't abandon work unnecessarily.
         GLOBAL_STATE->abandon_work = 0;
@@ -325,13 +322,11 @@ void stratum_task(void * pvParameters)
                     mining_notify * next_notify_json_str = (mining_notify *) queue_dequeue(&GLOBAL_STATE->stratum_queue);
                     STRATUM_V1_free_mining_notify(next_notify_json_str);
                 }
-                stratum_api_v1_message.mining_notification->difficulty = SYSTEM_TASK_MODULE.stratum_difficulty;
                 queue_enqueue(&GLOBAL_STATE->stratum_queue, stratum_api_v1_message.mining_notification);
             } else if (stratum_api_v1_message.method == MINING_SET_DIFFICULTY) {
-                if (stratum_api_v1_message.new_difficulty != SYSTEM_TASK_MODULE.stratum_difficulty) {
-                    SYSTEM_TASK_MODULE.stratum_difficulty = stratum_api_v1_message.new_difficulty;
-                    ESP_LOGI(TAG, "Set stratum difficulty: %ld", SYSTEM_TASK_MODULE.stratum_difficulty);
-                }
+                ESP_LOGI(TAG, "Set stratum difficulty: %ld", stratum_api_v1_message.new_difficulty);
+                GLOBAL_STATE->stratum_difficulty = stratum_api_v1_message.new_difficulty;
+                GLOBAL_STATE->new_set_mining_difficulty_msg = true;
             } else if (stratum_api_v1_message.method == MINING_SET_VERSION_MASK ||
                     stratum_api_v1_message.method == STRATUM_RESULT_VERSION_MASK) {
                 // 1fffe000
@@ -358,6 +353,9 @@ void stratum_task(void * pvParameters)
                 retry_attempts = 0;
                 if (stratum_api_v1_message.response_success) {
                     ESP_LOGI(TAG, "setup message accepted");
+                    if (stratum_api_v1_message.message_id == authorize_message_id) {
+                        STRATUM_V1_suggest_difficulty(GLOBAL_STATE->sock, GLOBAL_STATE->send_uid++, STRATUM_DIFFICULTY);
+                    }
                 } else {
                     ESP_LOGE(TAG, "setup message rejected: %s", stratum_api_v1_message.error_str);
                 }

--- a/main/tasks/stratum_task.h
+++ b/main/tasks/stratum_task.h
@@ -1,11 +1,6 @@
 #ifndef STRATUM_TASK_H_
 #define STRATUM_TASK_H_
 
-typedef struct
-{
-    uint32_t stratum_difficulty;
-} SystemTaskModule;
-
 void stratum_task(void *pvParameters);
 void stratum_close_connection(GlobalState * GLOBAL_STATE);
 


### PR DESCRIPTION
Fixes finding from https://github.com/bitaxeorg/ESP-Miner/discussions/902

It also refactor `set_difficulty` passing so `mining_notify` only actually received fields and accept a new difficulty in the same way as accepting a new version_mask in `create_jobs_task.c`.