### PR TITLE
Split unittest workflow up it can work with pull requests

### DIFF
--- a/.github/workflows/unittest-results.yml
+++ b/.github/workflows/unittest-results.yml
@@ -1,0 +1,45 @@
+name: Publish Test Results
+
+on:
+  workflow_run:
+    workflows: ["Unit Test"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+      issues: read
+      actions: read
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/event-file/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -38,3 +38,12 @@ jobs:
         with:
           name: test-results
           path: report.xml
+
+      - name: Check for test failures
+        if: always()
+        run: |
+          FAILURES=$(grep -oP 'failures="\K[0-9]+' report.xml || echo 0)
+          if [ "$FAILURES" -gt 0 ]; then
+            echo "::error ::Detected $FAILURES test failures."
+            exit 1
+          fi

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -2,33 +2,39 @@ name: Unit Test
 on: [push, pull_request]
 
 permissions:
-  checks: write
-  pull-requests: write
   contents: read
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
-    - name: esp-idf build
-      uses: espressif/esp-idf-ci-action@v1
-      with:
-        esp_idf_version: v5.4.2
-        target: esp32s3
-        command: GITHUB_ACTIONS="true" idf.py build
-        path: 'test-ci'
-    - name: Run tests and show result
-      uses: bitaxeorg/esp32-qemu-test-action@main
-      with:
-        path: 'test-ci'
-    - name: Inspect log
-      run: cat report.xml
-    - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1
-      if: always()
-      with:
-          files: report.xml
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: esp-idf build
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.4.2
+          target: esp32s3
+          command: GITHUB_ACTIONS="true" idf.py build
+          path: 'test-ci'
+
+      - name: Run tests
+        uses: bitaxeorg/esp32-qemu-test-action@main
+        with:
+          path: 'test-ci'
+
+      - name: Upload event file
+        uses: actions/upload-artifact@v4
+        with:
+          name: event-file
+          path: ${{ github.event_path }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: report.xml


### PR DESCRIPTION
Due to the limited permissions on pull requests, the unittest publisher should be run in its own workflow.

https://github.com/EnricoMi/publish-unit-test-result-action/tree/v2.0.0?tab=readme-ov-file#support-fork-repositories-and-dependabot-branches

https://github.com/bitaxeorg/ESP-Miner/issues/1109