### PR TITLE
Configure min fan speed percentage

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -62,6 +62,10 @@
               <label>Target Temperature {{form.controls['temptarget'].value}}°C</label>
               <p-slider [min]="35" [max]="66" formControlName="temptarget"></p-slider>
           </div>
+          <div class="col-12">
+              <label>Minimum Fan Speed {{form.controls['minfanspeed'].value}}%</label>
+              <p-slider [min]="0" [max]="99" formControlName="minfanspeed"></p-slider>
+          </div>
       </div>
 
         <div *ngIf="form.controls['autofanspeed'].value != true">

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -162,6 +162,7 @@ export class EditComponent implements OnInit, OnDestroy, OnChanges {
           coreVoltage: [info.coreVoltage, [Validators.required]],
           frequency: [info.frequency, [Validators.required]],
           autofanspeed: [info.autofanspeed == 1, [Validators.required]],
+          minfanspeed: [info.minFanSpeed, [Validators.required]],
           fanspeed: [info.fanspeed, [Validators.required]],
           temptarget: [info.temptarget, [Validators.required]],
           overheat_mode: [info.overheat_mode, [Validators.required]],

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -74,6 +74,7 @@ export class SystemService {
         invertscreen: 0,
         displayTimeout: -1,
         autofanspeed: 1,
+        minFanSpeed: 25,
         fanspeed: 100,
         temptarget: 60,
         statsFrequency: 30,

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -52,6 +52,7 @@ export interface ISystemInfo {
     idfVersion: string,
     boardVersion: string,
     autofanspeed: number,
+    minFanSpeed: number,
     fanspeed: number,
     temptarget: number,
     fanrpm: number,

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -547,7 +547,7 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
         nvs_config_set_u16(NVS_CONFIG_FAN_SPEED, item->valueint);
     }
     if ((item = cJSON_GetObjectItem(root, "minFanSpeed")) != NULL) {
-        nvs_config_set_u16(NVS_CONFIG_MIN_FAN_PCT, item->valueint);
+        nvs_config_set_u16(NVS_CONFIG_MIN_FAN_SPEED, item->valueint);
     }
     if ((item = cJSON_GetObjectItem(root, "temptarget")) != NULL) {
         nvs_config_set_u16(NVS_CONFIG_TEMP_TARGET, item->valueint);
@@ -699,7 +699,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddNumberToObject(root, "autofanspeed", nvs_config_get_u16(NVS_CONFIG_AUTO_FAN_SPEED, 1));
 
     cJSON_AddNumberToObject(root, "fanspeed", GLOBAL_STATE->POWER_MANAGEMENT_MODULE.fan_perc);
-    cJSON_AddNumberToObject(root, "minFanSpeed", nvs_config_get_u16(NVS_CONFIG_MIN_FAN_PCT, 25));
+    cJSON_AddNumberToObject(root, "minFanSpeed", nvs_config_get_u16(NVS_CONFIG_MIN_FAN_SPEED, 25));
     cJSON_AddNumberToObject(root, "temptarget", nvs_config_get_u16(NVS_CONFIG_TEMP_TARGET, 60));
     cJSON_AddNumberToObject(root, "fanrpm", GLOBAL_STATE->POWER_MANAGEMENT_MODULE.fan_rpm);
 

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -546,6 +546,9 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     if ((item = cJSON_GetObjectItem(root, "fanspeed")) != NULL) {
         nvs_config_set_u16(NVS_CONFIG_FAN_SPEED, item->valueint);
     }
+    if ((item = cJSON_GetObjectItem(root, "minFanSpeed")) != NULL) {
+        nvs_config_set_u16(NVS_CONFIG_MIN_FAN_PCT, item->valueint);
+    }
     if ((item = cJSON_GetObjectItem(root, "temptarget")) != NULL) {
         nvs_config_set_u16(NVS_CONFIG_TEMP_TARGET, item->valueint);
     }
@@ -692,10 +695,11 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddNumberToObject(root, "rotation", nvs_config_get_u16(NVS_CONFIG_ROTATION, 0));
     cJSON_AddNumberToObject(root, "invertscreen", nvs_config_get_u16(NVS_CONFIG_INVERT_SCREEN, 0));
     cJSON_AddNumberToObject(root, "displayTimeout", nvs_config_get_i32(NVS_CONFIG_DISPLAY_TIMEOUT, -1));
-    
+
     cJSON_AddNumberToObject(root, "autofanspeed", nvs_config_get_u16(NVS_CONFIG_AUTO_FAN_SPEED, 1));
 
     cJSON_AddNumberToObject(root, "fanspeed", GLOBAL_STATE->POWER_MANAGEMENT_MODULE.fan_perc);
+    cJSON_AddNumberToObject(root, "minFanSpeed", nvs_config_get_u16(NVS_CONFIG_MIN_FAN_PCT, 25));
     cJSON_AddNumberToObject(root, "temptarget", nvs_config_get_u16(NVS_CONFIG_TEMP_TARGET, 60));
     cJSON_AddNumberToObject(root, "fanrpm", GLOBAL_STATE->POWER_MANAGEMENT_MODULE.fan_rpm);
 

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -116,6 +116,7 @@ components:
         - isUsingFallbackStratum
         - macAddr
         - maxPower
+        - minimumFanSpeed
         - nominalVoltage
         - overheat_mode
         - overclockEnabled
@@ -228,6 +229,9 @@ components:
         maxPower:
           type: integer
           description: Maxmium power draw of the board in watts
+        minimumFanSpeed:
+          type: integer
+          description: Minimum fan speed percentage when using auto fan control
         nominalVoltage:
           type: integer
           description: Nominal board voltage

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -31,7 +31,7 @@
 #define NVS_CONFIG_DISPLAY_TIMEOUT "displayTimeout"
 #define NVS_CONFIG_AUTO_FAN_SPEED "autofanspeed"
 #define NVS_CONFIG_FAN_SPEED "fanspeed"
-#define NVS_CONFIG_MIN_FAN_PCT "minfanpct"
+#define NVS_CONFIG_MIN_FAN_SPEED "minfanspeed"
 #define NVS_CONFIG_TEMP_TARGET "temptarget"
 #define NVS_CONFIG_BEST_DIFF "bestdiff"
 #define NVS_CONFIG_SELF_TEST "selftest"

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -31,6 +31,7 @@
 #define NVS_CONFIG_DISPLAY_TIMEOUT "displayTimeout"
 #define NVS_CONFIG_AUTO_FAN_SPEED "autofanspeed"
 #define NVS_CONFIG_FAN_SPEED "fanspeed"
+#define NVS_CONFIG_MIN_FAN_PCT "minfanpct"
 #define NVS_CONFIG_TEMP_TARGET "temptarget"
 #define NVS_CONFIG_BEST_DIFF "bestdiff"
 #define NVS_CONFIG_SELF_TEST "selftest"

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -75,9 +75,8 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     
     while (1) {
 
-        // Refresh PID setpoint and minimum output from NVS in case it was changed via API
+        // Refresh PID setpoint from NVS in case it was changed via API
         pid_setPoint = (double)nvs_config_get_u16(NVS_CONFIG_TEMP_TARGET, pid_setPoint);
-        min_fan_pct = (double)nvs_config_get_u16(NVS_CONFIG_MIN_FAN_SPEED, min_fan_pct);
 
         power_management->voltage = Power_get_input_voltage(GLOBAL_STATE);
         power_management->power = Power_get_power(GLOBAL_STATE);

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -31,7 +31,7 @@ static const char * TAG = "power_management";
 
 double pid_input = 0.0;
 double pid_output = 0.0;
-double min_fan_pct = 25.0; // Default, 0-100%, will be overwritten by NVS
+double min_fan_pct = 25.0;
 double pid_setPoint = 60.0; // Default, will be overwritten by NVS
 double pid_p = 15.0;        
 double pid_i = 0.2;
@@ -63,7 +63,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     // Initialize PID controller with pid_d_startup and PID_REVERSE directly
     pid_init(&pid, &pid_input, &pid_output, &pid_setPoint, pid_p, pid_i, pid_d_startup, PID_P_ON_E, PID_REVERSE);
     pid_set_sample_time(&pid, POLL_RATE - 1); // Sample time in ms
-    pid_set_output_limits(&pid, min_fan_pct, 100); // Output limits fan_min% to 100%
+    pid_set_output_limits(&pid, min_fan_pct, 100);
     pid_set_mode(&pid, AUTOMATIC);        // This calls pid_initialize() internally
 
     vTaskDelay(500 / portTICK_PERIOD_MS);

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -58,7 +58,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     SystemModule * sys_module = &GLOBAL_STATE->SYSTEM_MODULE;
 
     pid_setPoint = (double)nvs_config_get_u16(NVS_CONFIG_TEMP_TARGET, pid_setPoint);
-    min_fan_pct = (double)nvs_config_get_u16(NVS_CONFIG_MIN_FAN_PCT, min_fan_pct);
+    min_fan_pct = (double)nvs_config_get_u16(NVS_CONFIG_MIN_FAN_SPEED, min_fan_pct);
 
     // Initialize PID controller with pid_d_startup and PID_REVERSE directly
     pid_init(&pid, &pid_input, &pid_output, &pid_setPoint, pid_p, pid_i, pid_d_startup, PID_P_ON_E, PID_REVERSE);
@@ -77,7 +77,7 @@ void POWER_MANAGEMENT_task(void * pvParameters)
 
         // Refresh PID setpoint and minimum output from NVS in case it was changed via API
         pid_setPoint = (double)nvs_config_get_u16(NVS_CONFIG_TEMP_TARGET, pid_setPoint);
-        min_fan_pct = (double)nvs_config_get_u16(NVS_CONFIG_MIN_FAN_PCT, min_fan_pct);
+        min_fan_pct = (double)nvs_config_get_u16(NVS_CONFIG_MIN_FAN_SPEED, min_fan_pct);
 
         power_management->voltage = Power_get_input_voltage(GLOBAL_STATE);
         power_management->power = Power_get_power(GLOBAL_STATE);

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -31,6 +31,7 @@ static const char * TAG = "power_management";
 
 double pid_input = 0.0;
 double pid_output = 0.0;
+double min_fan_pct = 25.0; // Default, 0-100%, will be overwritten by NVS
 double pid_setPoint = 60.0; // Default, will be overwritten by NVS
 double pid_p = 15.0;        
 double pid_i = 0.2;
@@ -57,11 +58,12 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     SystemModule * sys_module = &GLOBAL_STATE->SYSTEM_MODULE;
 
     pid_setPoint = (double)nvs_config_get_u16(NVS_CONFIG_TEMP_TARGET, pid_setPoint);
+    min_fan_pct = (double)nvs_config_get_u16(NVS_CONFIG_MIN_FAN_PCT, min_fan_pct);
 
     // Initialize PID controller with pid_d_startup and PID_REVERSE directly
     pid_init(&pid, &pid_input, &pid_output, &pid_setPoint, pid_p, pid_i, pid_d_startup, PID_P_ON_E, PID_REVERSE);
     pid_set_sample_time(&pid, POLL_RATE - 1); // Sample time in ms
-    pid_set_output_limits(&pid, 25, 100); // Output limits 25% to 100%
+    pid_set_output_limits(&pid, min_fan_pct, 100); // Output limits fan_min% to 100%
     pid_set_mode(&pid, AUTOMATIC);        // This calls pid_initialize() internally
 
     vTaskDelay(500 / portTICK_PERIOD_MS);
@@ -72,8 +74,10 @@ void POWER_MANAGEMENT_task(void * pvParameters)
     uint16_t last_asic_frequency = power_management->frequency_value;
     
     while (1) {
-        // Refresh PID setpoint from NVS in case it was changed via API
+
+        // Refresh PID setpoint and minimum output from NVS in case it was changed via API
         pid_setPoint = (double)nvs_config_get_u16(NVS_CONFIG_TEMP_TARGET, pid_setPoint);
+        min_fan_pct = (double)nvs_config_get_u16(NVS_CONFIG_MIN_FAN_PCT, min_fan_pct);
 
         power_management->voltage = Power_get_input_voltage(GLOBAL_STATE);
         power_management->power = Power_get_power(GLOBAL_STATE);


### PR DESCRIPTION
i noticed my chip struggling to get up to temp from a cold start, so this adds a new nvs entry, `minpid` (this should be renamed honestly) that stores the minimum fan speed for the auto fan control  
could be expanded into `p`, `i`, and `d` being tunable?  
no danger of overheating when setting to 0, the fan runs at 70% before pid kicks in  
wildcard pr

i feel like there was a pid issue or pr but i cant find it