### PR TITLE
Refactored network component

### DIFF
--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.html
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.html
@@ -1,14 +1,13 @@
-<ng-container *ngIf="form != null">
-    <form [formGroup]="form">
-
+<form *ngIf="form" [formGroup]="form">
+    <div class="card">
         <div class="field grid p-fluid">
-            <label htmlFor="hostname" class="col-12 mb-2 md:col-2 md:mb-0">Hostname:</label>
+            <label htmlFor="hostname" class="col-12 md:col-2 md:m-0">Hostname</label>
             <div class="col-12 md:col-10">
                 <input pInputText id="hostname" type="text" formControlName="hostname" />
             </div>
         </div>
         <div class="field grid p-fluid">
-            <label htmlFor="ssid" class="col-12 mb-2 md:col-2 md:mb-0">Wi-Fi SSID:</label>
+            <label htmlFor="ssid" class="col-12 md:col-2 md:m-0">Wi-Fi SSID</label>
             <div class="col-12 md:col-10 p-inputgroup">
                 <input pInputText id="ssid" type="text" formControlName="ssid" />
                 <p-button
@@ -21,14 +20,14 @@
             </div>
         </div>
         <div class="field grid p-fluid">
-            <label htmlFor="wifiPass" class="col-12 mb-2 md:col-2 md:mb-0">Wi-Fi Password:</label>
+            <label htmlFor="wifiPass" class="col-12 md:col-2 md:m-0">Wi-Fi Password</label>
             <div class="col-12 md:col-10 p-input-icon-right">
-                <i *ngIf="form.get('wifiPass')?.dirty" class="pi"
-                   [ngClass]="{'pi-eye': !showWifiPassword, 'pi-eye-slash': showWifiPassword}"
-                   (click)="toggleWifiPasswordVisibility()" style="cursor: pointer;"></i>
+                <i *ngIf="form.get('wifiPass')?.dirty" class="pi cursor-pointer"
+                    [ngClass]="{'pi-eye': !showWifiPassword, 'pi-eye-slash': showWifiPassword}"
+                    (click)="toggleWifiPasswordVisibility()"></i>
                 <input pInputText id="wifiPass" formControlName="wifiPass"
-                       [type]="showWifiPassword ? 'text' : 'password'"
-                       placeholder="Enter Wi-Fi password" />
+                    [type]="showWifiPassword ? 'text' : 'password'"
+                    placeholder="Enter Wi-Fi password" />
             </div>
         </div>
 
@@ -37,5 +36,5 @@
                 class="btn btn-primary">Save</button>
             <button pButton [disabled]="!savedChanges" (click)="restart()">Restart</button>
         </div>
-    </form>
-</ng-container>
+    </div>
+</form>

--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
@@ -3,6 +3,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
 import { finalize } from 'rxjs/operators';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { DialogService } from 'src/app/services/dialog.service';
 import { LoadingService } from 'src/app/services/loading.service';
 import { SystemService } from 'src/app/services/system.service';
@@ -19,6 +20,8 @@ interface WifiNetwork {
   styleUrls: ['./network.edit.component.scss']
 })
 export class NetworkEditComponent implements OnInit {
+  private formSubject = new BehaviorSubject<FormGroup | null>(null);
+  public form$: Observable<FormGroup | null> = this.formSubject.asObservable();
 
   public form!: FormGroup;
   public savedChanges: boolean = false;
@@ -45,7 +48,7 @@ export class NetworkEditComponent implements OnInit {
           ssid: [info.ssid, [Validators.required]],
           wifiPass: ['*****'],
         });
-
+        this.formSubject.next(this.form);
       });
   }
 

