### PR TITLE
.editorconfig: Add indent size for SCSS & HTML files

### DIFF
--- a/main/http_server/axe-os/.editorconfig
+++ b/main/http_server/axe-os/.editorconfig
@@ -14,3 +14,6 @@ quote_type = single
 [*.md]
 max_line_length = off
 trim_trailing_whitespace = false
+
+[*.{scss,html}]
+indent_size = 4


### PR DESCRIPTION
It looks like 4 spaces are used for HTML and SCSS files (default = 2). I adapted the `.editorconfig` file to ensure correct indentation for all developers working on FE files.