### PR TITLE
Common difficulty mask function

### DIFF
--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -62,24 +62,6 @@ int ASIC_set_max_baud(GlobalState * GLOBAL_STATE)
     return 0;
 }
 
-void ASIC_set_job_difficulty_mask(GlobalState * GLOBAL_STATE, uint8_t mask)
-{
-    switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
-        case BM1397:
-            BM1397_set_job_difficulty_mask(mask);
-            break;
-        case BM1366:
-            BM1366_set_job_difficulty_mask(mask);
-            break;
-        case BM1368:
-            BM1368_set_job_difficulty_mask(mask);
-            break;
-        case BM1370:
-            BM1370_set_job_difficulty_mask(mask);
-            break;
-    }
-}
-
 void ASIC_send_work(GlobalState * GLOBAL_STATE, void * next_job)
 {
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -45,7 +45,6 @@
 #define CORE_REGISTER_CONTROL 0x3C
 #define PLL3_PARAMETER 0x68
 #define FAST_UART_CONFIGURATION 0x28
-#define TICKET_MASK 0x14
 #define MISC_CONTROL 0x18
 
 typedef struct __attribute__((__packed__))
@@ -245,8 +244,10 @@ uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty
     unsigned char init136[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0x3C, 0x80, 0x00, 0x80, 0x20, 0x19};
     _send_simple(init136, 11);
 
-    //{0x55, 0xAA, 0x51, 0x09, 0x00, 0x14, 0x00, 0x00, 0x00, 0xFF, 0x08};
-    BM1366_set_job_difficulty_mask(difficulty);
+    //set difficulty mask
+    uint8_t difficulty_mask[6];
+    get_difficulty_mask(difficulty, difficulty_mask);
+    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), difficulty_mask, 6, BM1366_SERIALTX_DEBUG);    
 
     unsigned char init138[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0x54, 0x00, 0x00, 0x00, 0x03, 0x1D};
     _send_simple(init138, 11);
@@ -315,35 +316,6 @@ int BM1366_set_max_baud(void)
     unsigned char reg28[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0x28, 0x11, 0x30, 0x02, 0x00, 0x03};
     _send_simple(reg28, 11);
     return 1000000;
-}
-
-void BM1366_set_job_difficulty_mask(int difficulty)
-{
-
-    // Default mask of 256 diff
-    unsigned char job_difficulty_mask[9] = {0x00, TICKET_MASK, 0b00000000, 0b00000000, 0b00000000, 0b11111111};
-
-    // The mask must be a power of 2 so there are no holes
-    // Correct:  {0b00000000, 0b00000000, 0b11111111, 0b11111111}
-    // Incorrect: {0b00000000, 0b00000000, 0b11100111, 0b11111111}
-    // (difficulty - 1) if it is a pow 2 then step down to second largest for more hashrate sampling
-    difficulty = _largest_power_of_two(difficulty) - 1;
-
-    // convert difficulty into char array
-    // Ex: 256 = {0b00000000, 0b00000000, 0b00000000, 0b11111111}, {0x00, 0x00, 0x00, 0xff}
-    // Ex: 512 = {0b00000000, 0b00000000, 0b00000001, 0b11111111}, {0x00, 0x00, 0x01, 0xff}
-    for (int i = 0; i < 4; i++) {
-        char value = (difficulty >> (8 * i)) & 0xFF;
-        // The char is read in backwards to the register so we need to reverse them
-        // So a mask of 512 looks like 0b00000000 00000000 00000001 1111111
-        // and not 0b00000000 00000000 10000000 1111111
-
-        job_difficulty_mask[5 - i] = _reverse_bits(value);
-    }
-
-    ESP_LOGI(TAG, "Setting job ASIC mask to %d", difficulty);
-
-    _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), job_difficulty_mask, 6, BM1366_SERIALTX_DEBUG);
 }
 
 static uint8_t id = 0;

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -45,7 +45,6 @@
 #define CORE_REGISTER_CONTROL 0x3C
 #define PLL3_PARAMETER 0x68
 #define FAST_UART_CONFIGURATION 0x28
