### PR TITLE
Refresh Logs Page

### DIFF
--- a/main/http_server/axe-os/src/app/components/logs/logs.component.html
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.html
@@ -7,19 +7,21 @@
             </h2>
 
             <nav class="flex gap-3 w-full md:w-6">
-                <input
-                    pInputText
-                    type="text"
-                    class="w-full"
-                    autocomplete="off"
-                    placeholder="Case-sensitive filter"
-                    id="filter"
-                    formControlName="filter"/>
+                <span class="w-full p-input-icon-left">
+                    <i class="pi pi-filter"></i>
+                    <input
+                        pInputText
+                        type="text"
+                        class="w-full"
+                        autocomplete="off"
+                        placeholder="Case-sensitive filter"
+                        id="filter"
+                        formControlName="filter"/>
+                </span>
                 <p-button
                     pp-button
                     icon="pi pi-{{stopScroll ? 'play' : 'pause'}}"
                     (click)="stopScroll = !stopScroll"
-                    class="md:ml-3"
                     pTooltip="{{stopScroll ? 'Start' : 'Stop'}} Scrolling"
                     tooltipPosition="left">
                 </p-button>
@@ -34,7 +36,6 @@
                     pp-button
                     icon="pi pi-window-{{isExpanded ? 'minimize' : 'maximize'}}"
                     (click)="isExpanded = !isExpanded"
-                    class="md:ml-3"
                     pTooltip="{{isExpanded ? 'Minimize' : 'Maximize'}} Logs"
                     tooltipPosition="left">
                 </p-button>

--- a/main/http_server/axe-os/src/app/components/logs/logs.component.html
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.html
@@ -1,63 +1,48 @@
-<div class="grid">
-    <div class="col-12">
-        <div class="card">
-            <ng-container *ngIf="form != null">
-                <form [formGroup]="form">
-                    <div class="flex flex-wrap gap-3 align-items-center">
-                        <h2 class="mb-0" [ngClass]="{'w-full sm:w-auto': showLogs}">
-                            Realtime Logs
-                        </h2>
 
-                        <button pButton (click)="toggleLogs()" class="btn btn-secondary" [ngClass]="{'ml-auto sm:ml-0': !showLogs}">
-                            {{showLogs ? 'Hide': 'Show'}} Logs
-                        </button>
+<div *ngIf="form != null" class="card" [ngClass]="{'is-expanded': isExpanded}">
+    <form [formGroup]="form">
+        <div class="flex justify-content-between flex-column md:align-items-center md:flex-row mb-3">
+            <h2 class="mb-0 h-3rem">
+                Realtime Logs
+            </h2>
 
-                        <button pButton class="btn btn-secondary" (click)="stopScroll = !stopScroll" *ngIf="showLogs">
-                            {{stopScroll ? 'Start' : 'Stop'}} Scrolling
-                        </button>
-
-                        <button pButton class="btn btn-secondary" (click)="clearLogs()" *ngIf="showLogs">
-                            Clear Logs
-                        </button>
-
-                        <input pInputText type="text" autocomplete="off" class="ml-auto" *ngIf="showLogs"
-                            placeholder="Case-sensitive filter" id="filter" formControlName="filter"
-                        />
-
-                        <p-button
-                            icon="pi pi-window-maximize"
-                            pp-button
-                            (click)="isExpanded = !isExpanded"
-                            class="ml-auto"
-                            pTooltip="Maximize Logs"
-                            tooltipPosition="left"
-                            *ngIf="showLogs">
-                        </p-button>
-                    </div>
-
-                    <div *ngIf="showLogs" id="logs" #scrollContainer [ngClass]="{'is-expanded': isExpanded, 'mt-4': !isExpanded}">
-                        <div *ngFor="let log of logs" [ngClass]="log.className">₿ {{log.text | ANSI}}</div>
-
-                        <div class="fixed top-0 right-0 flex gap-2 p-2 md:mr-4">
-                            <p-button
-                                icon="pi pi-{{stopScroll ? 'play' : 'pause'}}-circle"
-                                pp-button
-                                (click)="stopScroll = !stopScroll"
-                                pTooltip="{{stopScroll ? 'Start' : 'Stop'}} Scrolling"
-                                tooltipPosition="left">
-                            </p-button>
-
-                            <p-button
-                                icon="pi pi-window-minimize"
-                                pp-button
-                                (click)="isExpanded = false"
-                                pTooltip="Minimize Logs"
-                                tooltipPosition="left">
-                            </p-button>
-                        </div>
-                    </div>
-                </form>
-            </ng-container>
+            <nav class="flex gap-3 w-full md:w-6">
+                <input
+                    pInputText
+                    type="text"
+                    class="w-full"
+                    autocomplete="off"
+                    placeholder="Case-sensitive filter"
+                    id="filter"
+                    formControlName="filter"/>
+                <p-button
+                    pp-button
+                    icon="pi pi-{{stopScroll ? 'play' : 'pause'}}"
+                    (click)="stopScroll = !stopScroll"
+                    class="md:ml-3"
+                    pTooltip="{{stopScroll ? 'Start' : 'Stop'}} Scrolling"
+                    tooltipPosition="left">
+                </p-button>
+                <p-button
+                    pp-button
+                    icon="pi pi-trash"
+                    (click)="clearLogs()"
+                    pTooltip="Clear Logs"
+                    tooltipPosition="left">
+                </p-button>
+                <p-button
+                    pp-button
+                    icon="pi pi-window-{{isExpanded ? 'minimize' : 'maximize'}}"
+                    (click)="isExpanded = !isExpanded"
+                    class="md:ml-3"
+                    pTooltip="{{isExpanded ? 'Minimize' : 'Maximize'}} Logs"
+                    tooltipPosition="left">
+                </p-button>
+            </nav>
         </div>
