### PR TITLE
Clean up quick links

### DIFF
--- a/main/http_server/axe-os/src/app/services/quicklink.service.ts
+++ b/main/http_server/axe-os/src/app/services/quicklink.service.ts
@@ -20,8 +20,6 @@ export class QuicklinkService {
             return `https://web.public-pool.io/#/app/${address}`;
         } else if (stratumURL.includes('ocean.xyz')) {
             return `https://ocean.xyz/stats/${address}`;
-        } else if (stratumURL.includes('solo.d-central.tech')) {
-            return `https://solo.d-central.tech/#/app/${address}`;
         } else if (/^eusolo[46]?.ckpool.org/.test(stratumURL)) {
             return `https://eusolostats.ckpool.org/users/${address}`;
         } else if (/^solo[46]?.ckpool.org/.test(stratumURL)) {
@@ -36,6 +34,8 @@ export class QuicklinkService {
             return `https://pool.nerdminer.de/#/app/${address}`;
         } else if (stratumURL.includes('solomining.de')) {
             return `https://pool.solomining.de/#/app/${address}`;
+        } else if (stratumURL.includes('yourdevice.ch')) {
+            return `https://blitzpool.yourdevice.ch/#/app/${address}`;
         } else if (stratumURL.includes('solo.stratum.braiins.com')) {
             return `https://solo.braiins.com/stats/${address}`;
         } else if (stratumURL.includes('parasite.wtf')) {


### PR DESCRIPTION
This PR cleans up the mining pools quick links.

- [x] Removed D-Central Pool ([offline since february](https://discord.com/channels/1091348375301013615/1094385599621894184/1389338117600837744))
- [x] Added [Blitz Pool](https://blitzpool.yourdevice.ch)