-#define TICKET_MASK 0x14
 #define MISC_CONTROL 0x18
 
 typedef struct __attribute__((__packed__))
@@ -262,9 +261,10 @@ uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x3C, 0x80, 0x00, 0x80, 0x0C}, 6, BM1370_SERIALTX_DEBUG); //from S21Pro dump
     //_send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x3C, 0x80, 0x00, 0x80, 0x18}, 6, BM1370_SERIALTX_DEBUG); //from S21 dump
 
-    //set ticket mask
-    // unsigned char init11[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0x14, 0x00, 0x00, 0x00, 0xFF, 0x08};
-    BM1370_set_job_difficulty_mask(difficulty);
+    //set difficulty mask
+    uint8_t difficulty_mask[6];
+    get_difficulty_mask(difficulty, difficulty_mask);
+    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), difficulty_mask, 6, BM1370_SERIALTX_DEBUG);    
 
     //Analog Mux Control -- not sent on S21 Pro?
     // unsigned char init12[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0x54, 0x00, 0x00, 0x00, 0x03, 0x1D};
@@ -348,40 +348,10 @@ int BM1370_set_max_baud(void)
     return 1000000;
 }
 
-
-void BM1370_set_job_difficulty_mask(int difficulty)
-{
-    // Default mask of 256 diff
-    unsigned char job_difficulty_mask[9] = {0x00, TICKET_MASK, 0b00000000, 0b00000000, 0b00000000, 0b11111111};
-
-    // The mask must be a power of 2 so there are no holes
-    // Correct:  {0b00000000, 0b00000000, 0b11111111, 0b11111111}
-    // Incorrect: {0b00000000, 0b00000000, 0b11100111, 0b11111111}
-    // (difficulty - 1) if it is a pow 2 then step down to second largest for more hashrate sampling
-    difficulty = _largest_power_of_two(difficulty) - 1;
-
-    // convert difficulty into char array
-    // Ex: 256 = {0b00000000, 0b00000000, 0b00000000, 0b11111111}, {0x00, 0x00, 0x00, 0xff}
-    // Ex: 512 = {0b00000000, 0b00000000, 0b00000001, 0b11111111}, {0x00, 0x00, 0x01, 0xff}
-    for (int i = 0; i < 4; i++) {
-        char value = (difficulty >> (8 * i)) & 0xFF;
-        // The char is read in backwards to the register so we need to reverse them
-        // So a mask of 512 looks like 0b00000000 00000000 00000001 1111111
-        // and not 0b00000000 00000000 10000000 1111111
-
-        job_difficulty_mask[5 - i] = _reverse_bits(value);
-    }
-
-    ESP_LOGI(TAG, "Setting ASIC difficulty mask to %d", difficulty);
-
-    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), job_difficulty_mask, 6, BM1370_SERIALTX_DEBUG);
-}
-
 static uint8_t id = 0;
 
 void BM1370_send_work(void * pvParameters, bm_job * next_bm_job)
 {
-
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
     BM1370_job job;

--- a/components/asic/common.c
+++ b/components/asic/common.c
@@ -126,3 +126,22 @@ esp_err_t receive_work(uint8_t * buffer, int buffer_size)
 
     return ESP_OK;
 }
+
+void get_difficulty_mask(uint16_t difficulty, uint8_t *job_difficulty_mask)
+{
+    // The mask must be a power of 2 so there are no holes
+    // Correct:   {0b00000000, 0b00000000, 0b11111111, 0b11111111}
+    // Incorrect: {0b00000000, 0b00000000, 0b11100111, 0b11111111}
+    difficulty = _largest_power_of_two(difficulty) - 1;
+
+    job_difficulty_mask[0] = 0x00;
+    job_difficulty_mask[1] = 0x14; // TICKET_MASK
+
+    // convert difficulty into char array
+    // Ex: 256 = {0b00000000, 0b00000000, 0b00000000, 0b11111111}, {0x00, 0x00, 0x00, 0xff}
+    // Ex: 512 = {0b00000000, 0b00000000, 0b00000001, 0b11111111}, {0x00, 0x00, 0x01, 0xff}
+    job_difficulty_mask[2] = _reverse_bits((difficulty >> 24) & 0xFF);
+    job_difficulty_mask[3] = _reverse_bits((difficulty >> 16) & 0xFF);
+    job_difficulty_mask[4] = _reverse_bits((difficulty >>  8) & 0xFF);
+    job_difficulty_mask[5] = _reverse_bits( difficulty        & 0xFF);
+}

