### PR TITLE
Improve Logs Fullscreen

### DIFF
--- a/main/http_server/axe-os/src/app/components/logs/logs.component.html
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.html
@@ -82,13 +82,24 @@
 
             <div *ngIf="showLogs" id="logs" #scrollContainer [ngClass]="{'is-expanded': isExpanded, 'mt-4': !isExpanded}">
                 <div *ngFor="let log of logs" [ngClass]="log.className">₿ {{log.text | ANSI}}</div>
-                <button pButton class="btn btn--icon absolute top-0 right-0"
-                    (click)="isExpanded = !isExpanded"
-                    pTooltip="Minimize Logs"
-                    tooltipPosition="left"
-                >
-                    <i class="pi pi-window-minimize"></i>
-                </button>
+
+                <div class="fixed top-0 right-0 flex gap-2 p-2">
+                    <button pButton class="btn btn--icon"
+                        (click)="stopScroll = !stopScroll"
+                        pTooltip="{{stopScroll ? 'Start' : 'Stop'}} Scrolling"
+                        tooltipPosition="left"
+                    >
+                        <i class="pi pi-{{stopScroll ? 'play' : 'pause'}}-circle"></i>
+                    </button>
+
+                    <button pButton class="btn btn--icon"
+                        (click)="isExpanded = false"
+                        pTooltip="Minimize Logs"
+                        tooltipPosition="left"
+                    >
+                        <i class="pi pi-window-minimize"></i>
+                    </button>
+                </div>
             </div>
         </div>
     </div>

--- a/main/http_server/axe-os/src/app/components/logs/logs.component.html
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.html
@@ -83,7 +83,7 @@
             <div *ngIf="showLogs" id="logs" #scrollContainer [ngClass]="{'is-expanded': isExpanded, 'mt-4': !isExpanded}">
                 <div *ngFor="let log of logs" [ngClass]="log.className">₿ {{log.text | ANSI}}</div>
 
-                <div class="fixed top-0 right-0 flex gap-2 p-2">
+                <div class="fixed top-0 right-0 flex gap-2 p-2 md:mr-4">
                     <button pButton class="btn btn--icon"
                         (click)="stopScroll = !stopScroll"
                         pTooltip="{{stopScroll ? 'Start' : 'Stop'}} Scrolling"

--- a/main/http_server/axe-os/src/app/components/logs/logs.component.scss
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.scss
@@ -22,6 +22,10 @@
     }
 }
 
+.btn--icon:focus {
+    box-shadow: none;
+}
+
 .ansi-red { color: #ff0000; }
 .ansi-green { color: #00ff00; }
 .ansi-yellow { color: #ffff00; }

--- a/main/http_server/axe-os/src/app/components/logs/logs.component.ts
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
+import { AfterViewChecked, Component, ElementRef, OnDestroy, ViewChild, HostListener } from '@angular/core';
 import { interval, map, Observable, shareReplay, startWith, Subscription, switchMap } from 'rxjs';
 import { SystemService } from 'src/app/services/system.service';
 import { WebsocketService } from 'src/app/services/web-socket.service';
@@ -23,6 +23,13 @@ export class LogsComponent implements OnDestroy, AfterViewChecked {
   public stopScroll: boolean = false;
 
   public isExpanded: boolean = false;
+
+  @HostListener('document:keydown.esc', ['$event'])
+  onEscKey(event: KeyboardEvent) {
+    if (this.isExpanded) {
+      this.isExpanded = false;
+    }
+  }
 
   constructor(
     private websocketService: WebsocketService,


### PR DESCRIPTION
According to [user feedback](https://github.com/bitaxeorg/ESP-Miner/issues/993) this PR improves the expanded logs view:

* Fix the unreachable minimize button
* Add listener for the ESC key to minimize the logs
* Add `Stop/Start Scrolling` button

<img width="892" alt="Screenshot 2025-06-02 at 20 00 33" src="https://github.com/user-attachments/assets/98eb5e37-a4cd-4a7e-8331-315c2fb7ef36" />
