### PR TITLE
Fix inconsistent function naming @ edit.component.ts

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -9,14 +9,14 @@
             <div class="field grid p-fluid">
                 <label class="col-12 mb-2 md:col-2 md:mb-0" htmlFor="frequency">Frequency</label>
                 <div class="col-12 md:col-10">
-                    <p-dropdown [options]="getDropdownFrequency()" optionLabel="name" optionValue="value"
+                    <p-dropdown [options]="dropdownFrequency" optionLabel="name" optionValue="value"
                         formControlName="frequency"></p-dropdown>
                 </div>
             </div>
 
             <div class="field grid p-fluid">
                 <label class="col-12 mb-2 md:col-2 md:mb-0" htmlFor="coreVoltage">Core Voltage</label>
-                <p-dropdown class="col-12 md:col-10" [options]="getCoreVoltage()" optionLabel="name"
+                <p-dropdown class="col-12 md:col-10" [options]="dropdownVoltage" optionLabel="name"
                     optionValue="value" formControlName="coreVoltage"></p-dropdown>
             </div>
         </ng-container>

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -8,6 +8,11 @@ import { SystemService } from 'src/app/services/system.service';
 import { eASICModel } from 'src/models/enum/eASICModel';
 import { ActivatedRoute } from '@angular/router';
 
+type Dropdown = {
+  name: string;
+  value: number;
+}[]
+
 const DISPLAY_TIMEOUT_STEPS = [0, 1, 2, 5, 15, 30, 60, 60 * 2, 60 * 4, 60* 8, -1];
 
 @Component({
@@ -234,11 +239,11 @@ export class EditComponent implements OnInit, OnDestroy {
       });
   }
 
-  getDropdownFrequency() {
+  get dropdownFrequency(): Dropdown {
     return this.buildDropdown('frequency', this.frequencyOptions, this.defaultFrequency);
   }
 
-  getCoreVoltage() {
+  get dropdownVoltage(): Dropdown {
     return this.buildDropdown('coreVoltage', this.voltageOptions, this.defaultVoltage);
   }
 
@@ -254,7 +259,7 @@ export class EditComponent implements OnInit, OnDestroy {
     return DISPLAY_TIMEOUT_STEPS[this.displayTimeoutMaxSteps - 1];
   }
 
-  buildDropdown(formField: string, apiOptions: number[], defaultValue: number): {name: string; value: number;}[] {
+  buildDropdown(formField: string, apiOptions: number[], defaultValue: number): Dropdown {
     if (!apiOptions.length) {
       return [];
     }


### PR DESCRIPTION
As @mutatrum correctly [pointed out](https://github.com/bitaxeorg/ESP-Miner/pull/964#discussion_r2111639471), the function names `getDropdownFrequency` and `getCoreVoltage` are inconsistent. I am aligning the function names with this request.

- [x] Renaming to getter functions `dropdownFrequency` and `dropdownVoltage`
- [x] Add return type `Dropdown`
