### PR TITLE
Pools Visual Separation

### DIFF
--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -3,80 +3,81 @@
         <div class="card">
             <h2>Pool Configuration</h2>
             <form [formGroup]="form" *ngIf="form != null">
-        <div class="field grid p-fluid">
-            <label htmlFor="stratumURL" class="col-12 mb-2 md:col-2 md:mb-0">Stratum Host:</label>
-            <div class="col-12 md:col-10">
-                <input pInputText id="stratumURL" type="text" formControlName="stratumURL" />
-                <div>
-                    <small>Do not include 'stratum+tcp://' or port.</small>
+                <div class="field grid p-fluid">
+                    <label htmlFor="stratumURL" class="col-12 mb-2 md:col-2 md:mb-0">Stratum Host:</label>
+                    <div class="col-12 md:col-10">
+                        <input pInputText id="stratumURL" type="text" formControlName="stratumURL" />
+                        <div>
+                            <small>Do not include 'stratum+tcp://' or port.</small>
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </div>
-        <div class="field grid p-fluid">
-            <label htmlFor="stratumPort" class="col-12 mb-2 md:col-2 md:mb-0">Stratum Port:</label>
-            <div class="col-12 md:col-10">
-                <input pInputText id="stratumPort" formControlName="stratumPort" type="number" />
-            </div>
-        </div>
-        <div class="field grid p-fluid">
-            <label htmlFor="stratumUser" class="col-12 mb-2 md:col-2 md:mb-0">Stratum User:</label>
-            <div class="col-12 md:col-10">
-                <input pInputText id="stratumUser" formControlName="stratumUser" type="text" />
-            </div>
-        </div>
-        <div class="field grid p-fluid">
-            <label htmlFor="stratumPassword" class="col-12 mb-2 md:col-2 md:mb-0">Stratum Password:</label>
-            <div class="col-12 md:col-10 p-input-icon-right">
-                <i *ngIf="form.get('stratumPassword')?.dirty" class="pi"
-                   [ngClass]="{'pi-eye': !showStratumPassword, 'pi-eye-slash': showStratumPassword}"
-                   (click)="toggleStratumPasswordVisibility()" style="cursor: pointer;"></i>
-                <input pInputText id="stratumPassword" formControlName="stratumPassword"
-                       [type]="showStratumPassword ? 'text' : 'password'"
-                       placeholder="Enter stratum password" />
-            </div>
-        </div>
-        <div class="field grid p-fluid">
-            <label htmlFor="fallbackStratumURL" class="col-12 mb-2 md:col-2 md:mb-0">Fallback Stratum Host:</label>
-            <div class="col-12 md:col-10">
-                <input pInputText id="fallbackStratumURL" type="text" formControlName="fallbackStratumURL" />
-                <div>
-                    <small>Do not include 'stratum+tcp://' or port.</small>
+                <div class="field grid p-fluid">
+                    <label htmlFor="stratumPort" class="col-12 mb-2 md:col-2 md:mb-0">Stratum Port:</label>
+                    <div class="col-12 md:col-10">
+                        <input pInputText id="stratumPort" formControlName="stratumPort" type="number" />
+                    </div>
                 </div>
-            </div>
-        </div>
-        <div class="field grid p-fluid">
-            <label htmlFor="fallbackStratumPort" class="col-12 mb-2 md:col-2 md:mb-0">Fallback Stratum Port:</label>
-            <div class="col-12 md:col-10">
-                <input pInputText id="fallbackStratumPort" formControlName="fallbackStratumPort" type="number" />
-            </div>
-        </div>
-        <div class="field grid p-fluid">
-            <label htmlFor="fallbackStratumUser" class="col-12 mb-2 md:col-2 md:mb-0">Fallback Stratum User:</label>
-            <div class="col-12 md:col-10">
-                <input pInputText id="fallbackStratumUser" formControlName="fallbackStratumUser" type="text" />
-            </div>
-        </div>
-        <div class="field grid p-fluid">
-            <label htmlFor="fallbackStratumPassword" class="col-12 mb-2 md:col-2 md:mb-0">Fallback Stratum Password:</label>
-            <div class="col-12 md:col-10 p-input-icon-right">
-                <i *ngIf="form.get('fallbackStratumPassword')?.dirty" class="pi"
-                   [ngClass]="{'pi-eye': !showFallbackStratumPassword, 'pi-eye-slash': showFallbackStratumPassword}"
-                   (click)="toggleFallbackStratumPasswordVisibility()" style="cursor: pointer;"></i>
-                <input pInputText id="fallbackStratumPassword" formControlName="fallbackStratumPassword"
-                       [type]="showFallbackStratumPassword ? 'text' : 'password'"
-                       placeholder="Enter fallback stratum password" />
-            </div>
-        </div>
+                <div class="field grid p-fluid">
+                    <label htmlFor="stratumUser" class="col-12 mb-2 md:col-2 md:mb-0">Stratum User:</label>
+                    <div class="col-12 md:col-10">
+                        <input pInputText id="stratumUser" formControlName="stratumUser" type="text" />
+                    </div>
+                </div>
+                <div class="field grid p-fluid">
+                    <label htmlFor="stratumPassword" class="col-12 mb-2 md:col-2 md:mb-0">Stratum Password:</label>
+                    <div class="col-12 md:col-10 p-input-icon-right">
+                        <i *ngIf="form.get('stratumPassword')?.dirty" class="pi"
+                        [ngClass]="{'pi-eye': !showStratumPassword, 'pi-eye-slash': showStratumPassword}"
+                        (click)="toggleStratumPasswordVisibility()" style="cursor: pointer;"></i>
+                        <input pInputText id="stratumPassword" formControlName="stratumPassword"
+                            [type]="showStratumPassword ? 'text' : 'password'"
+                            placeholder="Enter stratum password" />
+                    </div>
+                </div>
 
