### PR TITLE
SH1107 improvements, incomplete

### DIFF
--- a/main/display.c
+++ b/main/display.c
@@ -113,14 +113,13 @@ esp_err_t display_init(void * pvParameters)
         .reset_gpio_num = -1,
     };
 
-    esp_lcd_panel_ssd1306_config_t ssd1306_config = {
-        .height = GLOBAL_STATE->DISPLAY_CONFIG.v_res,
-    };
-    panel_config.vendor_config = &ssd1306_config;
-
     switch (GLOBAL_STATE->DISPLAY_CONFIG.display) {
         case SSD1306:
         case SSD1309:
+            esp_lcd_panel_ssd1306_config_t ssd1306_config = {
+                .height = GLOBAL_STATE->DISPLAY_CONFIG.h_res,
+            };
+            panel_config.vendor_config = &ssd1306_config;
             ESP_RETURN_ON_ERROR(esp_lcd_new_panel_ssd1306(io_handle, &panel_config, &panel_handle), TAG, "No display found");
             break;
         case SH1107:
@@ -153,7 +152,7 @@ esp_err_t display_init(void * pvParameters)
         .hres = GLOBAL_STATE->DISPLAY_CONFIG.h_res,
         .vres = GLOBAL_STATE->DISPLAY_CONFIG.v_res,
         .monochrome = true,
-        .color_format = LV_COLOR_FORMAT_I1,
+        .color_format = LV_COLOR_FORMAT_RGB565,
         .rotation = {
             .swap_xy = false,
             .mirror_x = !flip_screen, // The screen is not flipped, this is for backwards compatibility
@@ -169,6 +168,9 @@ esp_err_t display_init(void * pvParameters)
 
     if (esp_lcd_panel_init_err == ESP_OK) {
         if (lvgl_port_lock(0)) {
+
+            // lv_display_set_rotation(disp, LV_DISPLAY_ROTATION_90);
+
             lv_style_init(&scr_style);
             lv_style_set_text_font(&scr_style, &lv_font_portfolio_6x8);
             lv_style_set_bg_opa(&scr_style, LV_OPA_COVER);

--- a/main/display.h
+++ b/main/display.h
@@ -20,7 +20,7 @@ static const DisplayConfig display_configs[] = {
     { .name = "NONE",             .display = NONE,                                },
     { .name = "SSD1306 (128x32)", .display = SSD1306, .h_res = 128, .v_res = 32,  },
     { .name = "SSD1309 (128x64)", .display = SSD1309, .h_res = 128, .v_res = 64,  },
-    { .name = "SH1107 (128x64)",  .display = SH1107,  .h_res = 128, .v_res = 64,  },
+    { .name = "SH1107 (64x128)",  .display = SH1107,  .h_res = 64,  .v_res = 128, },
     { .name = "SH1107 (128x128)", .display = SH1107,  .h_res = 128, .v_res = 128, },
 };
 

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -273,6 +273,6 @@ export class EditComponent implements OnInit, OnDestroy {
   }
 
   getDisplays() {
-    return ["NONE", "SSD1306 (128x32)", "SSD1309 (128x64)", "SH1107 (128x64)", "SH1107 (128x128)"];
+    return ["NONE", "SSD1306 (128x32)", "SSD1309 (128x64)", "SH1107 (64x128)", "SH1107 (128x128)"];
   }
 }

--- a/main/i2c_bitaxe.h
+++ b/main/i2c_bitaxe.h
@@ -3,7 +3,7 @@
 
 #include "driver/i2c_master.h"
 
-#define I2C_BUS_SPEED_HZ 100000   /*!< I2C master clock frequency */
+#define I2C_BUS_SPEED_HZ 400000   /*!< I2C master clock frequency */
 
 esp_err_t i2c_bitaxe_init(void);
 esp_err_t i2c_bitaxe_add_device(uint8_t device_address, i2c_master_dev_handle_t * dev_handle, const char *device_tag);


### PR DESCRIPTION
This properly initialises the screen, but in the wrong orientation. Trying to rotate the screen through `lv_display_set_rotation` is corrupting the screen. 

I've opened a bug: https://github.com/espressif/esp-bsp/issues/574

Also increased I2C bus speed to 400Mhz, as 100Mhz was too slow to drive the higher resolution screens.