### PR TITLE
Init ASIC frequency in power_management_task

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -11,7 +11,6 @@
 #include "statistics_task.h"
 #include "system.h"
 #include "http_server.h"
-#include "nvs_config.h"
 #include "serial.h"
 #include "stratum_task.h"
 #include "i2c_bitaxe.h"
@@ -79,10 +78,6 @@ void app_main(void)
     wifi_init(&GLOBAL_STATE);
 
     SYSTEM_init_peripherals(&GLOBAL_STATE);
-
-    // This needs to be done before the power management task starts
-    GLOBAL_STATE.POWER_MANAGEMENT_MODULE.frequency_value = nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, CONFIG_ASIC_FREQUENCY);
-    ESP_LOGI(TAG, "NVS_CONFIG_ASIC_FREQ %f", (float)GLOBAL_STATE.POWER_MANAGEMENT_MODULE.frequency_value);
 
     xTaskCreate(POWER_MANAGEMENT_task, "power management", 8192, (void *) &GLOBAL_STATE, 10, NULL);
 

--- a/main/tasks/power_management_task.h
+++ b/main/tasks/power_management_task.h
@@ -9,7 +9,6 @@ typedef struct
     float chip_temp_avg;
     float vr_temp;
     float voltage;
-    float frequency_multiplier;
     float frequency_value;
     float power;
     float current;


### PR DESCRIPTION
This removes the last nvs read from `main.c`. Also removed unused `frequency_multiplier` field.