--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
@@ -30,7 +30,6 @@ export class NetworkEditComponent implements OnInit {
     private fb: FormBuilder,
     private systemService: SystemService,
     private toastr: ToastrService,
-    private toastrService: ToastrService,
     private loadingService: LoadingService,
     private http: HttpClient,
     private dialogService: DialogService
@@ -114,7 +113,8 @@ export class NetworkEditComponent implements OnInit {
 
           // Create dialog data
           const dialogData = filteredNetworks.map(n => ({
-            label: `${n.ssid} (${n.rssi}dBm)`,
+            label: n.ssid,
+            rssi: n.rssi,
             value: n.ssid
           }));
 

--- a/main/http_server/axe-os/src/app/components/network/network.component.html
+++ b/main/http_server/axe-os/src/app/components/network/network.component.html
@@ -1,4 +1,4 @@
-<div class="card">
+<div [ngClass]="{'card': (form$ | async), 'hidden': !(form$ | async)}">
     <h2>Network Configuration</h2>
 
     <app-network-edit></app-network-edit>

--- a/main/http_server/axe-os/src/app/components/network/network.component.ts
+++ b/main/http_server/axe-os/src/app/components/network/network.component.ts
@@ -1,10 +1,21 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild, AfterViewInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { Observable } from 'rxjs';
+import { NetworkEditComponent } from '../network-edit/network.edit.component';
 
 @Component({
   selector: 'app-network',
   templateUrl: './network.component.html',
   styleUrls: ['./network.component.scss'],
 })
-export class NetworkComponent {
+export class NetworkComponent implements AfterViewInit {
+  form$!: Observable<FormGroup | null>;
+
+  @ViewChild(NetworkEditComponent) networkEditComponent!: NetworkEditComponent;
+
   constructor() {}
+
+  ngAfterViewInit() {
+    this.form$ = this.networkEditComponent.form$;
+  }
 }

--- a/main/http_server/axe-os/src/app/services/dialog.service.ts
+++ b/main/http_server/axe-os/src/app/services/dialog.service.ts
@@ -4,6 +4,7 @@ import { DialogService as PrimeDialogService, DynamicDialogConfig } from 'primen
 
 interface DialogOption {
   label: string;
+  rssi: number;
   value: string;
 }
 
@@ -18,7 +19,7 @@ export class DialogService {
 
     const ref = this.primeDialogService.open(DialogListComponent, {
       header: title,
-      width: '400px',
+      width: '500px',
       data: {
         options: options,
         onSelect: (value: string) => {
@@ -38,18 +39,24 @@ export class DialogService {
 
 @Component({
   template: `
-    <style>
-      ::ng-deep .p-button:focus {
-        box-shadow: none !important;
-        background-color: var(--primary-color) !important;
-      }
-    </style>
     <div class="flex flex-column gap-2">
       <p-button *ngFor="let option of config.data.options"
         [label]="option.label"
         (onClick)="config.data.onSelect(option.value)"
-        styleClass="w-full text-left"
-      ></p-button>
+        styleClass="w-full text-left flex align-items-baseline"
+        pTooltip="{{option.label}} ({{option.rssi}}dBm)"
+        tooltipPosition="bottom"
+      >
+        <figure class="wifi-icon flex-order-2"
+          [ngClass]="{
+            'wifi-icon--excellent': option.rssi > -50,
+            'wifi-icon--good': option.rssi <= -50 && option.rssi > -60,
+            'wifi-icon--fair': option.rssi <= -60 && option.rssi > -70,
+            'wifi-icon--weak': option.rssi <= -70
+          }">
+          <i *ngFor="let item of [1,2,3,4]"></i>
+        </figure>
+      </p-button>
     </div>
   `
 })

--- a/main/http_server/axe-os/src/styles.scss
+++ b/main/http_server/axe-os/src/styles.scss
@@ -158,3 +158,32 @@ button.color-dot {
 .p-button-icon {
     font-size: 1.2rem;
 }
+
+.p-dialog {
+    @extend .card;
+    margin: 1rem;
+
+    &-header,
+    &-content {
+        padding: 0;
+        margin: 0;
+        background: none;
+    }
+
+    &-header {
+        margin: 0 0 2rem;
+    }
+
+    &-header-icon {
+        @extend .p-button;
+        width: 2.2rem;
+        height: 2.2rem;
+        color: #fff;
+        border-radius: 0;
+    }
+
+    &-title {
+        @extend h2;
+        margin: 0;
+    }
+}


### PR DESCRIPTION
To make the layout of all components look identical, I continue with the network view (settings https://github.com/bitaxeorg/ESP-Miner/pull/1062 and pool https://github.com/bitaxeorg/ESP-Miner/pull/1064 config already done). The following tasks have been completed:

1. Uniform network view stylings
2. Add observer to the parent component to hide it till the child is fully loaded
3. Restyle dialog component to look & feel like the modal component
4. Add WiFI icon to the WiFi network button
5. Add tooltip to the WiFi network button

_Todo after merge: Extract WiFi icon into a single component for easy reuse._

**Desktop**

https://github.com/user-attachments/assets/452cf76f-9050-4544-ae7b-fadc671b5e7a


**Desktop**
<img width="1203" alt="Screenshot 2025-06-27 at 12 33 46" src="https://github.com/user-attachments/assets/61042494-579a-4f86-8a70-0dde8fa69761" />

**Desktop | Dialog**
<img width="1203" alt="Screenshot 2025-06-27 at 12 33 57" src="https://github.com/user-attachments/assets/9f76bf0d-ffc4-495d-a91b-68940c1545a6" />

**Mobile**
<img width="418" alt="Screenshot 2025-06-27 at 12 34 36" src="https://github.com/user-attachments/assets/1172a602-fb1f-47a7-abe8-c790fa9b095d" />

**Mobile | Dialog**
<img width="414" alt="Screenshot 2025-06-27 at 12 34 15" src="https://github.com/user-attachments/assets/97478d6a-6344-45a2-900e-729ec01a83f0" />