### PR TITLE
Display Timeout Slider

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -86,6 +86,15 @@
             </div>
         </div>
 
+        <div class="field grid p-fluid">
+            <label htmlFor="displayTimeoutControl" class="col-12 md:col-2 hidden md:flex mb-2 md:mb-0">Display Sleep</label>
+            <div class="col-12 md:col-10">
+                <label class="block mb-2">{{getDisplayTimeoutFormated()}}</label>
+                <p-slider [min]="getDisplayTimeoutMin()" [max]="getDisplayTimeoutMax()" [step]="1" [formControl]="displayTimeoutControl"></p-slider>
+                <input type="hidden" formControlName="displayTimeout" />
+            </div>
+        </div>
+
         <div class="col-12 md:col-4">
             <div class="field-checkbox">
                 <p-checkbox name="flipscreen" formControlName="flipscreen" inputId="flipscreen"
@@ -99,16 +108,6 @@
                 <p-checkbox name="invertscreen" formControlName="invertscreen" inputId="invertscreen"
                     [binary]="true"></p-checkbox>
                 <label for="invertscreen">Invert Screen <i class="pi pi-info-circle" style="font-size: 0.8rem; margin-left: 0.2rem;" pTooltip="Inverts the colors"></i></label>
-            </div>
-        </div>
-
-        <div class="field grid p-fluid">
-            <label htmlFor="displayTimeout" class="col-12 mb-2 md:col-2 md:mb-0">Display Timeout</label>
-            <div class="col-12 md:col-10">
-                <input pInputText id="displayTimeout" formControlName="displayTimeout" required min="-1" max="71582" type="number" />
-                <div>
-                    <small>In minutes (-1=display always on, 0=display off).</small>
-                </div>
             </div>
         </div>
 

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -65,7 +65,7 @@ export class SystemService {
         display: "SSD1306 (128x32)",
         flipscreen: 1,
         invertscreen: 0,
-        displayTimeout: 0,
+        displayTimeout: -1,
         autofanspeed: 1,
         fanspeed: 100,
         temptarget: 60,


### PR DESCRIPTION
This PR replaces the display timeout input field with a slider. Since sliders can only work with ascending numbers (0 ... x ... -1 isn't possible), I use a hidden input field and synchronise the modified data between the slider and the input field.

The maximum adjustable value: 30 minutes. I can change this value if necessary. I consider this value to be optimal.

The layout is also optimised for mobile.

https://github.com/user-attachments/assets/2d9cae1b-a2ad-424c-bdc0-c4a32005be22

