### PR TITLE
Remove Knob Module

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -166,19 +166,12 @@
                     </div>
 
                     <div class="col-12">
-                        <!-- <p-knob [min]="100" [max]="maxFrequency" [readonly]="true" [(ngModel)]="info.frequency"
-                            valueTemplate="{value}"></p-knob>
-                        ASIC Frequency (MHz) -->
-
                         <h6>ASIC Frequency <span style="float: right;">{{info.frequency}} MHz</span></h6>
                         <p-progressBar [value]="(info.frequency / maxFrequency) * 100" [style]="{ height: '6px' }" >
                             <ng-template pTemplate="content" let-value></ng-template>
                         </p-progressBar>
                     </div>
                     <div class="col-12">
-                        <!-- <p-knob [min]="0.9" [max]="1.8" [readonly]="true" [(ngModel)]="info.coreVoltageActual"
-                            valueTemplate="{value}V"></p-knob>
-                        ASIC Voltage Measured -->
                         <h6>Measured ASIC Voltage <span style="float: right;">{{info.coreVoltageActual}} V</span></h6>
                         <p-progressBar [value]="(info.coreVoltageActual / 1.8) * 100" [style]="{ height: '6px' }" >
                             <ng-template pTemplate="content" let-value></ng-template>

--- a/main/http_server/axe-os/src/app/prime-ng.module.ts
+++ b/main/http_server/axe-os/src/app/prime-ng.module.ts
@@ -8,7 +8,6 @@ import { FileUploadModule } from 'primeng/fileupload';
 import { InputGroupModule } from 'primeng/inputgroup';
 import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
 import { InputTextModule } from 'primeng/inputtext';
-import { KnobModule } from 'primeng/knob';
 import { SidebarModule } from 'primeng/sidebar';
 import { SliderModule } from 'primeng/slider';
 
@@ -20,7 +19,6 @@ const primeNgModules = [
     SliderModule,
     ButtonModule,
     FileUploadModule,
-    KnobModule,
     ChartModule,
     InputGroupModule,
     InputGroupAddonModule,


### PR DESCRIPTION
Removes the remains of the old [Knob module](https://primeng.org/knob) that is no longer needed.