### PR TITLE
Add option to disable or enable mining via API and UI

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -32,6 +32,7 @@ SRCS
     "./power/INA260.c"
     "./power/power.c"
     "./power/vcore.c"
+    "mining_controller.c" # Added mining controller
 
 INCLUDE_DIRS
     "."

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -10,6 +10,8 @@
 #include "stratum_api.h"
 #include "work_queue.h"
 #include "device_config.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #define STRATUM_USER CONFIG_STRATUM_USER
 #define FALLBACK_STRATUM_USER CONFIG_FALLBACK_STRATUM_USER
@@ -104,6 +106,15 @@ typedef struct
 
     bool ASIC_initalized;
     bool psram_is_available;
+
+    // New fields for mining state and task handles
+    bool mining_enabled;
+    TaskHandle_t power_management_task_handle;
+    TaskHandle_t stratum_task_handle;
+    TaskHandle_t stratum_primary_heartbeat_task_handle;
+    TaskHandle_t create_jobs_task_handle;
+    TaskHandle_t asic_task_handle;
+    TaskHandle_t asic_result_task_handle;
 } GlobalState;
 
 #endif /* GLOBAL_STATE_H_ */

--- a/main/http_server/axe-os/api/system/asic_settings.c
+++ b/main/http_server/axe-os/api/system/asic_settings.c
@@ -4,13 +4,10 @@
 #include "cJSON.h"
 #include "global_state.h"
 #include "asic.h"
+#include "http_server.h"
 
 // static const char *TAG = "asic_api";
 static GlobalState *GLOBAL_STATE = NULL;
-
-// Function declarations from http_server.c
-extern esp_err_t is_network_allowed(httpd_req_t *req);
-extern esp_err_t set_cors_headers(httpd_req_t *req);
 
 // Initialize the ASIC API with the global state
 void asic_api_init(GlobalState *global_state) {

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -2,6 +2,10 @@
     <h4>Loading...</h4>
 </ng-template>
 <ng-container *ngIf="info$ | async as info; else loading">
+    <p-message *ngIf="!info.miningEnabled" severity="info" styleClass="w-full mb-4 py-4 border-round-xl"
+        text="Mining manually stopped. Enable mining to start hashing again.">
+    </p-message>
+    
     <!-- Temp warning alert -->
     <p-message *ngIf="info.overheat_mode" severity="error" styleClass="w-full mb-4 py-4 border-round-xl"
         text="Bitaxe has overheated - See settings">

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -3,7 +3,7 @@
 </ng-template>
 <ng-container *ngIf="info$ | async as info; else loading">
     <p-message *ngIf="!info.miningEnabled" severity="info" styleClass="w-full mb-4 py-4 border-round-xl"
-        text="Mining manually stopped. Enable mining to start hashing again.">
+        text="Mining manually disabled. Enable mining to start hashing again.">
     </p-message>
     
     <!-- Temp warning alert -->
@@ -265,6 +265,14 @@
             <div class="card" *ngIf="info$ | async as info; else loading">
                 <h5>Uptime</h5>
                 {{info.uptimeSeconds | dateAgo}}
+            </div>
+        </div>
+
+        <div class="col-12 lg:col-6">
+            <div class="card">
+                <h5>Mining Status</h5>
+                <p>Mining is currently {{ info.miningEnabled ? 'Enabled' : 'Disabled' }}.</p>
+                <button pButton type="button" icon="{{info.miningEnabled ? 'pi pi-stop-circle' : 'pi pi-play'}}" label="{{info.miningEnabled ? 'Disable Mining' : 'Enable Mining'}}" (click)="toggleMining(info.miningEnabled)"></button>
             </div>
         </div>
 

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ToastrService } from 'ngx-toastr';
 import { interval, map, Observable, shareReplay, startWith, switchMap, tap } from 'rxjs';
 import { HashSuffixPipe } from 'src/app/pipes/hash-suffix.pipe';
 import { QuicklinkService } from 'src/app/services/quicklink.service';
