### PR TITLE
Improved formatting of release notes

### DIFF
--- a/main/http_server/axe-os/src/app/components/update/update.component.ts
+++ b/main/http_server/axe-os/src/app/components/update/update.component.ts
@@ -126,8 +126,11 @@ export class UpdateComponent {
       .replace(/^#{1,6}\s+(.+)$/gim, '<h4 class="mt-2">$1</h4>') // Headlines
       .replace(/\*\*(.+?)\*\*|__(.+?)__/gim, '<b>$1</b>') // Bold text
       .replace(/\*(.+?)\*|_(.+?)_/gim, '<i>$1</i>') // Italic text
-      .replace(/\[(.*?)\]\((.*?)\s?(?:"(.*?)")?\)/gm, '<a href="$2" class="underline text-white" target="_blank">$1</a>') // Links
+      .replace(/\[(.*?)\]\((.*?)\s?(?:"(.*?)")?\)/gm, '<a href="$2" class="underline text-white" target="_blank">$1</a>') // Markdown links
+      .replace(/(https?:\/\/github\.com\/.+\/(.+[^\s])+)/gim, (match, p1, p2) => `<a href="${p1}" target="_blank">${match.includes('/pull/') ? '#' : ''}${p2}</a>`) // Regular links
+      .replace(/@([^\s]+)/gim, ' <a href="https://github.com/$1" target="_blank">@$1</a> ') // Username links
       .replace(/^\s*[-+*]\s?(.+)$/gim, '<li>$1</li>') // Unordered list
+      .replace(/`([^`]+)`/gim, '<code class="surface-100">$1</code>') // Code
       .replace(/\r\n\r\n/gim, '<br>'); // Breaks
 
     return toHTML.trim();


### PR DESCRIPTION
The PR adds some regular expression conditions that make usernames & non-Markdown links clickable and the release notes more readable.

**Before**
<img width="678" alt="Screenshot 2025-07-03 at 09 07 14" src="https://github.com/user-attachments/assets/41c9de31-0109-42c6-92b0-2dc538c805eb" />

**After**
<img width="692" alt="Screenshot 2025-07-03 at 09 06 48" src="https://github.com/user-attachments/assets/baf84584-ab34-4c6a-8cb4-3c3f72e18802" />