--- a/components/asic/include/asic.h
+++ b/components/asic/include/asic.h
@@ -8,7 +8,6 @@
 uint8_t ASIC_init(GlobalState * GLOBAL_STATE);
 task_result * ASIC_process_work(GlobalState * GLOBAL_STATE);
 int ASIC_set_max_baud(GlobalState * GLOBAL_STATE);
-void ASIC_set_job_difficulty_mask(GlobalState * GLOBAL_STATE, uint8_t mask);
 void ASIC_send_work(GlobalState * GLOBAL_STATE, void * next_job);
 void ASIC_set_version_mask(GlobalState * GLOBAL_STATE, uint32_t mask);
 bool ASIC_set_frequency(GlobalState * GLOBAL_STATE, float target_frequency);

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -23,7 +23,6 @@ typedef struct __attribute__((__packed__))
 
 uint8_t BM1366_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty);
 void BM1366_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
-void BM1366_set_job_difficulty_mask(int);
 void BM1366_set_version_mask(uint32_t version_mask);
 int BM1366_set_max_baud(void);
 int BM1366_set_default_baud(void);

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -23,7 +23,6 @@ typedef struct __attribute__((__packed__))
 
 uint8_t BM1368_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty);
 void BM1368_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
-void BM1368_set_job_difficulty_mask(int);
 void BM1368_set_version_mask(uint32_t version_mask);
 int BM1368_set_max_baud(void);
 int BM1368_set_default_baud(void);

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -23,7 +23,6 @@ typedef struct __attribute__((__packed__))
 
 uint8_t BM1370_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty);
 void BM1370_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
-void BM1370_set_job_difficulty_mask(int);
 void BM1370_set_version_mask(uint32_t version_mask);
 int BM1370_set_max_baud(void);
 int BM1370_set_default_baud(void);

--- a/components/asic/include/bm1397.h
+++ b/components/asic/include/bm1397.h
@@ -25,7 +25,6 @@ typedef struct __attribute__((__packed__))
 
 uint8_t BM1397_init(uint64_t frequency, uint16_t asic_count, uint16_t difficulty);
 void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
-void BM1397_set_job_difficulty_mask(int);
 void BM1397_set_version_mask(uint32_t version_mask);
 int BM1397_set_max_baud(void);
 int BM1397_set_default_baud(void);

--- a/components/asic/include/common.h
+++ b/components/asic/include/common.h
@@ -16,5 +16,6 @@ int _largest_power_of_two(int num);
 
 int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response_length);
 esp_err_t receive_work(uint8_t * buffer, int buffer_size);
+void get_difficulty_mask(uint16_t difficulty, uint8_t *job_difficulty_mask);
 
 #endif /* COMMON_H_ */

--- a/main/power/TPS546.c
+++ b/main/power/TPS546.c
@@ -729,20 +729,20 @@ float TPS546_get_vout(void)
     }
 }
 