@@ -41,7 +42,8 @@ export class HomeComponent {
     private systemService: SystemService,
     private themeService: ThemeService,
     private quickLinkService: QuicklinkService,
-    private shareRejectReasonsService: ShareRejectionExplanationService
+    private shareRejectReasonsService: ShareRejectionExplanationService,
+    private toastr: ToastrService
   ) {
     this.initializeChart();
 
@@ -267,6 +269,21 @@ export class HomeComponent {
 
   trackByReason(_index: number, item: { message: string, count: number }) {
     return item.message; //Track only by message
+  }
+
+  toggleMining(miningEnabled: boolean) {
+    this.toastr.info(`Toggling mining ${miningEnabled ? 'off' : 'on'}`, 'Requested');
+    const miningAction = miningEnabled ? this.systemService.stopMining() : this.systemService.startMining();
+
+    miningAction.subscribe({
+      next: () => {
+        this.toastr.success(`Mining ${miningEnabled ? 'disabled' : 'enabled'}`, 'Success')
+      },
+      error: (err) => {
+
+        this.toastr.error(`Failed to toggle mining: ${err}`, 'Error')
+      }
+    });
   }
 
   public calculateAverage(data: number[]): number {

--- a/main/http_server/axe-os/src/app/layout/app.menu.component.html
+++ b/main/http_server/axe-os/src/app/layout/app.menu.component.html
@@ -9,4 +9,18 @@
         <p-button (click)="restart()" id="restart" label="Restart" severity="primary"></p-button>
     </li>
 
+    <li id="start-mining-container" style="margin-top: 10px;">
+        <p-button (click)="callStartMining()" 
+                  label="Enable Mining" 
+                  icon="pi pi-play" 
+                  severity="success"></p-button>
+    </li>
+
+    <li id="stop-mining-container" style="margin-top: 10px;">
+        <p-button (click)="callStopMining()" 
+                  label="Disable Mining" 
+                  icon="pi pi-stop-circle" 
+                  severity="warning"></p-button>
+    </li>
+
 </ul>

--- a/main/http_server/axe-os/src/app/layout/app.menu.component.html
+++ b/main/http_server/axe-os/src/app/layout/app.menu.component.html
@@ -8,19 +8,4 @@
     <li id="restart-container">
         <p-button (click)="restart()" id="restart" label="Restart" severity="primary"></p-button>
     </li>
-
-    <li id="start-mining-container" style="margin-top: 10px;">
-        <p-button (click)="callStartMining()" 
-                  label="Enable Mining" 
-                  icon="pi pi-play" 
-                  severity="success"></p-button>
-    </li>
-
-    <li id="stop-mining-container" style="margin-top: 10px;">
-        <p-button (click)="callStopMining()" 
-                  label="Disable Mining" 
-                  icon="pi pi-stop-circle" 
-                  severity="warning"></p-button>
-    </li>
-
 </ul>

--- a/main/http_server/axe-os/src/app/layout/app.menu.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.menu.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
-
 import { SystemService } from '../services/system.service';
 import { LayoutService } from './service/app.layout.service';
 
@@ -39,32 +38,5 @@ export class AppMenuComponent implements OnInit {
         this.systemService.restart().subscribe(res => {
         });
         this.toastr.success('Success!', 'Bitaxe restarted');
-    }
-
-
-    callStartMining() {
-        this.toastr.info('Requesting to start mining...', 'Mining Start Requested');
-        this.systemService.startMining().subscribe({
-            next: () => {
-                this.toastr.success('Successfully started mining!', 'Mining Started');
-            },
-            error: (err) => {
-                this.toastr.error('Failed to start mining.', 'Error');
-                console.error('Error starting mining:', err);
-            }
-        });
-    }
-
-    callStopMining() {
-        this.toastr.info('Requesting to stop mining...', 'Mining Stop Requested');
-        this.systemService.stopMining().subscribe({
-            next: () => {
-                this.toastr.success('Successfully stopped mining!', 'Mining Stopped');
-            },
-            error: (err) => {
-                this.toastr.error('Failed to stop mining.', 'Error');
-                console.error('Error stopping mining:', err);
-            }
-        });
     }
 }

--- a/main/http_server/axe-os/src/app/layout/app.menu.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.menu.component.ts
@@ -37,8 +37,34 @@ export class AppMenuComponent implements OnInit {
 
     public restart() {
         this.systemService.restart().subscribe(res => {
-
         });
         this.toastr.success('Success!', 'Bitaxe restarted');
+    }
+
+
+    callStartMining() {
+        this.toastr.info('Requesting to start mining...', 'Mining Start Requested');
+        this.systemService.startMining().subscribe({
+            next: () => {
+                this.toastr.success('Successfully started mining!', 'Mining Started');
+            },
+            error: (err) => {
+                this.toastr.error('Failed to start mining.', 'Error');
+                console.error('Error starting mining:', err);
+            }
+        });
+    }
+
+    callStopMining() {
+        this.toastr.info('Requesting to stop mining...', 'Mining Stop Requested');
+        this.systemService.stopMining().subscribe({
+            next: () => {
+                this.toastr.success('Successfully stopped mining!', 'Mining Stopped');
+            },
+            error: (err) => {
+                this.toastr.error('Failed to stop mining.', 'Error');
+                console.error('Error stopping mining:', err);
+            }
+        });
     }
 }

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -68,10 +68,19 @@ export class SystemService {
 
           boardtemp1: 30,
           boardtemp2: 40,
-          overheat_mode: 0
+          overheat_mode: 0,
+          miningEnabled: true
         }
       ).pipe(delay(1000));
     }
