### PR TITLE
Added share accepted LED functionality to accessory port GPIO39

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,6 @@
 idf_component_register(
 SRCS
+    "accepted_led.c"
     "adc.c"
     "i2c_bitaxe.c"
     "main.c"

--- a/main/accepted_led.c
+++ b/main/accepted_led.c
@@ -1,0 +1,106 @@
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Source file : accepted_led.c
+// Header file : accepted_led.h
+//
+// Description : For Open Source Bitaxe ESP-Miner project.
+//               implements one-shot timer to flash LED on GPIO upon share acceptance
+//
+// Requirements : An LED and suitable series resistor should be connected to the allocated GPIO port of the ESP32-S3 MCU
+//				  so that the anode of the LED is attached to the ESP32-S3 GPIO and the resistor ties the cathode of the LED to GND.
+//                It is intended to use the accesory port on the Bitaxe board to connect an LED to.
+//                The default GPIO port for the LED is GPIO39.
+//
+// accepted_led_init(); should be called in system.c at "SYSTEM_init_peripherals" to initialise the GPIO and Timer
+// accepted_led_trigger(); should be called in stratum_task.c when an approprate stratum share accepted message is received
+//
+// TODO: add error checking
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include "esp_log.h"
+
+#include "esp_timer.h"
+#include "sdkconfig.h"
+#include "driver/gpio.h"
+
+//#define accepted_led_duration uint64_t 200000 //200mS 200000uS
+
+#define GPIO_ACCEPTED_LED CONFIG_GPIO_ACCEPTED_LED
+
+#ifndef CONFIG_GPIO_ACCEPTED_LED
+#define GPIO_ACCEPTED_LED 39
+#endif
+
+static const char * TAG = "Accepted_LED";
+
+
+static esp_timer_handle_t accepted_led_oneshot_timer;
+
+
+static void accepted_led_oneshot_timer_cb(void* arg){
+    //once the timer has expired the call-back function is called to turn off the LED
+    gpio_set_level(GPIO_ACCEPTED_LED, 0); //ensure LED is off
+}
+
+esp_err_t accepted_led_init (void){
+
+	//init GPIO port
+	gpio_config_t accepted_led_conf = {
+	 .intr_type = GPIO_INTR_DISABLE,
+	 .mode = GPIO_MODE_OUTPUT,
+	 .pin_bit_mask = (1ULL << GPIO_ACCEPTED_LED),
+	 .pull_down_en = 0,
+	 .pull_up_en = 0,
+	};
+
+	gpio_config(&accepted_led_conf);
+
+	gpio_set_level(GPIO_ACCEPTED_LED, 0); //ensure LED is off at init.
+
+
+	//init OneShot timer
+
+	const esp_timer_create_args_t accepted_led_oneshot_timer_args = {
+	 .callback = &accepted_led_oneshot_timer_cb,
+	 /* argument specified here will be passed to timer callback function */
+	 .arg = (void*) accepted_led_oneshot_timer,
+	 .name = "accepted-led-one-shot"
+	};
+
+	//create the timer but do not start it until it is first called from a valid share being accepted
+	ESP_ERROR_CHECK(esp_timer_create(&accepted_led_oneshot_timer_args, &accepted_led_oneshot_timer));
+	ESP_LOGI(TAG, "Accepted LED timer initialised");
+	return ESP_OK;
+
+}
+
+
+esp_err_t accepted_led_trigger(void){
+
+	gpio_set_level(GPIO_ACCEPTED_LED, 1); //turn on the LED
+
+	if (esp_timer_is_active(accepted_led_oneshot_timer)){
+	//if the timer is already running then restart it
+	esp_timer_restart(accepted_led_oneshot_timer, 200000);
+
+	}
+	else
+	{
+	//otherwise start it for the first time
+	esp_timer_start_once(accepted_led_oneshot_timer, 200000);
+	}
+
+	return ESP_OK;
+
+}
+
+
+
+
+
+
+
+

--- a/main/accepted_led.c
+++ b/main/accepted_led.c
@@ -26,12 +26,12 @@
 #include "sdkconfig.h"
 #include "driver/gpio.h"
 
-//#define accepted_led_duration uint64_t 200000 //200mS 200000uS
-
-#define GPIO_ACCEPTED_LED CONFIG_GPIO_ACCEPTED_LED
+#define accepted_led_duration 200000ULL //200mS 200000uS
 
 #ifndef CONFIG_GPIO_ACCEPTED_LED
 #define GPIO_ACCEPTED_LED 39
+#else
+#define GPIO_ACCEPTED_LED CONFIG_GPIO_ACCEPTED_LED
 #endif
 
 static const char * TAG = "Accepted_LED";
@@ -84,13 +84,13 @@ esp_err_t accepted_led_trigger(void){
 
 	if (esp_timer_is_active(accepted_led_oneshot_timer)){
 	//if the timer is already running then restart it
-	esp_timer_restart(accepted_led_oneshot_timer, 200000);
+	esp_timer_restart(accepted_led_oneshot_timer, accepted_led_duration);
 
 	}
 	else
 	{
 	//otherwise start it for the first time
-	esp_timer_start_once(accepted_led_oneshot_timer, 200000);
+	esp_timer_start_once(accepted_led_oneshot_timer, accepted_led_duration);
 	}
 
 	return ESP_OK;

--- a/main/accepted_led.h
+++ b/main/accepted_led.h
@@ -1,0 +1,7 @@
+#ifndef ACCEPTED_LED_H_
+#define ACCEPTED_LED_H_
+
+esp_err_t accepted_led_init (void);
+esp_err_t accepted_led_trigger(void);
+
+#endif /* ACCEPTED_LED_H_ */

--- a/main/system.c
+++ b/main/system.c
@@ -29,6 +29,7 @@
 #include "screen.h"
 #include "vcore.h"
 #include "thermal.h"
+#include "accepted_led.h"
 
 static const char * TAG = "SystemModule";
 
@@ -108,6 +109,8 @@ esp_err_t SYSTEM_init_peripherals(GlobalState * GLOBAL_STATE) {
     ESP_RETURN_ON_ERROR(input_init(screen_next, toggle_wifi_softap), TAG, "Input init failed!");
 
     ESP_RETURN_ON_ERROR(screen_start(GLOBAL_STATE), TAG, "Screen start failed!");
+
+    ESP_RETURN_ON_ERROR(accepted_led_init(), TAG, "Accepted LED start failed");
 
     return ESP_OK;
 }

--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -10,6 +10,7 @@
 #include "esp_wifi.h"
 #include <esp_sntp.h>
 #include <time.h>
+#include "accepted_led.h"
 
 #define PORT CONFIG_STRATUM_PORT
 #define STRATUM_URL CONFIG_STRATUM_URL
@@ -348,6 +349,7 @@ void stratum_task(void * pvParameters)
             } else if (stratum_api_v1_message.method == STRATUM_RESULT) {
                 if (stratum_api_v1_message.response_success) {
                     ESP_LOGI(TAG, "message result accepted");
+                    accepted_led_trigger();
                     SYSTEM_notify_accepted_share(GLOBAL_STATE);
                 } else {
                     ESP_LOGW(TAG, "message result rejected: %s", stratum_api_v1_message.error_str);


### PR DESCRIPTION
Added functionality for an LED to be connected to the accessory port of a Bitaxe board using GPIO39 as the driver.

The purpose being to show activity when the board is headless or the display is turned off.

The code implements an ESP one-shot timer.

When a stratum share accepted message is received, the **accepted_led_trigger();** function is called setting GPIO39 high and starting the one-shot timer which when expired turns off the LED, thus flashing the LED to show share accepted activity.

An LED and suitable size resistor are required to be connected to the accessory port of a board with the anode of the LED attached to GPIO39 and the cathode connected via a resistor ~1K to GND


https://github.com/user-attachments/assets/2f4cd4f2-f65b-4c7f-bde3-f167a7f5597b



