### PR TITLE
Accept and store float frequency values

### DIFF
--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -118,7 +118,7 @@ void ASIC_set_version_mask(GlobalState * GLOBAL_STATE, uint32_t mask)
 
 bool ASIC_set_frequency(GlobalState * GLOBAL_STATE, float target_frequency)
 {
-    ESP_LOGI(TAG, "Setting ASIC frequency to %.2f MHz", target_frequency);
+    ESP_LOGI(TAG, "Setting ASIC frequency to %g MHz", target_frequency);
     bool success = false;
     
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.model) {
@@ -139,9 +139,9 @@ bool ASIC_set_frequency(GlobalState * GLOBAL_STATE, float target_frequency)
     }
     
     if (success) {
-        ESP_LOGI(TAG, "Successfully transitioned to new ASIC frequency: %.2f MHz", target_frequency);
+        ESP_LOGI(TAG, "Successfully transitioned to new ASIC frequency: %g MHz", target_frequency);
     } else {
-        ESP_LOGE(TAG, "Failed to transition to new ASIC frequency: %.2f MHz", target_frequency);
+        ESP_LOGE(TAG, "Failed to transition to new ASIC frequency: %g MHz", target_frequency);
     }
     
     return success;

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -193,20 +193,20 @@ void BM1366_send_hash_frequency(float target_freq)
 
     _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), freqbuf, 6, BM1366_SERIALTX_DEBUG);
 
-    ESP_LOGI(TAG, "Setting Frequency to %.2fMHz (%.2f)", target_freq, newf);
+    ESP_LOGI(TAG, "Setting Frequency to %g MHz (%g)", target_freq, newf);
 }
 
 static void do_frequency_ramp_up(float target_frequency) {
-    ESP_LOGI(TAG, "Ramping up frequency from %.2f MHz to %.2f MHz", current_frequency, target_frequency);
-    do_frequency_transition(target_frequency, BM1366_send_hash_frequency, 1366);
+    ESP_LOGI(TAG, "Ramping up frequency from %g MHz to %g MHz", current_frequency, target_frequency);
+    do_frequency_transition(target_frequency, BM1366_send_hash_frequency, ASIC_BM1366.name);
 }
 
 // Add a public function for external use
 bool BM1366_set_frequency(float target_freq) {
-    return do_frequency_transition(target_freq, BM1366_send_hash_frequency, 1366);
+    return do_frequency_transition(target_freq, BM1366_send_hash_frequency, ASIC_BM1366.name);
 }
 
-uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty)
+uint8_t BM1366_init(float frequency, uint16_t asic_count, uint16_t difficulty)
 {
     // set version mask
     for (int i = 0; i < 3; i++) {
@@ -274,7 +274,7 @@ uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty
         _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_third, 6, BM1366_SERIALTX_DEBUG);
     }
 
-    do_frequency_ramp_up((float)frequency);
+    do_frequency_ramp_up(frequency);
 
     //register 10 is still a bit of a mystery. discussion: https://github.com/bitaxeorg/ESP-Miner/pull/167
 

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -166,20 +166,20 @@ void BM1368_send_hash_frequency(float target_freq) {
 
     _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, freqbuf, sizeof(freqbuf), BM1368_SERIALTX_DEBUG);
 
-    ESP_LOGI(TAG, "Setting Frequency to %.2fMHz (%.2f)", target_freq, best_freq);
+    ESP_LOGI(TAG, "Setting Frequency to %g MHz (%g)", target_freq, best_freq);
     current_frequency = target_freq;
 }
 
 bool BM1368_set_frequency(float target_freq) {
-    return do_frequency_transition(target_freq, BM1368_send_hash_frequency, 1368);
+    return do_frequency_transition(target_freq, BM1368_send_hash_frequency, ASIC_BM1368.name);
 }
 
 static void do_frequency_ramp_up(float target_frequency) {
-    ESP_LOGI(TAG, "Ramping up frequency from %.2f MHz to %.2f MHz", current_frequency, target_frequency);
-    do_frequency_transition(target_frequency, BM1368_send_hash_frequency, 1368);
+    ESP_LOGI(TAG, "Ramping up frequency from %g MHz to %g MHz", current_frequency, target_frequency);
+    do_frequency_transition(target_frequency, BM1368_send_hash_frequency, ASIC_BM1368.name);
 }
 
-uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty)
+uint8_t BM1368_init(float frequency, uint16_t asic_count, uint16_t difficulty)
 {
     // set version mask
     for (int i = 0; i < 4; i++) {
@@ -232,7 +232,7 @@ uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty
 
     BM1368_set_job_difficulty_mask(difficulty);
 
-    do_frequency_ramp_up((float)frequency);
+    do_frequency_ramp_up(frequency);
 
     _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, (uint8_t[]){0x00, 0x10, 0x00, 0x00, 0x15, 0xa4}, 6, false);
     BM1368_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -193,7 +193,7 @@ void BM1370_send_hash_frequency(float target_freq) {
 
     _send_BM1370(TYPE_CMD | GROUP_ALL | CMD_WRITE, freqbuf, 6, BM1370_SERIALTX_DEBUG);
 
-    ESP_LOGI(TAG, "Setting Frequency to %.2fMHz (%.2f)", target_freq, newf);
+    ESP_LOGI(TAG, "Setting Frequency to %g MHz (%g)", target_freq, newf);
 }
 
 static void do_frequency_ramp_up(float target_frequency) {
@@ -202,16 +202,16 @@ static void do_frequency_ramp_up(float target_frequency) {
         return;
     }
     
-    ESP_LOGI(TAG, "Ramping up frequency from 56.25 MHz to %.2f MHz", target_frequency);
-    do_frequency_transition(target_frequency, BM1370_send_hash_frequency, 1370);
+    ESP_LOGI(TAG, "Ramping up frequency from 56.25 MHz to %g MHz", target_frequency);
+    do_frequency_transition(target_frequency, BM1370_send_hash_frequency, ASIC_BM1370.name);
 }
 
 // Add a public function for external use
 bool BM1370_set_frequency(float target_freq) {
-    return do_frequency_transition(target_freq, BM1370_send_hash_frequency, 1370);
+    return do_frequency_transition(target_freq, BM1370_send_hash_frequency, ASIC_BM1370.name);
 }
 
-uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty)
+uint8_t BM1370_init(float frequency, uint16_t asic_count, uint16_t difficulty)
 {
     // set version mask
     for (int i = 0; i < 3; i++) {

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -218,10 +218,10 @@ void BM1397_send_hash_frequency(float frequency)
 
     vTaskDelay(10 / portTICK_PERIOD_MS);
 
-    ESP_LOGI(TAG, "Setting Frequency to %.2fMHz (%.2f)", frequency, newf);
+    ESP_LOGI(TAG, "Setting Frequency to %g MHz (%g)", frequency, newf);
 }
 
-uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty)
+uint8_t BM1397_init(float frequency, uint16_t asic_count, uint16_t difficulty)
 {
     // send the init command
     _send_read_address();

--- a/components/asic/frequency_transition_bmXX.c
+++ b/components/asic/frequency_transition_bmXX.c
@@ -8,7 +8,7 @@ static const char * TAG = "frequency_transition";
 
 static float current_frequency = 56.25;
 
-bool do_frequency_transition(float target_frequency, set_hash_frequency_fn set_frequency_fn, int asic_type) {
+bool do_frequency_transition(float target_frequency, set_hash_frequency_fn set_frequency_fn, const char * asic_type) {
     if (set_frequency_fn == NULL) {
         ESP_LOGE(TAG, "Invalid function pointer provided");
         return false;
@@ -51,6 +51,6 @@ bool do_frequency_transition(float target_frequency, set_hash_frequency_fn set_f
     set_frequency_fn(target);
     current_frequency = target;
     
-    ESP_LOGI(TAG, "Successfully transitioned ASIC type %d to %.2f MHz", asic_type, target);
+    ESP_LOGI(TAG, "Successfully transitioned %s to %g MHz", asic_type, target);
     return true;
 }

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -21,7 +21,7 @@ typedef struct __attribute__((__packed__))
     uint8_t version[4];
 } BM1366_job;
 
-uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty);
+uint8_t BM1366_init(float frequency, uint16_t asic_count, uint16_t difficulty);
 void BM1366_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1366_set_job_difficulty_mask(int);
 void BM1366_set_version_mask(uint32_t version_mask);

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -21,7 +21,7 @@ typedef struct __attribute__((__packed__))
     uint8_t version[4];
 } BM1368_job;
 
-uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty);
+uint8_t BM1368_init(float frequency, uint16_t asic_count, uint16_t difficulty);
 void BM1368_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1368_set_job_difficulty_mask(int);
 void BM1368_set_version_mask(uint32_t version_mask);

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -21,7 +21,7 @@ typedef struct __attribute__((__packed__))
     uint8_t version[4];
 } BM1370_job;
 
-uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty);
+uint8_t BM1370_init(float frequency, uint16_t asic_count, uint16_t difficulty);
 void BM1370_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1370_set_job_difficulty_mask(int);
 void BM1370_set_version_mask(uint32_t version_mask);

--- a/components/asic/include/bm1397.h
+++ b/components/asic/include/bm1397.h
@@ -23,7 +23,7 @@ typedef struct __attribute__((__packed__))
     uint8_t midstate3[32];
 } job_packet;
 
-uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty);
+uint8_t BM1397_init(float frequency, uint16_t asic_count, uint16_t difficulty);
 void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1397_set_job_difficulty_mask(int);
 void BM1397_set_version_mask(uint32_t version_mask);

--- a/components/asic/include/frequency_transition_bmXX.h
+++ b/components/asic/include/frequency_transition_bmXX.h
@@ -26,6 +26,6 @@ typedef void (*set_hash_frequency_fn)(float frequency);
  * @param asic_type The type of ASIC chip (for logging purposes only)
  * @return bool True if the transition was successful, false otherwise
  */
-bool do_frequency_transition(float target_frequency, set_hash_frequency_fn set_frequency_fn, int asic_type);
+bool do_frequency_transition(float target_frequency, set_hash_frequency_fn set_frequency_fn, const char * asic_type);
 
 #endif // FREQUENCY_TRANSITION_H

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -487,8 +487,11 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     if ((item = cJSON_GetObjectItem(root, "coreVoltage")) != NULL && item->valueint > 0) {
         nvs_config_set_u16(NVS_CONFIG_ASIC_VOLTAGE, item->valueint);
     }
-    if ((item = cJSON_GetObjectItem(root, "frequency")) != NULL && item->valueint > 0) {
-        nvs_config_set_u16(NVS_CONFIG_ASIC_FREQ, item->valueint);
+    if ((item = cJSON_GetObjectItem(root, "frequency")) != NULL && item->valuedouble > 0) {
+        float frequency = item->valuedouble;
+        nvs_config_set_float(NVS_CONFIG_ASIC_FREQUENCY_FLOAT, frequency);
+        // also store as u16 for backwards compatibility
+        nvs_config_set_u16(NVS_CONFIG_ASIC_FREQUENCY, (int) frequency);
     }
     if ((item = cJSON_GetObjectItem(root, "overheat_mode")) != NULL) {
         nvs_config_set_u16(NVS_CONFIG_OVERHEAT_MODE, 0);
@@ -577,7 +580,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     char * stratumUser = nvs_config_get_string(NVS_CONFIG_STRATUM_USER, CONFIG_STRATUM_USER);
     char * fallbackStratumUser = nvs_config_get_string(NVS_CONFIG_FALLBACK_STRATUM_USER, CONFIG_FALLBACK_STRATUM_USER);
     char * display = nvs_config_get_string(NVS_CONFIG_DISPLAY, "SSD1306 (128x32)");
-    uint16_t frequency = nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, CONFIG_ASIC_FREQUENCY);
+    float frequency = nvs_config_get_float(NVS_CONFIG_ASIC_FREQUENCY_FLOAT, CONFIG_ASIC_FREQUENCY);
     float expected_hashrate = frequency * GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count * GLOBAL_STATE->DEVICE_CONFIG.family.asic_count / 1000.0;
 
     uint8_t mac[6];

--- a/main/nvs_config.c
+++ b/main/nvs_config.c
@@ -5,6 +5,8 @@
 
 #define NVS_CONFIG_NAMESPACE "main"
 
+#define FLOAT_STR_LEN 32
+
 static const char * TAG = "nvs_config";
 
 char * nvs_config_get_string(const char * key, const char * default_value)
@@ -165,4 +167,30 @@ void nvs_config_set_u64(const char * key, const uint64_t value)
         ESP_LOGW(TAG, "Could not write nvs key: %s, value: %llu", key, value);
     }
     nvs_close(handle);
