### PR TITLE
Add Wi-Fi RSSI to the Logs Overview

### DIFF
--- a/main/http_server/axe-os/src/app/components/logs/logs.component.html
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.html
@@ -17,7 +17,7 @@
                 </tr>
                 <tr>
                     <td>Wi-Fi RSSI:</td>
-                    <td [ngClass]="{ 'text-green-500': info.wifiRSSI > -70, 'text-orange-500': info.wifiRSSI <= -70, 'text-red-500': info.wifiRSSI < -80}">
+                    <td [ngClass]="{'text-green-500': info.wifiRSSI > -70, 'text-orange-500': info.wifiRSSI <= -70, 'text-red-500': info.wifiRSSI < -80}">
                         {{info.wifiRSSI}} dBm
                     </td>
                 </tr>

--- a/main/http_server/axe-os/src/app/components/logs/logs.component.html
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.html
@@ -16,6 +16,12 @@
                     <td>{{info.wifiStatus}}</td>
                 </tr>
                 <tr>
+                    <td>Wi-Fi RSSI:</td>
+                    <td [ngClass]="{ 'text-green-500': info.wifiRSSI > -70, 'text-orange-500': info.wifiRSSI <= -70, 'text-red-500': info.wifiRSSI < -80}">
+                        {{info.wifiRSSI}} dBm
+                    </td>
+                </tr>
+                <tr>
                     <td>MAC Address:</td>
                     <td>{{info.macAddr}}</td>
                 </tr>

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -39,6 +39,7 @@ export class SystemService {
           ssid: "default",
           wifiPass: "password",
           wifiStatus: "Connected!",
+          wifiRSSI: -32,
           apEnabled: 0,
           sharesAccepted: 1,
           sharesRejected: 0,

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -26,6 +26,7 @@ export interface ISystemInfo {
     macAddr: string,
     ssid: string,
     wifiStatus: string,
+    wifiRSSI: number,
     apEnabled: number,
     sharesAccepted: number,
     sharesRejected: number,


### PR DESCRIPTION
Since the Wi-Fi RSSI value is available via [API](https://github.com/bitaxeorg/ESP-Miner/pull/739), we should display it in the WebGUI. My change adds the Wi-Fi RSSI to the Logs tab/overview.

The RSSI output is color-based according to the following rule:

* 'text-green-500': info.wifiRSSI > -70
* 'text-orange-500': info.wifiRSSI <= -70
* 'text-red-500': info.wifiRSSI < -80

<img width="1016" alt="Screenshot 2025-05-15 at 08 13 13" src="https://github.com/user-attachments/assets/9613dcc3-6587-48da-a203-8a33c6c5f02f" />
