### PR TITLE
Swarm should handle devices without asic endpoint

### DIFF
--- a/main/http_server/axe-os/api/system/asic_settings.c
+++ b/main/http_server/axe-os/api/system/asic_settings.c
@@ -36,7 +36,7 @@ esp_err_t GET_system_asic(httpd_req_t *req)
 
     // Add ASIC model to the JSON object
     cJSON_AddStringToObject(root, "ASICModel", GLOBAL_STATE->DEVICE_CONFIG.family.asic.name);
-    cJSON_AddStringToObject(root, "familyName", GLOBAL_STATE->DEVICE_CONFIG.family.name);
+    cJSON_AddStringToObject(root, "deviceModel", GLOBAL_STATE->DEVICE_CONFIG.family.name);
     cJSON_AddStringToObject(root, "swarmColor", GLOBAL_STATE->DEVICE_CONFIG.family.swarm_color);
     cJSON_AddNumberToObject(root, "asicCount", GLOBAL_STATE->DEVICE_CONFIG.family.asic_count);
 

--- a/main/http_server/axe-os/api/system/asic_settings.c
+++ b/main/http_server/axe-os/api/system/asic_settings.c
@@ -38,6 +38,7 @@ esp_err_t GET_system_asic(httpd_req_t *req)
     cJSON_AddStringToObject(root, "ASICModel", GLOBAL_STATE->DEVICE_CONFIG.family.asic.name);
     cJSON_AddStringToObject(root, "familyName", GLOBAL_STATE->DEVICE_CONFIG.family.name);
     cJSON_AddStringToObject(root, "swarmColor", GLOBAL_STATE->DEVICE_CONFIG.family.swarm_color);
+    cJSON_AddNumberToObject(root, "asicCount", GLOBAL_STATE->DEVICE_CONFIG.family.asic_count);
 
     cJSON_AddNumberToObject(root, "defaultFrequency", GLOBAL_STATE->DEVICE_CONFIG.family.asic.default_frequency_mhz);
 

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -120,7 +120,7 @@
                        [ngClass]="'text-'+device.swarmColor+'-500'"
                        [href]="'http://'+device.IP"
                        target="_blank"
-                       [pTooltip]="device.familyName || device.deviceModel || 'Other'"
+                       [pTooltip]="device.deviceModel || 'Other'"
                        tooltipPosition="top">{{device.IP}}</a>
                 </td>
                 <td>{{device.hostname}}</td>
@@ -177,7 +177,7 @@
     <div class="flex flex-wrap gap-2 mt-3 text-sm justify-content-center">
         <div *ngFor="let item of getFamilies" class="flex align-items-center gap-1">
             <span [class]="'text-' + item.swarmColor + '-500'">●</span>
-            <span>{{ item.familyName || item.deviceModel || 'Other' }} ({{item.asicCount > 1 ? item.asicCount + 'x ' : ''}}{{item.ASICModel}})</span>
+            <span>{{ item.deviceModel || 'Other' }} ({{item.asicCount > 1 ? item.asicCount + 'x ' : ''}}{{item.ASICModel}})</span>
         </div>
     </div>
 

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -177,7 +177,7 @@
     <div class="flex flex-wrap gap-2 mt-3 text-sm justify-content-center">
         <div *ngFor="let item of getFamilies" class="flex align-items-center gap-1">
             <span [class]="'text-' + item.swarmColor + '-500'">●</span>
-            <span>{{ item.familyName || 'Other' }} ({{item.ASICModel}})</span>
+            <span>{{ item.familyName || 'Other' }} ({{item.asicCount > 1 ? item.asicCount + 'x ' : ''}}{{item.ASICModel}})</span>
         </div>
     </div>
 

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -113,63 +113,63 @@
             <th>Restart</th>
             <th>Remove</th>
         </tr>
-        <ng-container *ngFor="let device of swarm">
+        <ng-container *ngFor="let axe of swarm">
             <tr>
                 <td>
                     <a