-        <div class="mt-2">
-            <button pButton [disabled]="!form.dirty || form.invalid" (click)="updateSystem()"
-                class="btn btn-primary mr-2">Save</button>
-            <b style="line-height: 34px;">You must restart this device after saving for changes to take effect.</b>
-        </div>
+                <div class="field grid p-fluid mt-5">
+                    <label htmlFor="fallbackStratumURL" class="col-12 mb-2 md:col-2 md:mb-0">Fallback Stratum Host:</label>
+                    <div class="col-12 md:col-10">
+                        <input pInputText id="fallbackStratumURL" type="text" formControlName="fallbackStratumURL" />
+                        <div>
+                            <small>Do not include 'stratum+tcp://' or port.</small>
+                        </div>
+                    </div>
+                </div>
+                <div class="field grid p-fluid">
+                    <label htmlFor="fallbackStratumPort" class="col-12 mb-2 md:col-2 md:mb-0">Fallback Stratum Port:</label>
+                    <div class="col-12 md:col-10">
+                        <input pInputText id="fallbackStratumPort" formControlName="fallbackStratumPort" type="number" />
+                    </div>
+                </div>
+                <div class="field grid p-fluid">
+                    <label htmlFor="fallbackStratumUser" class="col-12 mb-2 md:col-2 md:mb-0">Fallback Stratum User:</label>
+                    <div class="col-12 md:col-10">
+                        <input pInputText id="fallbackStratumUser" formControlName="fallbackStratumUser" type="text" />
+                    </div>
+                </div>
+                <div class="field grid p-fluid">
+                    <label htmlFor="fallbackStratumPassword" class="col-12 mb-2 md:col-2 md:mb-0">Fallback Stratum Password:</label>
+                    <div class="col-12 md:col-10 p-input-icon-right">
+                        <i *ngIf="form.get('fallbackStratumPassword')?.dirty" class="pi"
+                        [ngClass]="{'pi-eye': !showFallbackStratumPassword, 'pi-eye-slash': showFallbackStratumPassword}"
+                        (click)="toggleFallbackStratumPasswordVisibility()" style="cursor: pointer;"></i>
+                        <input pInputText id="fallbackStratumPassword" formControlName="fallbackStratumPassword"
+                            [type]="showFallbackStratumPassword ? 'text' : 'password'"
+                            placeholder="Enter fallback stratum password" />
+                    </div>
+                </div>
 
-        <div class="mt-2">
-          <button pButton [disabled]="!savedChanges" (click)="restart()">Restart</button>
-        </div>
+                <div class="mt-2">
+                    <button pButton [disabled]="!form.dirty || form.invalid" (click)="updateSystem()"
+                        class="btn btn-primary mr-2">Save</button>
+                    <b style="line-height: 34px;">You must restart this device after saving for changes to take effect.</b>
+                </div>
+
+                <div class="mt-2">
+                    <button pButton [disabled]="!savedChanges" (click)="restart()">Restart</button>
+                </div>
             </form>
         </div>
     </div>


### PR DESCRIPTION
To increase user-friendliness, we visually separate the primary and fallback pool fields from each other. Just more spacing between the both groups.

P.S. Most of the changes are to the code intent. The related one is just adding `mt-5` at L39.

**Before**
<img width="1136" alt="Screenshot 2025-05-15 at 08 25 33" src="https://github.com/user-attachments/assets/27e2de78-a6e5-40a7-886e-2e4d95f48399" />

**After**
<img width="1175" alt="Screenshot 2025-05-15 at 08 38 15" src="https://github.com/user-attachments/assets/ba8f2936-c060-4ecd-8bdc-16de0d8df2b3" />