+  }
+
+  public startMining(uri: string = ''): Observable<any> {
+    return this.httpClient.patch(`${uri}/api/mining/start`, {});
+  }
+
+  public stopMining(uri: string = ''): Observable<any> {
+    return this.httpClient.patch(`${uri}/api/mining/stop`, {});
   }
 
   public restart(uri: string = '') {

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -56,4 +56,5 @@ export interface ISystemInfo {
     overheat_mode: number,
     power_fault?: string
     overclockEnabled?: number
+    miningEnabled: boolean;
 }

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -43,8 +43,6 @@
 static const char * TAG = "http_server";
 static const char * CORS_TAG = "CORS";
 
-static GlobalState * GLOBAL_STATE;
-
 /* Handler for WiFi scan endpoint */
 static esp_err_t GET_wifi_scan(httpd_req_t *req)
 {
@@ -83,6 +81,7 @@ static esp_err_t GET_wifi_scan(httpd_req_t *req)
     return ESP_OK;
 }
 
+static GlobalState * GLOBAL_STATE;
 static httpd_handle_t server = NULL;
 QueueHandle_t log_queue = NULL;
 
@@ -162,7 +161,7 @@ static uint32_t extract_origin_ip_addr(char *origin)
     return origin_ip_addr;
 }
 
-esp_err_t is_network_allowed(httpd_req_t * req) 
+esp_err_t is_network_allowed(httpd_req_t * req)
 {
     if (GLOBAL_STATE->SYSTEM_MODULE.ap_enabled == true) {
         ESP_LOGI(CORS_TAG, "Device in AP mode. Allowing CORS.");
@@ -263,7 +262,7 @@ static esp_err_t set_content_type_from_file(httpd_req_t * req, const char * file
     return httpd_resp_set_type(req, type);
 }
 
-esp_err_t set_cors_headers(httpd_req_t * req) 
+esp_err_t set_cors_headers(httpd_req_t * req)
 {
 
     esp_err_t err;

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -37,10 +37,13 @@
 #include "TPS546.h"
 #include "theme_api.h"  // Add theme API include
 #include "axe-os/api/system/asic_settings.h"
+#include "mining_controller.h"
 #include "http_server.h"
 
 static const char * TAG = "http_server";
 static const char * CORS_TAG = "CORS";
+
+static GlobalState * GLOBAL_STATE;
 
 /* Handler for WiFi scan endpoint */
 static esp_err_t GET_wifi_scan(httpd_req_t *req)
@@ -80,7 +83,6 @@ static esp_err_t GET_wifi_scan(httpd_req_t *req)
     return ESP_OK;
 }
 
-static GlobalState * GLOBAL_STATE;
 static httpd_handle_t server = NULL;
 QueueHandle_t log_queue = NULL;
 
@@ -160,7 +162,7 @@ static uint32_t extract_origin_ip_addr(char *origin)
     return origin_ip_addr;
 }
 
-esp_err_t is_network_allowed(httpd_req_t * req)
+esp_err_t is_network_allowed(httpd_req_t * req) 
 {
     if (GLOBAL_STATE->SYSTEM_MODULE.ap_enabled == true) {
         ESP_LOGI(CORS_TAG, "Device in AP mode. Allowing CORS.");
@@ -261,7 +263,7 @@ static esp_err_t set_content_type_from_file(httpd_req_t * req, const char * file
     return httpd_resp_set_type(req, type);
 }
 
-esp_err_t set_cors_headers(httpd_req_t * req)
+esp_err_t set_cors_headers(httpd_req_t * req) 
 {
 
     esp_err_t err;
@@ -605,6 +607,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddStringToObject(root, "idfVersion", esp_get_idf_version());
     cJSON_AddStringToObject(root, "boardVersion", GLOBAL_STATE->DEVICE_CONFIG.board_version);
     cJSON_AddStringToObject(root, "runningPartition", esp_ota_get_running_partition()->label);
+    cJSON_AddBoolToObject(root, "miningEnabled", GLOBAL_STATE->mining_enabled);
 
     cJSON_AddNumberToObject(root, "flipscreen", nvs_config_get_u16(NVS_CONFIG_FLIP_SCREEN, 1));
     cJSON_AddNumberToObject(root, "overheat_mode", nvs_config_get_u16(NVS_CONFIG_OVERHEAT_MODE, 0));
@@ -777,6 +780,66 @@ esp_err_t POST_OTA_update(httpd_req_t * req)
     vTaskDelay(1000 / portTICK_PERIOD_MS);
     esp_restart();
 
+    return ESP_OK;
+}
+
+static esp_err_t PATCH_mining_stop_handler(httpd_req_t *req)
+{
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+    if (set_cors_headers(req) != ESP_OK) {
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "API call to stop mining.");
+    esp_err_t err = stop_mining(GLOBAL_STATE);
+
+    httpd_resp_set_type(req, "application/json");
+    cJSON *root = cJSON_CreateObject();
+    if (err == ESP_OK) {
+        cJSON_AddStringToObject(root, "status", "ok");
+        cJSON_AddStringToObject(root, "message", "Mining stop requested successfully.");
+    } else {
+        cJSON_AddStringToObject(root, "status", "error");
+        cJSON_AddStringToObject(root, "message", "Failed to request mining stop.");
+        httpd_resp_set_status(req, HTTPD_500_INTERNAL_SERVER_ERROR);
+    }
+    const char *response = cJSON_Print(root);
+    httpd_resp_sendstr(req, response);
+    free((void *)response);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+static esp_err_t PATCH_mining_start_handler(httpd_req_t *req)
+{
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+    if (set_cors_headers(req) != ESP_OK) {
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "API call to start mining.");
+    esp_err_t err = start_mining(GLOBAL_STATE);
+
+    httpd_resp_set_type(req, "application/json");
+    cJSON *root = cJSON_CreateObject();
+    if (err == ESP_OK) {
+        cJSON_AddStringToObject(root, "status", "ok");
+        cJSON_AddStringToObject(root, "message", "Mining start requested successfully.");
+    } else {
+        cJSON_AddStringToObject(root, "status", "error");
+        cJSON_AddStringToObject(root, "message", "Failed to request mining start.");
+        httpd_resp_set_status(req, HTTPD_500_INTERNAL_SERVER_ERROR);
+    }
+    const char *response = cJSON_Print(root);
+    httpd_resp_sendstr(req, response);
+    free((void *)response);
+    cJSON_Delete(root);
     return ESP_OK;
 }
 
@@ -1029,6 +1092,38 @@ esp_err_t start_rest_server(void * pvParameters)
         .is_websocket = true
     };
     httpd_register_uri_handler(server, &ws);
+
+    httpd_uri_t mining_stop_uri = {
+        .uri = "/api/mining/stop",
+        .method = HTTP_PATCH,
+        .handler = PATCH_mining_stop_handler,
+        .user_ctx = rest_context
+    };
+    httpd_register_uri_handler(server, &mining_stop_uri);
+
+    httpd_uri_t mining_stop_options_uri = {
+        .uri = "/api/mining/stop",
+        .method = HTTP_OPTIONS,
+        .handler = handle_options_request,
+        .user_ctx = NULL
+    };
+    httpd_register_uri_handler(server, &mining_stop_options_uri);
+
+    httpd_uri_t mining_start_uri = {
+        .uri = "/api/mining/start",
+        .method = HTTP_PATCH,
+        .handler = PATCH_mining_start_handler,
+        .user_ctx = rest_context
+    };
+    httpd_register_uri_handler(server, &mining_start_uri);
+
+    httpd_uri_t mining_start_options_uri = {
+        .uri = "/api/mining/start",
+        .method = HTTP_OPTIONS,
+        .handler = handle_options_request,
+        .user_ctx = NULL
+    };
+    httpd_register_uri_handler(server, &mining_start_options_uri);
 
     if (enter_recovery) {
         /* Make default route serve Recovery */

--- a/main/http_server/http_server.h
+++ b/main/http_server/http_server.h
@@ -1,7 +1,10 @@
 #ifndef HTTP_SERVER_H_
 #define HTTP_SERVER_H_
 #include <esp_http_server.h>
+#include "esp_err.h"
 
 esp_err_t start_rest_server(void *pvParameters);
+esp_err_t is_network_allowed(httpd_req_t *req);
+esp_err_t set_cors_headers(httpd_req_t *req);
 
 #endif

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -135,6 +135,7 @@ components:
         - vrTemp
         - wifiStatus
         - wifiRSSI
+        - miningEnabled
       properties:
         ASICModel:
           type: string
@@ -285,6 +286,9 @@ components:
         wifiRSSI:
           type: number
           description: WiFi signal strength
+        miningEnabled:
+          type: boolean
+          description: Whether mining is currently enabled (true) or stopped (false)
 
     Settings:
       type: object
@@ -420,8 +424,68 @@ components:
 
     InternalError:
       description: Internal server error
+    MiningActionResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [ok, error]
+          description: Result status of the action.
+        message:
+          type: string
+          description: A message describing the result of the action.
+      required:
+        - status
+        - message
 
 paths:
+  /api/mining/start:
+    patch:
+      summary: Start mining operations
+      description: Initiates or restarts the mining process.
+      operationId: startMining
+      tags:
+        - mining
+      responses:
+        '200':
+          description: Mining start successfully requested.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MiningActionResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalError'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MiningActionResponse'
+
+
+  /api/mining/stop:
+    patch:
+      summary: Stop mining operations
+      description: Halts the current mining process.
+      operationId: stopMining
+      tags:
+        - mining
+      responses:
+        '200':
+          description: Mining stop successfully requested.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MiningActionResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalError'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MiningActionResponse'
+
   /api/system/wifi/scan:
     get:
       summary: Scan for available WiFi networks

--- a/main/main.c
+++ b/main/main.c
@@ -4,6 +4,7 @@
 #include "nvs_flash.h"
 
 #include "main.h"
+#include "mining_controller.h"
 
 #include "asic_result_task.h"
 #include "asic_task.h"
@@ -26,7 +27,14 @@ static GlobalState GLOBAL_STATE = {
     .extranonce_2_len = 0, 
     .abandon_work = 0, 
     .version_mask = 0,
-    .ASIC_initalized = false
+    .ASIC_initalized = false,
+    .mining_enabled = false,
+    .power_management_task_handle = NULL,
+    .stratum_task_handle = NULL,
+    .stratum_primary_heartbeat_task_handle = NULL,
+    .create_jobs_task_handle = NULL,
+    .asic_task_handle = NULL,
+    .asic_result_task_handle = NULL
 };
 
 static const char * TAG = "bitaxe";
@@ -97,24 +105,8 @@ void app_main(void)
 
     wifi_softap_off();
 
-    queue_init(&GLOBAL_STATE.stratum_queue);
-    queue_init(&GLOBAL_STATE.ASIC_jobs_queue);
-
-    SERIAL_init();
-
-    if (ASIC_init(&GLOBAL_STATE) == 0) {
-        GLOBAL_STATE.SYSTEM_MODULE.asic_status = "Chip count 0";
-        ESP_LOGE(TAG, "Chip count 0");
-        return;
+    // Start mining operations using the mining_controller
+    if (start_mining(&GLOBAL_STATE) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to start mining operations. System will not mine.");
     }
-
-    SERIAL_set_baud(ASIC_set_max_baud(&GLOBAL_STATE));
-    SERIAL_clear_buffer();
-
-    GLOBAL_STATE.ASIC_initalized = true;
-
-    xTaskCreate(stratum_task, "stratum admin", 8192, (void *) &GLOBAL_STATE, 5, NULL);
-    xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 10, NULL);
-    xTaskCreate(ASIC_task, "asic", 8192, (void *) &GLOBAL_STATE, 10, NULL);
-    xTaskCreate(ASIC_result_task, "asic result", 8192, (void *) &GLOBAL_STATE, 15, NULL);
 }

--- a/main/mining_controller.c
+++ b/main/mining_controller.c
@@ -1,0 +1,224 @@
+#include "mining_controller.h"
+#include "esp_log.h"
+#include "esp_system.h"
+#include "freertos/semphr.h"
+#include <stdlib.h>
+
+#include "asic_result_task.h"
+#include "asic_task.h"
+#include "create_jobs_task.h"
+#include "main.h"
+#include "power_management_task.h"
+#include "stratum_task.h"
+
+#include "asic.h"
+#include "power.h"
+#include "serial.h"
+#include "vcore.h"
+#include "work_queue.h"
+
+#include "nvs_config.h"
+
+static const char * TAG = "mining_controller";
+
+esp_err_t start_mining(GlobalState * global_state)
+{
+    ESP_LOGI(TAG, "Starting mining operations...");
+
+    if (global_state->mining_enabled) {
+        ESP_LOGW(TAG, "Mining is already enabled.");
+        return ESP_OK;
+    }
+
+    BaseType_t task_created;
+    task_created = xTaskCreate(POWER_MANAGEMENT_task, "power management", 8192, (void *) global_state, 10,
+                               &global_state->power_management_task_handle);
+    if (task_created != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create POWER_MANAGEMENT_task");
+        global_state->ASIC_initalized = false;
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "POWER_MANAGEMENT_task created.");
+
+    global_state->mining_enabled = true;
+    global_state->abandon_work = 0;
+
+    // 1. Initialize hardware/modules related to mining
+    ESP_LOGI(TAG, "Initializing VCORE...");
+    if (VCORE_init(global_state) != ESP_OK) {
+        ESP_LOGE(TAG, "VCORE_init failed. Cannot start mining.");
+        return ESP_FAIL;
+    }
+
+    ESP_LOGI(TAG, "Initializing Queues...");
+    queue_init(&global_state->stratum_queue);
+    queue_init(&global_state->ASIC_jobs_queue);
+
+    ESP_LOGI(TAG, "Initializing Serial for ASIC...");
+    SERIAL_init();
+
+    ESP_LOGI(TAG, "Initializing ASIC...");
+    if (ASIC_init(global_state) == 0) {
+        global_state->SYSTEM_MODULE.asic_status = "Chip count 0 on restart";
+        ESP_LOGE(TAG, "ASIC_init failed (Chip count 0). Cannot start mining.");
+        global_state->ASIC_initalized = false;
+        return ESP_FAIL;
+    }
+
+    ESP_LOGI(TAG, "Setting ASIC baud rate and clearing buffer...");
+    SERIAL_set_baud(ASIC_set_max_baud(global_state));
+    SERIAL_clear_buffer();
+
+    global_state->ASIC_initalized = true;
+
+    // 2. Reset flags
+    global_state->new_stratum_version_rolling_msg = false;
+
+    // 3. Create tasks and store handles
+    ESP_LOGI(TAG, "Creating mining tasks...");
+
+    task_created = xTaskCreate(stratum_task, "stratum admin", 8192, (void *) global_state, 5, &global_state->stratum_task_handle);
+    if (task_created != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create stratum_task");
+        // Rollback previous tasks
+        if (global_state->power_management_task_handle)
+            vTaskDelete(global_state->power_management_task_handle);
+        global_state->ASIC_initalized = false;
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "stratum_task created.");
+
+    task_created =
+        xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) global_state, 10, &global_state->create_jobs_task_handle);
+    if (task_created != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create create_jobs_task");
+        // Rollback previous tasks
+        if (global_state->stratum_task_handle)
+            vTaskDelete(global_state->stratum_task_handle);
+        if (global_state->power_management_task_handle)
+            vTaskDelete(global_state->power_management_task_handle);
+        global_state->ASIC_initalized = false;
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "create_jobs_task created.");
+
+    task_created = xTaskCreate(ASIC_task, "asic", 8192, (void *) global_state, 10, &global_state->asic_task_handle);
+    if (task_created != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create ASIC_task");
+        // Rollback previous tasks
+        if (global_state->create_jobs_task_handle)
+            vTaskDelete(global_state->create_jobs_task_handle);
+        if (global_state->stratum_task_handle)
+            vTaskDelete(global_state->stratum_task_handle);
+        if (global_state->power_management_task_handle)
+            vTaskDelete(global_state->power_management_task_handle);
+        global_state->ASIC_initalized = false;
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "ASIC_task created.");
+
+    task_created =
+        xTaskCreate(ASIC_result_task, "asic result", 8192, (void *) global_state, 15, &global_state->asic_result_task_handle);
+    if (task_created != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create ASIC_result_task");
+        // Rollback previous tasks
+        if (global_state->asic_task_handle)
+            vTaskDelete(global_state->asic_task_handle);
+        if (global_state->ASIC_TASK_MODULE.semaphore) {
+            vSemaphoreDelete(global_state->ASIC_TASK_MODULE.semaphore);
+            global_state->ASIC_TASK_MODULE.semaphore = NULL;
+        }
+        if (global_state->ASIC_TASK_MODULE.active_jobs) {
+            free(global_state->ASIC_TASK_MODULE.active_jobs);
+            global_state->ASIC_TASK_MODULE.active_jobs = NULL;
+        }
+        if (global_state->valid_jobs) {
+            free(global_state->valid_jobs);
+            global_state->valid_jobs = NULL;
+        }
+
+        if (global_state->create_jobs_task_handle)
+            vTaskDelete(global_state->create_jobs_task_handle);
+        if (global_state->stratum_task_handle)
+            vTaskDelete(global_state->stratum_task_handle);
+        if (global_state->power_management_task_handle)
+            vTaskDelete(global_state->power_management_task_handle);
+        global_state->ASIC_initalized = false;
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "ASIC_result_task created.");
+
+    ESP_LOGI(TAG, "Mining operations started successfully.");
+    return ESP_OK;
+}
+
+esp_err_t stop_mining(GlobalState * global_state)
+{
+    ESP_LOGI(TAG, "Stopping mining operations...");
+
+    if (!global_state->mining_enabled) {
+        ESP_LOGW(TAG, "Mining is already disabled.");
+        return ESP_OK;
+    }
+
+    // 1. Signal tasks that mining is stopping
+    global_state->mining_enabled = false;
+    global_state->abandon_work = 1;
+
+    // 2. Close network connections and clean primary job queues
+    ESP_LOGI(TAG, "Closing stratum connection...");
+    stratum_close_connection(global_state);
+
+    // Add a delay to allow tasks to process stop flags before disabling power
+    ESP_LOGI(TAG, "Allowing tasks to process flags (150ms delay)...");
+    vTaskDelay(pdMS_TO_TICKS(150));
+
+    // 3. Stop ASIC hardware
+    if (global_state->ASIC_initalized) {
+        float safe_low_frequency = 56.25;
+        ESP_LOGI(TAG, "Setting ASIC frequency to a safe low value (%.2f MHz) before power disable...", safe_low_frequency);
+        bool freq_set_success = ASIC_set_frequency(global_state, safe_low_frequency);
+        if (freq_set_success) {
+            ESP_LOGI(TAG, "ASIC frequency set to %.2f MHz. Delaying for frequency to settle (50ms)...", safe_low_frequency);
+            vTaskDelay(pdMS_TO_TICKS(50));
+        } else {
+            ESP_LOGW(TAG, "Failed to set ASIC to safe low frequency. Proceeding with power disable.");
+        }
+    } else {
+        ESP_LOGI(TAG, "ASIC not initialized, skipping frequency ramp down.");
+    }
+
+    ESP_LOGI(TAG, "Disabling power to ASIC...");
+    Power_disable(global_state);
+
+    // Add a small delay after power disable for hardware to settle
+    ESP_LOGI(TAG, "Delay after Power_disable (50ms)...");
+    vTaskDelay(pdMS_TO_TICKS(50));
+
+    // 4. Cleaning up tasks
+    ESP_LOGI(TAG, "Cleaning up mining tasks...");
+    if (global_state->ASIC_TASK_MODULE.semaphore != NULL) {
+        vSemaphoreDelete(global_state->ASIC_TASK_MODULE.semaphore);
+        global_state->ASIC_TASK_MODULE.semaphore = NULL;
+        ESP_LOGI(TAG, "ASIC task semaphore deleted.");
+    }
+    if (global_state->ASIC_TASK_MODULE.active_jobs != NULL) {
+        free(global_state->ASIC_TASK_MODULE.active_jobs);
+        global_state->ASIC_TASK_MODULE.active_jobs = NULL;
+        ESP_LOGI(TAG, "ASIC active_jobs memory freed.");
+    }
+    if (global_state->valid_jobs != NULL) {
+        free(global_state->valid_jobs);
+        global_state->valid_jobs = NULL;
+        ESP_LOGI(TAG, "ASIC valid_jobs memory freed.");
+    }
+
+    // 5. Update final state and reset statistics
+    global_state->ASIC_initalized = false;
+
+    ESP_LOGI(TAG, "Resetting mining statistics for API reporting.");
+    global_state->SYSTEM_MODULE.current_hashrate = 0.0;
+
+    ESP_LOGI(TAG, "Mining operations stopped successfully.");
+    return ESP_OK;
+}

--- a/main/mining_controller.c
+++ b/main/mining_controller.c
@@ -12,7 +12,6 @@
 #include "stratum_task.h"
 
 #include "asic.h"
-#include "power.h"
 #include "serial.h"
 #include "vcore.h"
 #include "work_queue.h"
@@ -35,6 +34,9 @@ esp_err_t start_mining(GlobalState * global_state)
 
     if (global_state->power_management_task_handle == NULL) {
         ESP_LOGI(TAG, "POWER_MANAGEMENT_task not running. Creating new task...");
+
+        global_state->POWER_MANAGEMENT_MODULE.frequency_value = nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, CONFIG_ASIC_FREQUENCY);
+        ESP_LOGI(TAG, "NVS_CONFIG_ASIC_FREQ %f", (float)global_state->POWER_MANAGEMENT_MODULE.frequency_value);
         task_created = xTaskCreate(POWER_MANAGEMENT_task, "power management", 8192, (void *) global_state, 10,
                                    &global_state->power_management_task_handle);
         if (task_created != pdPASS) {
@@ -216,7 +218,7 @@ esp_err_t stop_mining(GlobalState * global_state)
     }
 
     ESP_LOGI(TAG, "Disabling power to ASIC...");
-    Power_disable(global_state);
+    VCORE_set_voltage(0.0, global_state);
 
     // Add a small delay after power disable for hardware to settle
     ESP_LOGI(TAG, "Delay after Power_disable (50ms)...");

--- a/main/mining_controller.h
+++ b/main/mining_controller.h
@@ -1,0 +1,10 @@
+#ifndef MINING_CONTROLLER_H_
+#define MINING_CONTROLLER_H_
+
+#include "global_state.h"
+#include "esp_err.h"
+
+esp_err_t start_mining(GlobalState *global_state);
+esp_err_t stop_mining(GlobalState *global_state);
+
+#endif

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -18,6 +18,16 @@ void ASIC_result_task(void *pvParameters)
 
     while (1)
     {
+        if (!GLOBAL_STATE->mining_enabled) {
+            ESP_LOGI(TAG, "Mining disabled, ASIC_result_task stopping.");
+
+            if (GLOBAL_STATE->asic_result_task_handle != NULL) {
+                GLOBAL_STATE->asic_result_task_handle = NULL;
+            }
+            vTaskDelete(NULL);
+            return;
+        }
+
         //task_result *asic_result = (*GLOBAL_STATE->ASIC_functions.receive_result_fn)(GLOBAL_STATE);
         task_result *asic_result = ASIC_process_work(GLOBAL_STATE);
 

--- a/main/tasks/asic_task.c
+++ b/main/tasks/asic_task.c
@@ -36,8 +36,17 @@ void ASIC_task(void *pvParameters)
 
     while (1)
     {
-        bm_job *next_bm_job = (bm_job *)queue_dequeue(&GLOBAL_STATE->ASIC_jobs_queue);
+        if (!GLOBAL_STATE->mining_enabled) {
+            ESP_LOGI(TAG, "Mining disabled, ASIC_task stopping.");
+            if (GLOBAL_STATE->asic_task_handle != NULL) {
+                GLOBAL_STATE->asic_task_handle = NULL; 
+            }
+            vTaskDelete(NULL); 
+            return; 
+        }
 
+        bm_job *next_bm_job = (bm_job *)queue_dequeue(&GLOBAL_STATE->ASIC_jobs_queue);
+        
         if (next_bm_job->pool_diff != GLOBAL_STATE->stratum_difficulty)
         {
             ESP_LOGI(TAG, "New pool difficulty %lu", next_bm_job->pool_diff);

--- a/main/tasks/asic_task.c
+++ b/main/tasks/asic_task.c
@@ -46,7 +46,6 @@ void ASIC_task(void *pvParameters)
         }
 
         bm_job *next_bm_job = (bm_job *)queue_dequeue(&GLOBAL_STATE->ASIC_jobs_queue);
-        
         if (next_bm_job->pool_diff != GLOBAL_STATE->stratum_difficulty)
         {
             ESP_LOGI(TAG, "New pool difficulty %lu", next_bm_job->pool_diff);

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -78,7 +78,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
             ESP_LOGI(TAG, "Mining disabled. Power management task active, fan at minimum.");
 
             double min_fan_percent_when_disabled = 25.0; 
-            Thermal_set_fan_percent(GLOBAL_STATE->device_model, min_fan_percent_when_disabled / 100.0);
+            Thermal_set_fan_percent(GLOBAL_STATE->DEVICE_CONFIG, min_fan_percent_when_disabled / 100.0);
             power_management->fan_perc = (uint16_t)min_fan_percent_when_disabled;
             
             // Reset last core voltage and frequency to ensure they are reapplied when mining restarts

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -66,6 +66,16 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     uint16_t last_asic_frequency = power_management->frequency_value;
     
     while (1) {
+        if (!GLOBAL_STATE->mining_enabled) {
+            ESP_LOGI(TAG, "Mining disabled, POWER_MANAGEMENT_task stopping.");
+            
+            // Consider if PID needs specific deinitialization: pid_set_mode(&pid, MANUAL);
+            if (GLOBAL_STATE->power_management_task_handle != NULL) {
+                 GLOBAL_STATE->power_management_task_handle = NULL;
+            }
+            vTaskDelete(NULL);
+            return;
+        }
 
         // Refresh PID setpoint from NVS in case it was changed via API
         pid_setPoint = (double)nvs_config_get_u16(NVS_CONFIG_TEMP_TARGET, pid_setPoint);

--- a/main/work_queue.h
+++ b/main/work_queue.h
@@ -22,5 +22,6 @@ void queue_enqueue(work_queue *queue, void *new_work);
 void ASIC_jobs_queue_clear(work_queue *queue);
 void *queue_dequeue(work_queue *queue);
 void queue_clear(work_queue *queue);
+int queue_get_count(work_queue *queue); // Added to get count safely
 
 #endif // WORK_QUEUE_H

--- a/main/work_queue.h
+++ b/main/work_queue.h
@@ -22,6 +22,5 @@ void queue_enqueue(work_queue *queue, void *new_work);
 void ASIC_jobs_queue_clear(work_queue *queue);
 void *queue_dequeue(work_queue *queue);
 void queue_clear(work_queue *queue);
-int queue_get_count(work_queue *queue); // Added to get count safely
 
 #endif // WORK_QUEUE_H


### PR DESCRIPTION
This PR adds the option to disable and enable the mining without powering of the whole ESP.

Add two endpoints `/api/mining/stop` and `/api/mining/start` as well as a card to the home.component.ts:

![grafik](https://github.com/user-attachments/assets/03db9192-65ab-46f5-b169-bbf314941db6)
![grafik](https://github.com/user-attachments/assets/d18377c9-e21a-4177-9bca-0019c7e06ebd)

When mining is resumed, it hovers at roughly 800 GH/s for a minute or two before going up to normal levels again.

Tested on my 601 for a week with multiple starts and stops.
