### PR TITLE
Removal of unnecessary code @ edit.component.ts

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -174,11 +174,6 @@ export class EditComponent implements OnInit, OnDestroy {
       });
   }
 
-  showWifiPassword: boolean = false;
-  toggleWifiPasswordVisibility() {
-    this.showWifiPassword = !this.showWifiPassword;
-  }
-
   disableOverheatMode() {
     this.form.patchValue({ overheat_mode: 0 });
     this.updateSystem();


### PR DESCRIPTION
This change removes the remaining code from `edit.component.ts`. It was probably left behind when the network settings were moved to their own tab.