-                       [ngClass]="'text-'+device.swarmColor+'-500'"
-                       [href]="'http://'+device.IP"
+                       [ngClass]="'text-'+axe.swarmColor+'-500'"
+                       [href]="'http://'+axe.IP"
                        target="_blank"
-                       [pTooltip]="device.deviceModel || 'Other'"
-                       tooltipPosition="top">{{device.IP}}</a>
+                       [pTooltip]="axe.deviceModel || 'Other'"
+                       tooltipPosition="top">{{axe.IP}}</a>
                 </td>
-                <td>{{device.hostname}}</td>
-                <td>{{device.hashRate * 1000000000 | hashSuffix}}</td>
+                <td>{{axe.hostname}}</td>
+                <td>{{axe.hashRate * 1000000000 | hashSuffix}}</td>
                 <td>
                     <div class="w-min cursor-pointer"
                          pTooltip="Shares Accepted"
                          tooltipPosition="top">
-                        {{device.sharesAccepted | number: '1.0-0'}}
+                        {{axe.sharesAccepted | number: '1.0-0'}}
                     </div>
                     <div class="text-sm w-min cursor-pointer"
                          pTooltip="Shares Rejected"
                          tooltipPosition="top">
-                        {{device.sharesRejected | number: '1.0-0'}}
+                        {{axe.sharesRejected | number: '1.0-0'}}
                     </div>
                 </td>
                 <td>
                     <div class="w-min cursor-pointer"
                          pTooltip="Best Diff"
                          tooltipPosition="top">
-                        {{device.bestDiff}}
+                        {{axe.bestDiff}}
                     </div>
                     <div class="text-sm w-min cursor-pointer"
                          pTooltip="Best Session Diff"
                          tooltipPosition="top">
-                        {{device.bestSessionDiff}}
+                        {{axe.bestSessionDiff}}
                     </div>
                 </td>
-                <td>{{device.uptimeSeconds | dateAgo: {intervals: 2} }}</td>
-                <td>{{device.power | number: '1.1-1'}} <small>W</small> </td>
+                <td>{{axe.uptimeSeconds | dateAgo: {intervals: 2} }}</td>
+                <td>{{axe.power | number: '1.1-1'}} <small>W</small> </td>
                 <td>
                     <div
-                         [ngClass]="{'text-orange-500': device.temp > 68}"
+                         [ngClass]="{'text-orange-500': axe.temp > 68}"
                          pTooltip="ASIC Temperature"
                          tooltipPosition="top">
-                        {{device.temp | number: '1.0-1'}}°<small>C</small>
+                        {{axe.temp | number: '1.0-1'}}°<small>C</small>
                     </div>
                     <div class="text-sm w-min cursor-pointer"
-                         [ngClass]="{'text-orange-500': device.vrTemp > 90}"
-                         *ngIf="device.vrTemp"
+                         [ngClass]="{'text-orange-500': axe.vrTemp > 90}"
+                         *ngIf="axe.vrTemp"
                          pTooltip="Voltage Regulator Temperature"
                          tooltipPosition="top">
-                        {{device.vrTemp | number: '1.0-1'}}°<small>C</small>
+                        {{axe.vrTemp | number: '1.0-1'}}°<small>C</small>
                     </div>
                 </td>
-                <td>{{device.version}}</td>
-                <td><p-button icon="pi pi-pencil" pp-button (click)="edit(device)"></p-button></td>
-                <td><p-button icon="pi pi-sync" pp-button severity="danger" (click)="restart(device)"></p-button></td>
-                <td><p-button icon="pi pi-trash" pp-button severity="secondary" (click)="remove(device)"></p-button></td>
+                <td>{{axe.version}}</td>
+                <td><p-button icon="pi pi-pencil" pp-button (click)="edit(axe)"></p-button></td>
+                <td><p-button icon="pi pi-sync" pp-button severity="danger" (click)="restart(axe)"></p-button></td>
+                <td><p-button icon="pi pi-trash" pp-button severity="secondary" (click)="remove(axe)"></p-button></td>
             </tr>
         </ng-container>
     </table>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -113,63 +113,63 @@
             <th>Restart</th>
             <th>Remove</th>
         </tr>
