### PR TITLE
Fixed label icon wrap @ pool page

### DIFF
--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -46,8 +46,10 @@
                             [binary]="true"></p-checkbox>
                     </div>
                     <label [htmlFor]="pool + 'ExtranonceSubscribe'" class="col-11 m-0 pl-3 md:col-2 md:flex-order-1 md:p-2">
-                        Enable Extranonce Subscribe
-                        <i class="pi pi-info-circle text-xs px-1" pTooltip="Required by some pools, check the pool documentation."></i>
+                        Enable Extranonce <span class="white-space-nowrap">
+                            Subscribe
+                            <i class="pi pi-info-circle text-xs px-1" pTooltip="Required by some pools, check the pool documentation."></i>
+                        </span>
                     </label>
                 </div>
             </div>


### PR DESCRIPTION
The bad icon wrap is fixed by this PR. Sorry @mutatrum my bad, I just noticed the bug.

**Before**

<img width="771" alt="Screenshot 2025-06-26 at 17 25 13" src="https://github.com/user-attachments/assets/b978d659-0c53-4983-9bb8-1af5b1926ffd" />


**After**
<img width="729" alt="Screenshot 2025-06-26 at 17 25 46" src="https://github.com/user-attachments/assets/66adab9d-4391-475c-9d97-83a0c303ce5a" />
