### PR TITLE
Remove duplicate fonts on production build

### DIFF
--- a/main/http_server/axe-os/src/styles.scss
+++ b/main/http_server/axe-os/src/styles.scss
@@ -1,19 +1,19 @@
 @font-face {
     font-family: 'Angel Wish';
-    src: url(./assets/fonts/AngelWish.woff2) format('woff2'),
-         url(./assets/fonts/AngelWish.woff) format('woff'),
-         url(./assets/fonts/AngelWish.ttf) format('truetype');
+    src: url(/assets/fonts/AngelWish.woff2) format('woff2'),
+         url(/assets/fonts/AngelWish.woff) format('woff'),
+         url(/assets/fonts/AngelWish.ttf) format('truetype');
 }
 
 @font-face {
     font-family: 'Nippo-Regular';
-    src: url(./assets/fonts/Nippo-Regular.woff2) format('woff2'),
-         url(./assets/fonts/Nippo-Regular.woff) format('woff'),
-         url(./assets/fonts/Nippo-Regular.ttf) format('truetype');
+    src: url(/assets/fonts/Nippo-Regular.woff2) format('woff2'),
+         url(/assets/fonts/Nippo-Regular.woff) format('woff'),
+         url(/assets/fonts/Nippo-Regular.ttf) format('truetype');
     font-weight: 400;
     font-display: swap;
     font-style: normal;
-  }
+}
 
 * {
     font-family: 'Nippo-Regular';


### PR DESCRIPTION
Both fonts `AngelWish` and `Nippo-Regular` are stored twice during production build: Once in the `root` folder and once in the `assets` folder. This is a [known issue](https://stackoverflow.com/questions/44405403/angular-cli-production-build-placing-duplicates-of-all-my-fonts-in-the-root-of-m).

This fix stores fonts only once. There are no duplicates. This saves 265 kB.

**Before**
<img width="661" alt="Screenshot 2025-06-06 at 11 49 28" src="https://github.com/user-attachments/assets/c1edd595-e53d-4003-b3c1-044f5cf0ffc8" />

**After**
<img width="660" alt="Screenshot 2025-06-06 at 11 51 16" src="https://github.com/user-attachments/assets/b5b3415d-bb37-46e3-8222-781f1d4d45e5" />
