### PR TITLE
Uniform logging tags

### DIFF
--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -66,7 +66,7 @@ typedef struct __attribute__((__packed__))
 
 static float current_frequency = 56.25;
 
-static const char * TAG = "bm1366Module";
+static const char * TAG = "bm1366";
 
 static task_result result;
 

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -64,7 +64,7 @@ typedef struct __attribute__((__packed__))
     uint8_t crc;
 } bm1368_asic_result_t;
 
-static const char * TAG = "bm1368Module";
+static const char * TAG = "bm1368";
 
 static task_result result;
 

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -64,7 +64,7 @@ typedef struct __attribute__((__packed__))
     uint8_t crc;
 } bm1370_asic_result_t;
 
-static const char * TAG = "bm1370Module";
+static const char * TAG = "bm1370";
 
 static task_result result;
 

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -62,7 +62,7 @@ typedef struct __attribute__((__packed__))
     uint8_t crc;
 } bm1397_asic_result_t;
 
-static const char *TAG = "bm1397Module";
+static const char * TAG = "bm1397";
 
 static uint32_t prev_nonce = 0;
 static task_result result;

--- a/components/asic/frequency_transition_bmXX.c
+++ b/components/asic/frequency_transition_bmXX.c
@@ -4,13 +4,13 @@
 #include "freertos/task.h"
 #include <math.h>
 
-const char *FREQUENCY_TRANSITION_TAG = "frequency_transition";
+static const char * TAG = "frequency_transition";
 
 static float current_frequency = 56.25;
 
 bool do_frequency_transition(float target_frequency, set_hash_frequency_fn set_frequency_fn, int asic_type) {
     if (set_frequency_fn == NULL) {
-        ESP_LOGE(FREQUENCY_TRANSITION_TAG, "Invalid function pointer provided");
+        ESP_LOGE(TAG, "Invalid function pointer provided");
         return false;
     }
 
@@ -51,6 +51,6 @@ bool do_frequency_transition(float target_frequency, set_hash_frequency_fn set_f
     set_frequency_fn(target);
     current_frequency = target;
     
-    ESP_LOGI(FREQUENCY_TRANSITION_TAG, "Successfully transitioned ASIC type %d to %.2f MHz", asic_type, target);
+    ESP_LOGI(TAG, "Successfully transitioned ASIC type %d to %.2f MHz", asic_type, target);
     return true;
 }

--- a/components/dns_server/dns_server.c
+++ b/components/dns_server/dns_server.c
@@ -26,7 +26,7 @@
 #define QD_TYPE_A (0x0001)
 #define ANS_TTL_SEC (300)
 
-static const char * TAG = "example_dns_redirect_server";
+static const char * TAG = "dns_server";
 
 // DNS Header Packet
 typedef struct __attribute__((__packed__))

--- a/main/adc.c
+++ b/main/adc.c
@@ -6,7 +6,7 @@
 #define ADC_ATTEN   ADC_ATTEN_DB_12
 #define ADC_CHANNEL ADC_CHANNEL_1
 
-static const char * TAG = "ADC";
+static const char * TAG = "adc";
 
 static adc_cali_handle_t adc1_cali_chan1_handle;
 static adc_oneshot_unit_handle_t adc1_handle;

--- a/main/http_server/axe-os/api/system/asic_settings.c
+++ b/main/http_server/axe-os/api/system/asic_settings.c
@@ -5,7 +5,7 @@
 #include "global_state.h"
 #include "asic.h"
 
-// static const char *TAG = "asic_api";
+// static const char *TAG = "asic_settings";
 static GlobalState *GLOBAL_STATE = NULL;
 
 // Function declarations from http_server.c

--- a/main/power/vcore.c
+++ b/main/power/vcore.c
@@ -13,6 +13,8 @@
 #define GPIO_ASIC_RESET  CONFIG_GPIO_ASIC_RESET
 #define GPIO_PLUG_SENSE  CONFIG_GPIO_PLUG_SENSE
 
+static const char *TAG = "vcore";
+
 static TPS546_CONFIG TPS546_CONFIG_GAMMATURBO = {
     /* vin voltage */
     .TPS546_INIT_VIN_ON = 11.0,
@@ -44,8 +46,6 @@ static TPS546_CONFIG TPS546_CONFIG_GAMMA = {
     .TPS546_INIT_IOUT_OC_WARN_LIMIT = 25.00, /* A */
     .TPS546_INIT_IOUT_OC_FAULT_LIMIT = 30.00 /* A */
 };
-
-static const char *TAG = "vcore.c";
 
 esp_err_t VCORE_init(GlobalState * GLOBAL_STATE) {
     if (GLOBAL_STATE->DEVICE_CONFIG.DS4432U) {

--- a/main/system.c
+++ b/main/system.c
@@ -30,7 +30,7 @@
 #include "vcore.h"
 #include "thermal.h"
 
-static const char * TAG = "SystemModule";
+static const char * TAG = "system";
 
 static void _suffix_string(uint64_t, char *, size_t, int);
 

--- a/main/tasks/asic_task.c
+++ b/main/tasks/asic_task.c
@@ -9,7 +9,7 @@
 
 #include "asic.h"
 
-static const char *TAG = "ASIC_task";
+static const char *TAG = "asic_task";
 
 // static bm_job ** active_jobs; is required to keep track of the active jobs since the
 


### PR DESCRIPTION
Renaming `example_dns_redirect_server` made me look at all others.