+}
+
+float nvs_config_get_float(const char *key, float default_value)
+{
+    char default_str[FLOAT_STR_LEN];
+    snprintf(default_str, sizeof(default_str), "%.6f", default_value);
+
+    char *str_value = nvs_config_get_string(key, default_str);
+
+    char *endptr;
+    float value = strtof(str_value, &endptr);
+    if (endptr == str_value || *endptr != '\0') {
+        ESP_LOGW(TAG, "Invalid float format for key %s: %s", key, str_value);
+        value = default_value;
+    }
+
+    free(str_value);
+    return value;
+}
+
+void nvs_config_set_float(const char *key, float value)
+{
+    char str_value[FLOAT_STR_LEN];
+    snprintf(str_value, sizeof(str_value), "%.6f", value);
+
+    nvs_config_set_string(key, str_value);
 }

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -16,7 +16,8 @@
 #define NVS_CONFIG_STRATUM_PASS "stratumpass"
 #define NVS_CONFIG_FALLBACK_STRATUM_USER "fbstratumuser"
 #define NVS_CONFIG_FALLBACK_STRATUM_PASS "fbstratumpass"
-#define NVS_CONFIG_ASIC_FREQ "asicfrequency"
+#define NVS_CONFIG_ASIC_FREQUENCY "asicfrequency"
+#define NVS_CONFIG_ASIC_FREQUENCY_FLOAT "asicfrequency_f"
 #define NVS_CONFIG_ASIC_VOLTAGE "asicvoltage"
 #define NVS_CONFIG_ASIC_MODEL "asicmodel"
 #define NVS_CONFIG_DEVICE_MODEL "devicemodel"
@@ -47,5 +48,7 @@ int32_t nvs_config_get_i32(const char * key, const int32_t default_value);
 void nvs_config_set_i32(const char * key, const int32_t value);
 uint64_t nvs_config_get_u64(const char * key, const uint64_t default_value);
 void nvs_config_set_u64(const char * key, const uint64_t value);
+float nvs_config_get_float(const char *key, float default_value);
+void nvs_config_set_float(const char *key, float value);
 
 #endif // MAIN_NVS_CONFIG_H

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -24,6 +24,7 @@
 #include "esp_psram.h"
 #include "power.h"
 #include "thermal.h"
+#include "power_management_task.h"
 
 #include "bm1397.h"
 #include "bm1366.h"
@@ -327,8 +328,7 @@ bool self_test(void * pvParameters)
         tests_done(GLOBAL_STATE, TESTS_FAILED);
     }
 
-    GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value = nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, CONFIG_ASIC_FREQUENCY);
-    ESP_LOGI(TAG, "NVS_CONFIG_ASIC_FREQ %f", (float)GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value);
+    POWER_MANAGEMENT_init_frequency(&GLOBAL_STATE->POWER_MANAGEMENT_MODULE);
 
     uint8_t chips_detected = ASIC_init(GLOBAL_STATE);
     uint8_t chips_expected = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -44,8 +44,21 @@ int pid_startup_counter = 0;
 #define PID_STARTUP_HOLD_DURATION 3  // Number of cycles to HOLD pid_d_startup
 #define PID_STARTUP_RAMP_DURATION 17 // Number of cycles to RAMP DOWN D (Total startup duration PID_STARTUP_HOLD_DURATION + PID_STARTUP_RAMP_DURATION)
 
-
 PIDController pid;
