### PR TITLE
Introduction Modal Component

### DIFF
--- a/main/http_server/axe-os/src/app/app.module.ts
+++ b/main/http_server/axe-os/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { PoolComponent } from './components/pool/pool.component';
 import { NetworkEditComponent } from './components/network-edit/network.edit.component';
 import { HomeComponent } from './components/home/home.component';
 import { LoadingComponent } from './components/loading/loading.component';
+import { ModalComponent } from './components/modal/modal.component';
 import { LogsComponent } from './components/logs/logs.component';
 import { NetworkComponent } from './components/network/network.component';
 import { SettingsComponent } from './components/settings/settings.component';
@@ -38,6 +39,7 @@ const components = [
   NetworkEditComponent,
   HomeComponent,
   LoadingComponent,
+  ModalComponent,
   NetworkComponent,
   SettingsComponent,
   LogsComponent,

--- a/main/http_server/axe-os/src/app/components/modal/modal.component.html
+++ b/main/http_server/axe-os/src/app/components/modal/modal.component.html
@@ -1,0 +1,13 @@
+<ng-container *ngIf="isVisible">
+    <div class="modal-backdrop" (click)="isVisible = false"></div>
+    <div class="modal card">
+        <header class="flex justify-content-between align-items-center p-3 pb-5">
+            <h1 class="m-0">{{headline}}</h1>
+            <p-button icon="pi pi-times" pp-button class="close" (click)="isVisible = false"></p-button>
+        </header>
+
+        <main class="overflow-y-auto flex-1 p-0 px-3">
+            <ng-content></ng-content>
+        </main>
+    </div>
+</ng-container>

--- a/main/http_server/axe-os/src/app/components/modal/modal.component.scss
+++ b/main/http_server/axe-os/src/app/components/modal/modal.component.scss
@@ -1,0 +1,30 @@
+.modal {
+    position: fixed;
+    max-height: 80dvh;
+    width: 90dvw;
+    z-index: 999;
+    top: 50%;
+    left: 50%;
+    transform: translate3d(-50%, -50%, 0);
+    padding: 1rem 1rem 2rem;
+    display: flex;
+    flex-direction: column;
+
+    @media (min-width: 768px) {
+        width: 70dvw;
+    }
+
+    @media (min-width: 1024px) {
+        width: 50dvw;
+    }
+
+    &-backdrop {
+        background-color: rgba(0, 0, 0, 0.5);
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        position: fixed;
+        z-index: 9;
+    }
+}

--- a/main/http_server/axe-os/src/app/components/modal/modal.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/modal/modal.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ModalComponent } from './modal.component';
+
+describe('ModalComponent', () => {
+  let component: ModalComponent;
+  let fixture: ComponentFixture<ModalComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ModalComponent]
+    });
+    fixture = TestBed.createComponent(ModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/main/http_server/axe-os/src/app/components/modal/modal.component.ts
+++ b/main/http_server/axe-os/src/app/components/modal/modal.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-modal',
+  templateUrl: './modal.component.html',
+  styleUrls: ['./modal.component.scss'],
+})
+export class ModalComponent {
+  public isVisible = false;
+
+  @Input() headline: string = '';
+
+  constructor() {}
+}

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -179,9 +179,6 @@
 
 </div>
 
-<div class="modal-backdrop" *ngIf="showEdit" (click)="showEdit = false"></div>
-<div class="modal card" *ngIf="showEdit">
-    <div class="close" (click)="showEdit = false">&#10006;</div>
-    <h1>{{selectedAxeOs.IP}}</h1>
-    <app-edit [uri]="'http://' + selectedAxeOs.IP"></app-edit>
-</div>
+<app-modal [headline]="selectedAxeOs?.IP">
+    <app-edit *ngIf="selectedAxeOs" [uri]="'http://' + selectedAxeOs.IP"></app-edit>
+</app-modal>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.scss
@@ -44,47 +44,6 @@ a {
     color: white;
 }
 
-.modal-backdrop {
-    background-color: rgba(0, 0, 0, 0.5);
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    position: fixed;
-    z-index: 9;
-}
-
-.modal {
-    position: fixed;
-    max-height: 80dvh;
-    width: 90dvw;
-    z-index: 999;
-    top: 10vh;
-    left: 50%;
-    transform: translateX(-50%);
-    padding: 2rem;
-    overflow-y: auto;
-}
-
-@media (min-width: 768px) {
-  .modal {
-    width: 70dvw;
-  }
-}
-
-@media (min-width: 1024px) {
-  .modal {
-    width: 50dvw;
-  }
-}
-
-.close {
-    position: absolute;
-    right: 20px;
-    top: 20px;
-    cursor: pointer;
-}
-
 .table-container {
     width: 100%;
     overflow-x: auto;

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -1,10 +1,12 @@
 import { HttpClient } from '@angular/common/http';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
 import { catchError, from, map, mergeMap, of, take, timeout, toArray } from 'rxjs';
 import { LocalStorageService } from 'src/app/local-storage.service';
 import { SystemService } from 'src/app/services/system.service';
+import { ModalComponent } from '../modal/modal.component';
+
 const SWARM_DATA = 'SWARM_DATA'
 const SWARM_REFRESH_TIME = 'SWARM_REFRESH_TIME';
 const SWARM_SORTING = 'SWARM_SORTING'
@@ -16,10 +18,11 @@ const SWARM_SORTING = 'SWARM_SORTING'
 })
 export class SwarmComponent implements OnInit, OnDestroy {
 
+  @ViewChild(ModalComponent) modalComponent!: ModalComponent;
+
   public swarm: any[] = [];
 
   public selectedAxeOs: any = null;
-  public showEdit = false;
 
   public form: FormGroup;
 
@@ -175,7 +178,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
   public edit(axe: any) {
     this.selectedAxeOs = axe;
-    this.showEdit = true;
+    this.modalComponent.isVisible = true;
   }
 
   public restart(axe: any) {


### PR DESCRIPTION
This PR introduces the Modal component. Currently, a modal is used on the swarm page only. With this change the modal can be used on different places. For example for [release notes](https://github.com/bitaxeorg/ESP-Miner/pull/1005).

Additionally, the modal has been visually improved to fit with the current app design. Headline & Close button are sticky now.

<img width="1225" alt="Screenshot 2025-06-06 at 21 05 44" src="https://github.com/user-attachments/assets/eeb76541-a0a9-444d-b31d-530de2a8bbfd" />

