### PR TITLE
LVGL upstream bug

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  lvgl/lvgl: "^9"
+  lvgl/lvgl: "9.2.2"
   espressif/esp_lvgl_port: "^2.6.0"
   esp_lcd_sh1107: "^1"  
   ## Required IDF version


### PR DESCRIPTION
this assignes the lvgl/lvgl to 9.2.2 so the build doesnt fail. 9.3.0 has been released causing some trouble