### PR TITLE
Dashboard: Get expected hash rate from API

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -43,8 +43,8 @@
                     </span>
                 </ng-container>
 
-                <div class="text-500 text-xs" *ngIf="!info.power_fault && (expectedHashRate$ | async) as expectedHashRate">
-                    Expected: {{expectedHashRate * 1000000000 | hashSuffix}}
+                <div class="text-500 text-xs" *ngIf="!info.power_fault && info.expectedHashrate">
+                    Expected: {{info.expectedHashrate * 1000000000 | hashSuffix}}
                 </div>
             </div>
         </div>
@@ -71,8 +71,8 @@
                     </span>
                 </ng-container>
 
-                <div class="text-500 text-xs" *ngIf="!info.power_fault && (expectedHashRate$ | async) as expectedHashRate">
-                    Expected: {{info.power / (expectedHashRate/1000) | number: '1.2-2'}} J/TH
+                <div class="text-500 text-xs" *ngIf="!info.power_fault && info.expectedHashrate">
+                    Expected: {{info.power / (info.expectedHashrate/1000) | number: '1.2-2'}} J/TH
                 </div>
             </div>
         </div>

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -18,7 +18,6 @@ export class HomeComponent {
 
   public info$!: Observable<ISystemInfo>;
   public stats$!: Observable<ISystemStatistics>;
-  public expectedHashRate$!: Observable<number | undefined>;
 
   public chartOptions: any;
   public dataLabel: number[] = [];
@@ -279,10 +278,6 @@ export class HomeComponent {
       shareReplay({ refCount: true, bufferSize: 1 })
     );
 
-    this.expectedHashRate$ = this.info$.pipe(map(info => {
-      return Math.floor(info.frequency * ((info.smallCoreCount * info.asicCount) / 1000))
-    }))
-
     this.quickLink$ = this.info$.pipe(
       map(info => {
         const url = info.isUsingFallbackStratum ? info.fallbackStratumURL : info.stratumURL;
@@ -324,5 +319,5 @@ export class HomeComponent {
     });
 
     return this.calculateAverage(efficiencies);
-  }  
+  }
 }


### PR DESCRIPTION
Since [we can get the expected hash rate from the API](https://github.com/bitaxeorg/ESP-Miner/pull/603), there is no need to calculate it in the front end. This PR uses the expected hash rate from the `info` endpoint.