-    </div>
+
+        <div id="logs" #scrollContainer>
+            <div *ngFor="let log of logs" [ngClass]="log.className">₿ {{log.text | ANSI}}</div>
+        </div>
+    </form>
 </div>

--- a/main/http_server/axe-os/src/app/components/logs/logs.component.scss
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.scss
@@ -1,29 +1,37 @@
 #logs {
-    height: 500px;
+    height: calc(100svh - 4rem - 10rem - 4rem - 4px); // padding + height + border
     font-family: monospace;
     border: 1px solid #304562;
     overflow-y: scroll;
     overflow-x: hidden;
 
-    >div {
+    @media (min-width: 768px) {
+        height: calc(100vh - 4rem - 9rem - 4rem - 4px); // padding + height + border
+    }
+
+    > div {
         max-width: 100%;
         line-break: anywhere;
         font-family: 'Courier New', Courier, monospace;
     }
-
-    &.is-expanded {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100vw;
-        height: 100vh;
-        z-index: 999;
-        background: var(--surface-overlay);
-    }
 }
 
-.p-button-icon-only:focus {
-    box-shadow: none;
+.is-expanded {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 999;
+    background: var(--surface-overlay);
+
+    #logs {
+        height: calc(100svh - 4rem - 2rem - 4rem - 4px); // padding + height + border
+
+        @media (min-width: 768px) {
+            height: calc(100vh - 4rem - 4rem - 4px); // padding + height + border
+        }
+    }
 }
 
 .ansi-red { color: #ff0000; }

--- a/main/http_server/axe-os/src/app/components/logs/logs.component.ts
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.ts
@@ -1,9 +1,7 @@
 import { AfterViewChecked, Component, Input, OnInit, ElementRef, OnDestroy, ViewChild, HostListener } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { Observable, Subscription } from 'rxjs';
-import { SystemService } from 'src/app/services/system.service';
+import { Subscription } from 'rxjs';
 import { WebsocketService } from 'src/app/services/web-socket.service';
-import { ISystemInfo } from 'src/models/ISystemInfo';
 
 @Component({
   selector: 'app-logs',
@@ -25,17 +23,17 @@ export class LogsComponent implements OnInit, OnDestroy, AfterViewChecked {
   @ViewChild('scrollContainer') private scrollContainer!: ElementRef;
 
   @HostListener('document:keydown.esc', ['$event'])
-  onEscKey(event: KeyboardEvent) {
+  onEscKey() {
     if (this.isExpanded) {
       this.isExpanded = false;
     }
   }
+
   @Input() uri = '';
 
   constructor(
     private fb: FormBuilder,
     private websocketService: WebsocketService,
-    private systemService: SystemService
   ) {}
 
   ngOnInit(): void {

--- a/main/http_server/axe-os/src/app/components/logs/logs.component.ts
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.ts
@@ -46,6 +46,7 @@ export class LogsComponent implements OnInit, OnDestroy, AfterViewChecked {
 
   ngOnDestroy(): void {
     this.websocketSubscription?.unsubscribe();
+    this.clearLogs();
   }
 
   private subscribeLogs() {

--- a/main/http_server/axe-os/src/app/layout/styles/theme/themes/vela/_variables.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/theme/themes/vela/_variables.scss
@@ -126,7 +126,7 @@ $passwordStrongBg: #c5e1a5 !default;
 
 //button
 $buttonPadding: 0.5rem 1rem !default;
-$buttonIconOnlyWidth: 2.357rem !default;
+$buttonIconOnlyWidth: 2.5rem !default;
 $buttonIconOnlyPadding: 0.5rem 0 !default;
 $buttonBg: $primaryColor !default;
 $buttonTextColor: $primaryTextColor !default;

--- a/main/http_server/axe-os/src/app/layout/styles/theme/themes/vela/bitaxe/_variables.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/theme/themes/vela/bitaxe/_variables.scss
@@ -8,4 +8,6 @@ $highlightBg: rgba(100, 181, 246, .16) !default;
 $highlightTextColor: rgba(255,255,255,.87) !default;
 $highlightFocusBg: rgba($primaryColor, .24) !default;
 
+$inputPadding: 0.5rem 0.75rem !default;
+
 @import '../_variables';

--- a/main/http_server/axe-os/src/styles.scss
+++ b/main/http_server/axe-os/src/styles.scss
@@ -69,10 +69,6 @@ p-chart>div {
         background: var(--button-hover-bg);
         border-color: var(--button-hover-bg);
     }
-
-    &:focus {
-        box-shadow: var(--button-focus-shadow);
-    }
 }
 
 .p-button.p-button-text.color-dot {


### PR DESCRIPTION
Over time, more and more buttons have been added to the Logs toolbar. Recently, a nice filter was added. It's time to update the layout of the Logs page so that everything fits and looks consistent, even on mobile devices.

* No toggle for hide/show logs. Logs are initialized immediately when the page is called up.
* The toolbar remains after maximizing the Logs window.

**Desktop View**

https://github.com/user-attachments/assets/e4dfc59a-d348-4515-9a59-6a028ce6efe6

**Mobile View**
<img width="429" alt="Screenshot 2025-06-19 at 10 00 42" src="https://github.com/user-attachments/assets/9ee8b6a0-0b42-4f90-b487-ac16be42797f" />

Closed https://github.com/bitaxeorg/ESP-Miner/issues/1015 https://github.com/bitaxeorg/ESP-Miner/issues/1047