### PR TITLE
Add Braiins Solo Pool to Pool Quick Links

### DIFF
--- a/main/http_server/axe-os/src/app/services/quicklink.service.ts
+++ b/main/http_server/axe-os/src/app/services/quicklink.service.ts
@@ -36,6 +36,8 @@ export class QuicklinkService {
             return `https://pool.nerdminer.de/#/app/${address}`;
         } else if (stratumURL.includes('solomining.de')) {
             return `https://pool.solomining.de/#/app/${address}`;
+        } else if (stratumURL.includes('solo.stratum.braiins.com')) {
+          return `https://solo.braiins.com/stats/${address}`;
         }
         return stratumURL.startsWith('http') ? stratumURL : `http://${stratumURL}`;
     }


### PR DESCRIPTION
This change adds [Braiins Solo Pool](https://solo.braiins.com) to the existing Quick Links so that the dashboard link is opened correctly.

Tested with:
* fallbackStratumURL: "solo.stratum.braiins.com",
* fallbackStratumPort: 3333,

`@system.service.ts`