### PR TITLE
Uniform notifications design

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -213,7 +213,7 @@ export class EditComponent implements OnInit, OnDestroy {
           if (this.isRestartRequired) {
             this.toastr.warning('You must restart this device after saving for changes to take effect', 'Warning');
           }
-          this.toastr.success(successMessage, 'Success!');
+          this.toastr.success(successMessage, 'Success');
           this.savedChanges = true;
         },
         error: (err: HttpErrorResponse) => {
@@ -248,7 +248,7 @@ export class EditComponent implements OnInit, OnDestroy {
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe({
         next: () => {
-          const successMessage = this.uri ? `Bitaxe at ${this.uri} restarted` : 'Bitaxe restarted';
+          const successMessage = this.uri ? `Device at ${this.uri} restarted` : 'Device restarted';
           this.toastr.success(successMessage, 'Success');
         },
         error: (err: HttpErrorResponse) => {

--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
@@ -72,11 +72,11 @@ export class NetworkEditComponent implements OnInit {
       .subscribe({
         next: () => {
           this.toastr.warning('You must restart this device after saving for changes to take effect', 'Warning');
-          this.toastr.success('Success!', 'Saved network settings');
+          this.toastr.success('Saved network settings', 'Success');
           this.savedChanges = true;
         },
         error: (err: HttpErrorResponse) => {
-          this.toastr.error('Error.', `Could not save. ${err.message}`);
+          this.toastr.error(`Could not save. ${err.message}`, 'Error');
           this.savedChanges = false;
         }
       });
@@ -138,10 +138,10 @@ export class NetworkEditComponent implements OnInit {
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe({
         next: () => {
-          this.toastr.success('Success!', 'Bitaxe restarted');
+          this.toastr.success('Device restarted', 'Success');
         },
         error: (err: HttpErrorResponse) => {
-          this.toastr.error('Error', `Could not restart. ${err.message}`);
+          this.toastr.error(`Could not restart. ${err.message}`, 'Error');
         }
       });
   }

--- a/main/http_server/axe-os/src/app/components/pool/pool.component.ts
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.ts
@@ -84,7 +84,7 @@ export class PoolComponent implements OnInit {
         next: () => {
           const successMessage = this.uri ? `Saved pool settings for ${this.uri}` : 'Saved pool settings';
           this.toastr.warning('You must restart this device after saving for changes to take effect', 'Warning');
-          this.toastr.success(successMessage, 'Success!');
+          this.toastr.success(successMessage, 'Success');
           this.savedChanges = true;
         },
         error: (err: HttpErrorResponse) => {
@@ -100,7 +100,7 @@ export class PoolComponent implements OnInit {
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe({
         next: () => {
-          const successMessage = this.uri ? `Bitaxe at ${this.uri} restarted` : 'Bitaxe restarted';
+          const successMessage = this.uri ? `Device at ${this.uri} restarted` : 'Device restarted';
           this.toastr.success(successMessage, 'Success');
         },
         error: (err: HttpErrorResponse) => {

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -149,7 +149,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
         timeout(5000),
         catchError(error => {
           const errorMessage = error?.message || error?.statusText || error?.toString() || 'Unknown error';
-          this.toastr.error('Failed to get info from ' + IP, errorMessage);
+          this.toastr.error(errorMessage, 'Error');
           // Return existing device with zeroed stats instead of the previous state
           const existingDevice = this.swarm.find(axeOs => axeOs.IP === IP);
           return of({
@@ -176,7 +176,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
     // Check if IP already exists
     if (this.swarm.some(item => item.IP === IP)) {
-      this.toastr.warning('This IP address already exists in the swarm', 'Duplicate Entry');
+      this.toastr.warning('This IP address already exists in the swarm', 'Warning');
       return;
     }
 
@@ -210,7 +210,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
       })
     ).subscribe(res => {
       if (res !== null) {
-        this.toastr.success(`Bitaxe at ${axe.IP} restarted`, 'Success');
+        this.toastr.success(`Device at ${axe.IP} restarted`, 'Success');
       }
     });
   }

--- a/main/http_server/axe-os/src/app/components/update/update.component.ts
+++ b/main/http_server/axe-os/src/app/components/update/update.component.ts
@@ -58,7 +58,7 @@ export class UpdateComponent {
             this.firmwareUpdateProgress = Math.round((event.loaded / (event.total as number)) * 100);
           } else if (event.type === HttpEventType.Response) {
             if (event.ok) {
-              this.toastrService.success('Firmware updated. Device has been successfully restarted.', 'Success!');
+              this.toastrService.success('Firmware updated. Device has been successfully restarted.', 'Success');
 
             } else {
               this.toastrService.error(event.statusText, 'Error');

--- a/main/http_server/axe-os/src/app/layout/app.menu.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.menu.component.ts
@@ -48,7 +48,7 @@ export class AppMenuComponent implements OnInit {
 
     public restart() {
         this.systemService.restart().subscribe(res => {});
-        this.toastr.success('Success!', 'Bitaxe restarted');
+        this.toastr.success('Device restarted', 'Success');
     }
 
     public isMobile() {

--- a/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
@@ -34,7 +34,7 @@ export class AppTopBarComponent {
 
   public restart() {
     this.systemService.restart().subscribe(() => {});
-    this.toastr.success('Success!', 'Bitaxe restarted');
+    this.toastr.success('Device restarted', 'Success');
   }
 
   public isDesktop() {


### PR DESCRIPTION
Currently, Toastr notifications are not uniform. This pull request ensures consistency.

1. Notifications title is always `Success` | `Warning` | `Error`
2. Notification message is always the message not the title
3. ~~Bitaxe~~ → Device
