### PR TITLE
Fix selected accent color after page reload

### DIFF
--- a/main/http_server/axe-os/src/app/components/design/theme-config.component.ts
+++ b/main/http_server/axe-os/src/app/components/design/theme-config.component.ts
@@ -235,6 +235,7 @@ export class ThemeConfigComponent implements OnInit {
           // Apply accent colors if they exist
           if (settings.accentColors) {
             this.applyThemeColors(settings.accentColors);
+            this.currentColor = settings.accentColors['--primary-color'];
           }
         }
       },


### PR DESCRIPTION
After reloading the page, the choosed accent color is not selected. This PR automatically selects the accent color again after the page reloads.

**Before**
<img width="1196" alt="Screenshot 2025-06-26 at 14 42 49" src="https://github.com/user-attachments/assets/3ab41429-0ec8-425a-bc6c-ca0fe04c9114" />

**After**
<img width="1198" alt="Screenshot 2025-06-26 at 14 43 08" src="https://github.com/user-attachments/assets/a5ce0e20-52e5-489d-8063-0a94682fce8f" />