-esp_err_t TPS546_check_status(GlobalState * global_state) {
+esp_err_t TPS546_check_status(GlobalState * GLOBAL_STATE) {
 
+    SystemModule * SYSTEM_MODULE = &GLOBAL_STATE->SYSTEM_MODULE;
     uint16_t status;
-    SystemModule * sys_module = &global_state->SYSTEM_MODULE;
 
     ESP_RETURN_ON_ERROR(smb_read_word(PMBUS_STATUS_WORD, &status), TAG, "Failed to read STATUS_WORD");
     //determine if this is a fault we care about
     if (status & (TPS546_STATUS_OFF | TPS546_STATUS_VOUT_OV | TPS546_STATUS_IOUT_OC | TPS546_STATUS_VIN_UV | TPS546_STATUS_TEMP)) {
-        if (sys_module->power_fault == 0) {
+        if (SYSTEM_MODULE->power_fault == 0) {
             ESP_RETURN_ON_ERROR(TPS546_parse_status(status), TAG, "Failed to parse STATUS_WORD");
-            sys_module->power_fault = 1;
+            SYSTEM_MODULE->power_fault = 1;
         }
     } else {
-        sys_module->power_fault = 0;
+        SYSTEM_MODULE->power_fault = 0;
     }
     return ESP_OK;
 }

--- a/main/power/TPS546.h
+++ b/main/power/TPS546.h
@@ -183,7 +183,7 @@ esp_err_t TPS546_set_vout(float volts);
 void TPS546_show_voltage_settings(void);
 void TPS546_print_status(void);
 
-esp_err_t TPS546_check_status(GlobalState * global_state);
+esp_err_t TPS546_check_status(GlobalState * GLOBAL_STATE);
 esp_err_t TPS546_clear_faults(void);
 
 const char* TPS546_get_error_message(void); //Get the current TPS error message

--- a/main/power/vcore.c
+++ b/main/power/vcore.c
@@ -84,7 +84,7 @@ esp_err_t VCORE_init(GlobalState * GLOBAL_STATE) {
     return ESP_OK;
 }
 
-esp_err_t VCORE_set_voltage(float core_voltage, GlobalState * GLOBAL_STATE)
+esp_err_t VCORE_set_voltage(GlobalState * GLOBAL_STATE, float core_voltage)
 {
     ESP_LOGI(TAG, "Set ASIC voltage = %.3fV", core_voltage);
  

--- a/main/power/vcore.h
+++ b/main/power/vcore.h
@@ -4,7 +4,7 @@
 #include "global_state.h"
 
 esp_err_t VCORE_init(GlobalState * GLOBAL_STATE);
-esp_err_t VCORE_set_voltage(float core_voltage, GlobalState * GLOBAL_STATE);
+esp_err_t VCORE_set_voltage(GlobalState * GLOBAL_STATE, float core_voltage);
 int16_t VCORE_get_voltage_mv(GlobalState * GLOBAL_STATE);
 esp_err_t VCORE_check_fault(GlobalState * GLOBAL_STATE);
 const char* VCORE_get_fault_string(GlobalState * GLOBAL_STATE);

--- a/main/system.c
+++ b/main/system.c
@@ -102,9 +102,9 @@ esp_err_t SYSTEM_init_peripherals(GlobalState * GLOBAL_STATE) {
 
     // Initialize the core voltage regulator
     ESP_RETURN_ON_ERROR(VCORE_init(GLOBAL_STATE), TAG, "VCORE init failed!");
-    ESP_RETURN_ON_ERROR(VCORE_set_voltage(nvs_config_get_u16(NVS_CONFIG_ASIC_VOLTAGE, CONFIG_ASIC_VOLTAGE) / 1000.0, GLOBAL_STATE), TAG, "VCORE set voltage failed!");
+    ESP_RETURN_ON_ERROR(VCORE_set_voltage(GLOBAL_STATE, nvs_config_get_u16(NVS_CONFIG_ASIC_VOLTAGE, CONFIG_ASIC_VOLTAGE) / 1000.0), TAG, "VCORE set voltage failed!");
 
-    ESP_RETURN_ON_ERROR(Thermal_init(GLOBAL_STATE->DEVICE_CONFIG), TAG, "Thermal init failed!");
+    ESP_RETURN_ON_ERROR(Thermal_init(&GLOBAL_STATE->DEVICE_CONFIG), TAG, "Thermal init failed!");
 
     vTaskDelay(500 / portTICK_PERIOD_MS);
 

--- a/main/thermal/thermal.c
+++ b/main/thermal/thermal.c
@@ -4,21 +4,21 @@
 
 static const char * TAG = "thermal";
 
-esp_err_t Thermal_init(DeviceConfig device_config)
+esp_err_t Thermal_init(DeviceConfig * DEVICE_CONFIG)
 {
-    if (device_config.EMC2101) {
-        ESP_LOGI(TAG, "Initializing EMC2101 (Temperature offset: %dC)", device_config.emc_temp_offset);
+    if (DEVICE_CONFIG->EMC2101) {
+        ESP_LOGI(TAG, "Initializing EMC2101 (Temperature offset: %dC)", DEVICE_CONFIG->emc_temp_offset);
         esp_err_t res = EMC2101_init();
         // TODO: Improve this check.
-        if (device_config.emc_ideality_factor != 0x00) {
-            ESP_LOGI(TAG, "EMC2101 configuration: Ideality Factor: %02x, Beta Compensation: %02x", device_config.emc_ideality_factor, device_config.emc_beta_compensation);
-            EMC2101_set_ideality_factor(device_config.emc_ideality_factor);
-            EMC2101_set_beta_compensation(device_config.emc_beta_compensation);
+        if (DEVICE_CONFIG->emc_ideality_factor != 0x00) {
+            ESP_LOGI(TAG, "EMC2101 configuration: Ideality Factor: %02x, Beta Compensation: %02x", DEVICE_CONFIG->emc_ideality_factor, DEVICE_CONFIG->emc_beta_compensation);
+            EMC2101_set_ideality_factor(DEVICE_CONFIG->emc_ideality_factor);
+            EMC2101_set_beta_compensation(DEVICE_CONFIG->emc_beta_compensation);
         }
         return res;
     }
-    if (device_config.EMC2103) {
-        ESP_LOGI(TAG, "Initializing EMC2103 (Temperature offset: %dC)", device_config.emc_temp_offset);
+    if (DEVICE_CONFIG->EMC2103) {
+        ESP_LOGI(TAG, "Initializing EMC2103 (Temperature offset: %dC)", DEVICE_CONFIG->emc_temp_offset);
         return EMC2103_init();
     }
 
@@ -26,23 +26,23 @@ esp_err_t Thermal_init(DeviceConfig device_config)
 }
 
 //percent is a float between 0.0 and 1.0
-esp_err_t Thermal_set_fan_percent(DeviceConfig device_config, float percent)
+esp_err_t Thermal_set_fan_percent(DeviceConfig * DEVICE_CONFIG, float percent)
 {
-    if (device_config.EMC2101) {
+    if (DEVICE_CONFIG->EMC2101) {
         EMC2101_set_fan_speed(percent);
     }
-    if (device_config.EMC2103) {
+    if (DEVICE_CONFIG->EMC2103) {
         EMC2103_set_fan_speed(percent);
     }
     return ESP_OK;
 }
 
-uint16_t Thermal_get_fan_speed(DeviceConfig device_config) 
+uint16_t Thermal_get_fan_speed(DeviceConfig * DEVICE_CONFIG) 
 {
-    if (device_config.EMC2101) {
+    if (DEVICE_CONFIG->EMC2101) {
         return EMC2101_get_fan_speed();
     }
-    if (device_config.EMC2103) {
+    if (DEVICE_CONFIG->EMC2103) {
         return EMC2103_get_fan_speed();
     }
     return 0;

--- a/main/thermal/thermal.h
+++ b/main/thermal/thermal.h
@@ -8,9 +8,9 @@
 #include "EMC2103.h"
 #include "global_state.h"
 
-esp_err_t Thermal_init(DeviceConfig device_config);
-esp_err_t Thermal_set_fan_percent(DeviceConfig device_config, float percent);
-uint16_t Thermal_get_fan_speed(DeviceConfig device_config);
+esp_err_t Thermal_init(DeviceConfig * DEVICE_CONFIG);
+esp_err_t Thermal_set_fan_percent(DeviceConfig * DEVICE_CONFIG, float percent);
+uint16_t Thermal_get_fan_speed(DeviceConfig * DEVICE_CONFIG);
 
 float Thermal_get_chip_temp(GlobalState * GLOBAL_STATE);
 


### PR DESCRIPTION
Extracted some cleanups from #1098

Extract `BM##_set_job_difficulty_mask` into a single function
Set difficulty in self-test before ASIC_init to eliminate `ASIC_set_job_difficulty_mask`
Pass `DEVICE_CONFIG` by pointer instead of by value in `thermal.c`
Fixed some capitalisation of `GLOBAL_STATE` and some others 