-        <ng-container *ngFor="let axe of swarm">
+        <ng-container *ngFor="let device of swarm">
             <tr>
                 <td>
                     <a
-                       [ngClass]="'text-'+axe.swarmColor+'-500'"
-                       [href]="'http://'+axe.IP"
+                       [ngClass]="'text-'+device.swarmColor+'-500'"
+                       [href]="'http://'+device.IP"
                        target="_blank"
-                       [pTooltip]="axe.familyName"
-                       tooltipPosition="top">{{axe.IP}}</a>
+                       [pTooltip]="device.familyName || device.deviceModel || 'Other'"
+                       tooltipPosition="top">{{device.IP}}</a>
                 </td>
-                <td>{{axe.hostname}}</td>
-                <td>{{axe.hashRate * 1000000000 | hashSuffix}}</td>
+                <td>{{device.hostname}}</td>
+                <td>{{device.hashRate * 1000000000 | hashSuffix}}</td>
                 <td>
                     <div class="w-min cursor-pointer"
                          pTooltip="Shares Accepted"
                          tooltipPosition="top">
-                        {{axe.sharesAccepted | number: '1.0-0'}}
+                        {{device.sharesAccepted | number: '1.0-0'}}
                     </div>
                     <div class="text-sm w-min cursor-pointer"
                          pTooltip="Shares Rejected"
                          tooltipPosition="top">
-                        {{axe.sharesRejected | number: '1.0-0'}}
+                        {{device.sharesRejected | number: '1.0-0'}}
                     </div>
                 </td>
                 <td>
                     <div class="w-min cursor-pointer"
                          pTooltip="Best Diff"
                          tooltipPosition="top">
-                        {{axe.bestDiff}}
+                        {{device.bestDiff}}
                     </div>
                     <div class="text-sm w-min cursor-pointer"
                          pTooltip="Best Session Diff"
                          tooltipPosition="top">
-                        {{axe.bestSessionDiff}}
+                        {{device.bestSessionDiff}}
                     </div>
                 </td>
-                <td>{{axe.uptimeSeconds | dateAgo: {intervals: 2} }}</td>
-                <td>{{axe.power | number: '1.1-1'}} <small>W</small> </td>
+                <td>{{device.uptimeSeconds | dateAgo: {intervals: 2} }}</td>
+                <td>{{device.power | number: '1.1-1'}} <small>W</small> </td>
                 <td>
                     <div
-                         [ngClass]="{'text-orange-500': axe.temp > 68}"
+                         [ngClass]="{'text-orange-500': device.temp > 68}"
                          pTooltip="ASIC Temperature"
                          tooltipPosition="top">
-                        {{axe.temp | number: '1.0-1'}}°<small>C</small>
+                        {{device.temp | number: '1.0-1'}}°<small>C</small>
                     </div>
                     <div class="text-sm w-min cursor-pointer"
-                         [ngClass]="{'text-orange-500': axe.vrTemp > 90}"
-                         *ngIf="axe.vrTemp"
+                         [ngClass]="{'text-orange-500': device.vrTemp > 90}"
+                         *ngIf="device.vrTemp"
                          pTooltip="Voltage Regulator Temperature"
                          tooltipPosition="top">
-                        {{axe.vrTemp | number: '1.0-1'}}°<small>C</small>
+                        {{device.vrTemp | number: '1.0-1'}}°<small>C</small>
                     </div>
                 </td>
-                <td>{{axe.version}}</td>
-                <td><p-button icon="pi pi-pencil" pp-button (click)="edit(axe)"></p-button></td>
-                <td><p-button icon="pi pi-sync" pp-button severity="danger" (click)="restart(axe)"></p-button></td>
-                <td><p-button icon="pi pi-trash" pp-button severity="secondary" (click)="remove(axe)"></p-button></td>
+                <td>{{device.version}}</td>
+                <td><p-button icon="pi pi-pencil" pp-button (click)="edit(device)"></p-button></td>
+                <td><p-button icon="pi pi-sync" pp-button severity="danger" (click)="restart(device)"></p-button></td>
+                <td><p-button icon="pi pi-trash" pp-button severity="secondary" (click)="remove(device)"></p-button></td>
             </tr>
         </ng-container>
     </table>
