### PR TITLE
Add workflow for building and publishing our devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,23 +1,43 @@
-FROM espressif/idf:v5.4.1
+# Stage 1: Base image with ESP-IDF and common dependencies
+FROM espressif/idf:v5.4.1 AS base
 
 ARG DEBIAN_FRONTEND=nointeractive
 
+# Install common dependencies
 RUN apt-get update \
   && apt install -y -q \
   cmake \
   git \
   hwdata \
-  libglib2.0-0 \
+  libglib2.0-dev \
   libnuma1 \
-  libpixman-1-0 \
+  libpixman-1-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Node.js and npm (v20 is required)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+  && apt-get install -y nodejs
+
+# Common environment setup
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+RUN echo "source /opt/esp/idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
+
+ENTRYPOINT ["/opt/esp/entrypoint.sh"]
+CMD ["/bin/bash"]
+
+# Stage 2: QEMU tools
+FROM base AS qemu
+
+# Install QEMU dependencies
+RUN apt-get update \
+  && apt install -y -q \
   linux-tools-virtual \
   && rm -rf /var/lib/apt/lists/*
 
+# Set up usbip for QEMU USB/IP functionality
 RUN update-alternatives --install /usr/local/bin/usbip usbip `ls /usr/lib/linux-tools/*/usbip | tail -n1` 20
-
-# Node.js and npm (v20 is required)
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-RUN apt-get update && apt-get install -y nodejs
 
 # QEMU
 ENV QEMU_REL=esp-develop-20220919
@@ -25,18 +45,9 @@ ENV QEMU_SHA256=f6565d3f0d1e463a63a7f81aec94cce62df662bd42fc7606de4b4418ed55f870
 ENV QEMU_DIST=qemu-${QEMU_REL}.tar.bz2
 ENV QEMU_URL=https://github.com/espressif/qemu/releases/download/${QEMU_REL}/${QEMU_DIST}
 
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
-
 RUN wget --no-verbose ${QEMU_URL} \
   && echo "${QEMU_SHA256} *${QEMU_DIST}" | sha256sum --check --strict - \
   && tar -xf $QEMU_DIST -C /opt \
   && rm ${QEMU_DIST}
 
 ENV PATH=/opt/qemu/bin:${PATH}
-
-RUN echo "source /opt/esp/idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
-
-ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
-
-CMD ["/bin/bash"]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,81 @@
+name: Build and Publish DevContainers
+
+on:
+  push:
+    paths:
+      - '.devcontainer/**'
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    outputs:
+      base_tags: ${{ steps.meta.outputs.tags }}
+      base_labels: ${{ steps.meta.outputs.labels }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for base image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/devcontainer
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=sha,format=long,prefix=sha-
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: .devcontainer/Dockerfile
+          target: base
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-qemu:
+    needs: build-base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for QEMU image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/devcontainer-qemu
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=sha,format=long,prefix=sha-
+
+      - name: Build and push QEMU image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: .devcontainer/Dockerfile
+          target: qemu
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Splits the devcontainer Dockerfile into 2 stages, one for the base esp-idf tooling and a second that includes qemu support. This reduces the size of the base Dockerfile while keeping our devcontainer functionality.

Each stage is published as a container to ghcr.