### PR TITLE
Uniform icon only buttons

### DIFF
--- a/main/http_server/axe-os/src/app/components/logs/logs.component.html
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.html
@@ -70,25 +70,25 @@
                     {{stopScroll ? 'Start' : 'Stop'}} Scrolling
                 </button>
 
-                <button pButton class="btn btn--icon ml-auto"
+                <p-button
+                    icon="pi pi-window-maximize"
+                    pp-button
                     (click)="isExpanded = !isExpanded"
+                    class="ml-auto"
                     pTooltip="Maximize Logs"
                     tooltipPosition="left"
-                    *ngIf="showLogs"
-                >
-                    <i class="pi pi-window-maximize"></i>
-                </button>
+                    *ngIf="showLogs"></p-button>
             </div>
 
             <div *ngIf="showLogs" id="logs" #scrollContainer [ngClass]="{'is-expanded': isExpanded, 'mt-4': !isExpanded}">
                 <div *ngFor="let log of logs" [ngClass]="log.className">₿ {{log.text | ANSI}}</div>
-                <button pButton class="btn btn--icon absolute top-0 right-0"
+                <p-button
+                    icon="pi pi-window-minimize"
+                    pp-button
                     (click)="isExpanded = !isExpanded"
+                    class="absolute top-0 right-0"
                     pTooltip="Minimize Logs"
-                    tooltipPosition="left"
-                >
-                    <i class="pi pi-window-minimize"></i>
-                </button>
+                    tooltipPosition="left"></p-button>
             </div>
         </div>
     </div>

--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.html
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.html
@@ -11,7 +11,13 @@
             <label htmlFor="ssid" class="col-12 mb-2 md:col-2 md:mb-0">Wi-Fi SSID:</label>
             <div class="col-12 md:col-10 p-inputgroup">
                 <input pInputText id="ssid" type="text" formControlName="ssid" />
-                <button pButton type="button" icon="pi pi-search" (click)="scanWifi()" [loading]="scanning"></button>
+                <p-button
+                    icon="pi pi-search"
+                    pp-button
+                    (click)="scanWifi()"
+                    [loading]="scanning"
+                    pTooltip="Scan Wi-Fi"
+                    tooltipPosition="left"></p-button>
             </div>
         </div>
         <div class="field grid p-fluid">

--- a/main/http_server/axe-os/src/styles.scss
+++ b/main/http_server/axe-os/src/styles.scss
@@ -163,11 +163,3 @@ button.color-dot {
         }
     }
 }
-
-.btn--icon {
-    padding: 0.5rem;
-
-    i {
-        font-size: 1.4rem;
-    }
-}


### PR DESCRIPTION
This PR uses the component `<p-button>` for icon only buttons. It's the same component used for the [action buttons](https://github.com/bitaxeorg/ESP-Miner/blob/master/main/http_server/axe-os/src/app/components/swarm/swarm.component.html#L137-L139) on the Swarm page. This approach ensures uniformity among all buttons with icons only.

Affected buttons:
* Logs
   - Maximize Logs
   - Minimize Logs
   - Stop/Start Scrolling
* Network
   - Scan Wi-Fi