@@ -177,7 +177,7 @@
     <div class="flex flex-wrap gap-2 mt-3 text-sm justify-content-center">
         <div *ngFor="let item of getFamilies" class="flex align-items-center gap-1">
             <span [class]="'text-' + item.swarmColor + '-500'">●</span>
-            <span>{{ item.familyName || 'Other' }} ({{item.asicCount > 1 ? item.asicCount + 'x ' : ''}}{{item.ASICModel}})</span>
+            <span>{{ item.familyName || item.deviceModel || 'Other' }} ({{item.asicCount > 1 ? item.asicCount + 'x ' : ''}}{{item.ASICModel}})</span>
         </div>
     </div>
 

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -166,7 +166,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
     forkJoin({
       info: this.httpClient.get<any>(`http://${IP}/api/system/info`),
-      asic: this.httpClient.get<any>(`http://${IP}/api/system/asic`).pipe(catchError(() => of({}))) // Return empty object if ASIC endpoint fails
+      asic: this.httpClient.get<any>(`http://${IP}/api/system/asic`).pipe(catchError(() => of({})))
     }).subscribe(({ info, asic }) => {
       if (!info.ASICModel || !asic.ASICModel) {
         return;

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -143,7 +143,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
     return from(ips).pipe(
       mergeMap(IP => forkJoin({
         info: this.httpClient.get(`http://${IP}/api/system/info`),
-        asic: this.httpClient.get(`http://${IP}/api/system/asic`)
+        asic: this.httpClient.get(`http://${IP}/api/system/asic`).pipe(catchError(() => of({}))) // Return empty object if ASIC endpoint fails
       }).pipe(
         map(({ info, asic }) => {
           return { IP, ...info, ...asic };
@@ -314,6 +314,6 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
   get getFamilies(): ISystemASIC[] {
     return this.swarm.filter((v, i, a) =>
-      a.findIndex(({ familyName }) => v.familyName === familyName) === i);
+      a.findIndex(({ familyName, ASICModel, asicCount }) => v.familyName === familyName && v.ASICModel === ASICModel && v.asicCount === asicCount) === i);
   }
 }

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -10,7 +10,7 @@ const SWARM_DATA = 'SWARM_DATA';
 const SWARM_REFRESH_TIME = 'SWARM_REFRESH_TIME';
 const SWARM_SORTING = 'SWARM_SORTING';
 
-type SwarmDevice = { IP: string; ASICModel: string; familyName: string; deviceModel: string; swarmColor: string; asicCount: number; [key: string]: any };
+type SwarmDevice = { IP: string; ASICModel: string; deviceModel: string; swarmColor: string; asicCount: number; [key: string]: any };
 
 @Component({
   selector: 'app-swarm',
@@ -310,8 +310,8 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
   get getFamilies(): SwarmDevice[] {
     return this.swarm.filter((v, i, a) =>
-      a.findIndex(({ familyName, deviceModel, ASICModel, asicCount }) =>
-        (v.familyName || v.deviceModel) === (familyName || deviceModel) &&
+      a.findIndex(({ deviceModel, ASICModel, asicCount }) =>
+        v.deviceModel === deviceModel &&
         v.ASICModel === ASICModel &&
         v.asicCount === asicCount
       ) === i

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -34,7 +34,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
   public refreshTimeSet = 30;
 
   public totals: { hashRate: number; power: number; bestDiff: string } = { hashRate: 0, power: 0, bestDiff: '0' };
-  
+
   public isRefreshing = false;
 
   public refreshIntervalControl: FormControl;

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -4,15 +4,13 @@ import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms'
 import { ToastrService } from 'ngx-toastr';
 import { forkJoin, catchError, from, map, mergeMap, of, take, timeout, toArray, Observable } from 'rxjs';
 import { LocalStorageService } from 'src/app/local-storage.service';
-import { SystemService } from 'src/app/services/system.service';
-import { ISystemASIC } from 'src/models/ISystemASIC';
 import { ModalComponent } from '../modal/modal.component';
 
-const SWARM_DATA = 'SWARM_DATA'
+const SWARM_DATA = 'SWARM_DATA';
 const SWARM_REFRESH_TIME = 'SWARM_REFRESH_TIME';
-const SWARM_SORTING = 'SWARM_SORTING'
+const SWARM_SORTING = 'SWARM_SORTING';
 
-type SwarmDevice = { IP: string; [key: string]: any };
+type SwarmDevice = { IP: string; ASICModel: string; familyName: string; deviceModel: string; swarmColor: string; asicCount: number; [key: string]: any };
 
 @Component({
   selector: 'app-swarm',
@@ -35,8 +33,8 @@ export class SwarmComponent implements OnInit, OnDestroy {
   public refreshIntervalTime = 30;
   public refreshTimeSet = 30;
 
-  public totals: { hashRate: number, power: number, bestDiff: string } = { hashRate: 0, power: 0, bestDiff: '0' };
-
+  public totals: { hashRate: number; power: number; bestDiff: string } = { hashRate: 0, power: 0, bestDiff: '0' };
+  
   public isRefreshing = false;
 
   public refreshIntervalControl: FormControl;
@@ -46,7 +44,6 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
   constructor(
     private fb: FormBuilder,
-    private systemService: SystemService,
     private toastr: ToastrService,
     private localStorageService: LocalStorageService,
     private httpClient: HttpClient
@@ -82,14 +79,14 @@ export class SwarmComponent implements OnInit, OnDestroy {
       this.scanNetwork();
     } else {
       this.swarm = swarmData;
-      this.refreshList();
+      this.refreshList(true);
     }
 
     this.refreshIntervalRef = window.setInterval(() => {
       if (!this.scanning && !this.isRefreshing) {
         this.refreshIntervalTime--;
         if (this.refreshIntervalTime <= 0) {
-          this.refreshList();
+          this.refreshList(false);
         }
       }
     }, 1000);
@@ -139,14 +136,15 @@ export class SwarmComponent implements OnInit, OnDestroy {
     });
   }
 
-  private getAllDeviceInfo(ips: string[], errorHandler: (error: any, ip: string) => Observable<SwarmDevice[] | null>) {
+  private getAllDeviceInfo(ips: string[], errorHandler: (error: any, ip: string) => Observable<SwarmDevice[] | null>, fetchAsic: boolean = true) {
     return from(ips).pipe(
       mergeMap(IP => forkJoin({
         info: this.httpClient.get(`http://${IP}/api/system/info`),
-        asic: this.httpClient.get(`http://${IP}/api/system/asic`).pipe(catchError(() => of({}))) // Return empty object if ASIC endpoint fails
+        asic: fetchAsic ? this.httpClient.get(`http://${IP}/api/system/asic`).pipe(catchError(() => of({}))) : of({})
       }).pipe(
         map(({ info, asic }) => {
-          return { IP, ...info, ...asic };
+          const existingDevice = this.swarm.find(device => device.IP === IP);
+            return {IP, ...(existingDevice ? existingDevice : {}), ...info, ...asic};
         }),
         timeout(5000),
         catchError(error => errorHandler(error, IP))
@@ -166,11 +164,9 @@ export class SwarmComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const uri = `http://${IP}`;
-
     forkJoin({
-      info: this.systemService.getInfo(uri),
-      asic: this.systemService.getAsicSettings(uri)
+      info: this.httpClient.get<any>(`http://${IP}/api/system/info`),
+      asic: this.httpClient.get<any>(`http://${IP}/api/system/asic`).pipe(catchError(() => of({}))) // Return empty object if ASIC endpoint fails
     }).subscribe(({ info, asic }) => {
       if (!info.ASICModel || !asic.ASICModel) {
         return;
@@ -189,7 +185,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
   }
 
   public restart(axe: any) {
-    this.systemService.restart(`http://${axe.IP}`).pipe(
+    this.httpClient.get(`http://${axe.IP}/api/system/restart`).pipe(
       catchError(error => {
         this.toastr.error(`Failed to restart device at ${axe.IP}`, 'Error');
         return of(null);
@@ -202,7 +198,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
   }
 
   public remove(axeOs: any) {
-    this.swarm = this.swarm.filter(axe => axe.IP != axeOs.IP);
+    this.swarm = this.swarm.filter(axe => axe.IP !== axeOs.IP);
     this.localStorageService.setObject(SWARM_DATA, this.swarm);
     this.calculateTotals();
   }
@@ -224,7 +220,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
     });
   };
 
-  public refreshList() {
+  public refreshList(fetchAsic: boolean = true) {
     if (this.scanning) {
       return;
     }
@@ -233,7 +229,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
     const ips = this.swarm.map(axeOs => axeOs.IP);
     this.isRefreshing = true;
 
-    this.getAllDeviceInfo(ips, this.refreshErrorHandler).subscribe({
+    this.getAllDeviceInfo(ips, this.refreshErrorHandler, fetchAsic).subscribe({
       next: (result) => {
         this.swarm = result;
         this.sortSwarm();
@@ -312,8 +308,13 @@ export class SwarmComponent implements OnInit, OnDestroy {
       .reduce((max, curr) => this.compareBestDiff(max, curr), '0');
   }
 
-  get getFamilies(): ISystemASIC[] {
+  get getFamilies(): SwarmDevice[] {
     return this.swarm.filter((v, i, a) =>
-      a.findIndex(({ familyName, ASICModel, asicCount }) => v.familyName === familyName && v.ASICModel === ASICModel && v.asicCount === asicCount) === i);
+      a.findIndex(({ familyName, deviceModel, ASICModel, asicCount }) =>
+        (v.familyName || v.deviceModel) === (familyName || deviceModel) &&
+        v.ASICModel === ASICModel &&
+        v.asicCount === asicCount
+      ) === i
+    );
   }
 }

--- a/main/http_server/axe-os/src/app/components/system/system.component.html
+++ b/main/http_server/axe-os/src/app/components/system/system.component.html
@@ -5,12 +5,12 @@
                 <h2>System</h2>
                 <table>
                     <tr>
-                        <td>Model:</td>
+                        <td>Device Model:</td>
                         <td>
                             <span [class]="'text-' + asic.swarmColor + '-500'">
-                                {{asic.familyName || 'Other'}}
+                                {{asic.deviceModel || 'Other'}}
                             </span>
-                            ({{asic.ASICModel}})
+                            ({{asic.asicCount > 1 ? asic.asicCount + 'x ' : ''}}{{asic.ASICModel}})
                         </td>
                     </tr>
                     <tr>

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -49,7 +49,6 @@ export class SystemService {
         sharesRejected: 0,
         sharesRejectedReasons: [],
         uptimeSeconds: 38,
-        asicCount: 1,
         smallCoreCount: 672,
         ASICModel: "BM1366",
         stratumURL: "public-pool.io",

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -169,6 +169,7 @@ export class SystemService {
       ASICModel: "BM1366",
       familyName: "Ultra",
       swarmColor: "purple",
+      asicCount: 1,
       defaultFrequency: 485,
       frequencyOptions: [400, 425, 450, 475, 485, 500, 525, 550, 575],
       defaultVoltage: 1200,

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -166,7 +166,7 @@ export class SystemService {
     // Mock data for development
     return of({
       ASICModel: "BM1366",
-      familyName: "Ultra",
+      deviceModel: "Ultra",
       swarmColor: "purple",
       asicCount: 1,
       defaultFrequency: 485,

--- a/main/http_server/axe-os/src/models/ISystemASIC.ts
+++ b/main/http_server/axe-os/src/models/ISystemASIC.ts
@@ -1,6 +1,6 @@
 export interface ISystemASIC {
   ASICModel: string;
-  familyName: string;
+  deviceModel: string;
   swarmColor: string;
   asicCount: number;
   defaultFrequency: number;

--- a/main/http_server/axe-os/src/models/ISystemASIC.ts
+++ b/main/http_server/axe-os/src/models/ISystemASIC.ts
@@ -2,6 +2,7 @@ export interface ISystemASIC {
   ASICModel: string;
   familyName: string;
   swarmColor: string;
+  asicCount: number;
   defaultFrequency: number;
   frequencyOptions: number[];
   defaultVoltage: number;

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -31,7 +31,6 @@ export interface ISystemInfo {
     sharesRejected: number,
     sharesRejectedReasons: ISharesRejectedStat[];
     uptimeSeconds: number,
-    asicCount: number,
     smallCoreCount: number,
     ASICModel: string,
     stratumURL: string,

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -665,7 +665,6 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     }
 
     cJSON_AddNumberToObject(root, "uptimeSeconds", (esp_timer_get_time() - GLOBAL_STATE->SYSTEM_MODULE.start_time) / 1000000);
-    // cJSON_AddNumberToObject(root, "asicCount", GLOBAL_STATE->DEVICE_CONFIG.family.asic_count);
     cJSON_AddNumberToObject(root, "smallCoreCount", GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count);
     cJSON_AddStringToObject(root, "ASICModel", GLOBAL_STATE->DEVICE_CONFIG.family.asic.name);
     cJSON_AddStringToObject(root, "stratumURL", stratumURL);

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -665,7 +665,7 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     }
 
     cJSON_AddNumberToObject(root, "uptimeSeconds", (esp_timer_get_time() - GLOBAL_STATE->SYSTEM_MODULE.start_time) / 1000000);
-    cJSON_AddNumberToObject(root, "asicCount", GLOBAL_STATE->DEVICE_CONFIG.family.asic_count);
+    // cJSON_AddNumberToObject(root, "asicCount", GLOBAL_STATE->DEVICE_CONFIG.family.asic_count);
     cJSON_AddNumberToObject(root, "smallCoreCount", GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count);
     cJSON_AddStringToObject(root, "ASICModel", GLOBAL_STATE->DEVICE_CONFIG.family.asic.name);
     cJSON_AddStringToObject(root, "stratumURL", stratumURL);

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -523,7 +523,7 @@ paths:
                   - ASICModel
                   - swarmColor
                   - asicCount
-                  - familyName
+                  - deviceModel
                   - defaultFrequency
                   - frequencyOptions
                   - defaultVoltage
@@ -539,9 +539,9 @@ paths:
                       - BM1397
                     examples:
                       - "BM1366"
-                  familyName:
+                  deviceModel:
                     type: string
-                    description: Board family name
+                    description: Device model name
                     examples:
                       - "Ultra"
                   swarmColor:

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -89,7 +89,6 @@ components:
       required:
         - ASICModel
         - apEnabled
-        - asicCount
         - autofanspeed
         - bestDiff
         - bestSessionDiff
@@ -150,9 +149,6 @@ components:
         apEnabled:
           type: number
           description: Whether AP mode is enabled (0=no, 1=yes)
-        asicCount:
-          type: number
-          description: Number of ASICs detected
         autofanspeed:
           type: number
           description: Automatic fan speed control (0=manual, 1=auto)
@@ -526,6 +522,7 @@ paths:
                 required:
                   - ASICModel
                   - swarmColor
+                  - asicCount
                   - familyName
                   - defaultFrequency
                   - frequencyOptions
@@ -552,6 +549,9 @@ paths:
                     description: Swarm color
                     examples:
                       - "purple"
+                  asicCount:
+                    type: number
+                    description: Number of ASICs detected
                   defaultFrequency:
                     type: number
                     description: Default frequency for the ASIC model in MHz


### PR DESCRIPTION
This is best effort backwards compatible leniency towards devices that don't have the `/api/system/asic` endpoint yet. It also points to a way to move towards a more organised api which doesn't break the whole world.

API CHANGES: 
- `/api/system/asic`
  - renamed `familyName` to `deviceModel`
  - added `asicCount`
- `/api/system/info`
  - removed `asicCount`