+
+void POWER_MANAGEMENT_init_frequency(PowerManagementModule * power_management)
+{
+    float frequency = nvs_config_get_float(NVS_CONFIG_ASIC_FREQUENCY_FLOAT, -1);
+    if (frequency < 0) { // fallback if the float value is not yet set
+        frequency = (float) nvs_config_get_u16(NVS_CONFIG_ASIC_FREQUENCY, CONFIG_ASIC_FREQUENCY);
+
+        nvs_config_set_float(NVS_CONFIG_ASIC_FREQUENCY_FLOAT, frequency);
+    }
+
+    ESP_LOGI(TAG, "ASIC Frequency: %gMHz", frequency);
+
+    power_management->frequency_value = frequency;
+}
 
 void POWER_MANAGEMENT_task(void * pvParameters)
 {
@@ -55,6 +68,10 @@ void POWER_MANAGEMENT_task(void * pvParameters)
 
     PowerManagementModule * power_management = &GLOBAL_STATE->POWER_MANAGEMENT_MODULE;
     SystemModule * sys_module = &GLOBAL_STATE->SYSTEM_MODULE;
+
+    POWER_MANAGEMENT_init_frequency(power_management);
+    
+    float last_asic_frequency = power_management->frequency_value;
 
     pid_setPoint = (double)nvs_config_get_u16(NVS_CONFIG_TEMP_TARGET, pid_setPoint);
 
@@ -67,10 +84,6 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     vTaskDelay(500 / portTICK_PERIOD_MS);
     uint16_t last_core_voltage = 0.0;
 
-    power_management->frequency_value = nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, CONFIG_ASIC_FREQUENCY);
-    ESP_LOGI(TAG, "ASIC Frequency: %.2fMHz", (float)power_management->frequency_value);
-    uint16_t last_asic_frequency = power_management->frequency_value;
-    
     while (1) {
 
         // Refresh PID setpoint from NVS in case it was changed via API
@@ -99,7 +112,8 @@ void POWER_MANAGEMENT_task(void * pvParameters)
             VCORE_set_voltage(0.0f, GLOBAL_STATE);
 
             nvs_config_set_u16(NVS_CONFIG_ASIC_VOLTAGE, 1000);
-            nvs_config_set_u16(NVS_CONFIG_ASIC_FREQ, 50);
+            nvs_config_set_u16(NVS_CONFIG_ASIC_FREQUENCY, 50);
+            nvs_config_set_float(NVS_CONFIG_ASIC_FREQUENCY_FLOAT, 50);
             nvs_config_set_u16(NVS_CONFIG_FAN_SPEED, 100);
             nvs_config_set_u16(NVS_CONFIG_AUTO_FAN_SPEED, 0);
             nvs_config_set_u16(NVS_CONFIG_OVERHEAT_MODE, 1);
@@ -161,7 +175,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
         }
 
         uint16_t core_voltage = nvs_config_get_u16(NVS_CONFIG_ASIC_VOLTAGE, CONFIG_ASIC_VOLTAGE);
-        uint16_t asic_frequency = nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, CONFIG_ASIC_FREQUENCY);
+        float asic_frequency = nvs_config_get_float(NVS_CONFIG_ASIC_FREQUENCY_FLOAT, CONFIG_ASIC_FREQUENCY);
 
         if (core_voltage != last_core_voltage) {
             ESP_LOGI(TAG, "setting new vcore voltage to %umV", core_voltage);
@@ -170,12 +184,12 @@ void POWER_MANAGEMENT_task(void * pvParameters)
         }
 
         if (asic_frequency != last_asic_frequency) {
-            ESP_LOGI(TAG, "New ASIC frequency requested: %uMHz (current: %uMHz)", asic_frequency, last_asic_frequency);
+            ESP_LOGI(TAG, "New ASIC frequency requested: %g MHz (current: %g MHz)", asic_frequency, last_asic_frequency);
             
-            bool success = ASIC_set_frequency(GLOBAL_STATE, (float)asic_frequency);
+            bool success = ASIC_set_frequency(GLOBAL_STATE, asic_frequency);
             
             if (success) {
-                power_management->frequency_value = (float)asic_frequency;
+                power_management->frequency_value = asic_frequency;
             }
             
             last_asic_frequency = asic_frequency;

--- a/main/tasks/power_management_task.h
+++ b/main/tasks/power_management_task.h
@@ -14,6 +14,8 @@ typedef struct
     float current;
 } PowerManagementModule;
 
+void POWER_MANAGEMENT_init_frequency(PowerManagementModule * power_management);
+
 void POWER_MANAGEMENT_task(void * pvParameters);
 
 #endif


### PR DESCRIPTION
One of the things I found in #1045 is that frequency values are currently bound to integer values, however, the PLL settings can resolve way more frequencies. By accepting frequency as float, way more values can be used.

Currently it only accepts exact values, a next step could be to make it more lenient.