### PR TITLE
Upgrade from idf 5.4.1 to 5.4.2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf:v5.4.1
+FROM espressif/idf:v5.4.2
 
 ARG DEBIAN_FRONTEND=nointeractive
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: esp-idf build
       uses: espressif/esp-idf-ci-action@v1
       with:
-        esp_idf_version: v5.4.1
+        esp_idf_version: v5.4.2
         target: esp32s3
         command: GITHUB_ACTIONS="true" idf.py build
         path: '.'

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -29,7 +29,7 @@ jobs:
     - name: esp-idf build
       uses: espressif/esp-idf-ci-action@v1
       with:
-        esp_idf_version: v5.4.1
+        esp_idf_version: v5.4.2
         target: esp32s3
         command: GITHUB_ACTIONS="true" idf.py build
         path: '.'

--- a/.github/workflows/release-factory-beta.yml
+++ b/.github/workflows/release-factory-beta.yml
@@ -34,14 +34,14 @@ jobs:
       - name: esp-idf build
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: v5.4.1
+          esp_idf_version: v5.4.2
           target: esp32s3
           command: GITHUB_ACTIONS="true" idf.py build
           path: '.'
       - name: "esp-idf build factory config for ${{ matrix.build_type }}"
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: v5.4.1
+          esp_idf_version: v5.4.2
           target: esp32s3
           command: /opt/esp/idf/components/nvs_flash/nvs_partition_generator/nvs_partition_gen.py generate config-${{ matrix.build_type }}.cvs config.bin 0x6000
           path: '.'

--- a/.github/workflows/release-factory.yml
+++ b/.github/workflows/release-factory.yml
@@ -34,14 +34,14 @@ jobs:
       - name: esp-idf build
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: v5.4.1
+          esp_idf_version: v5.4.2
           target: esp32s3
           command: GITHUB_ACTIONS="true" idf.py build
           path: '.'
       - name: "esp-idf build factory config for ${{ matrix.build_type }}"
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: v5.4.1
+          esp_idf_version: v5.4.2
           target: esp32s3
           command: /opt/esp/idf/components/nvs_flash/nvs_partition_generator/nvs_partition_gen.py generate config-${{ matrix.build_type }}.cvs config.bin 0x6000
           path: '.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     - name: esp-idf build
       uses: espressif/esp-idf-ci-action@v1
       with:
-        esp_idf_version: v5.4.1
+        esp_idf_version: v5.4.2
         target: esp32s3
         command: GITHUB_ACTIONS="true" idf.py build
         path: '.'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -17,7 +17,7 @@ jobs:
     - name: esp-idf build
       uses: espressif/esp-idf-ci-action@v1
       with:
-        esp_idf_version: v5.4.1
+        esp_idf_version: v5.4.2
         target: esp32s3
         command: GITHUB_ACTIONS="true" idf.py build
         path: 'test-ci'


### PR DESCRIPTION
Upgraded ESP-IDF from v5.4.1 to v5.4.2 to benefit from stability improvements, bug fixes, and performance enhancements. Notably, fixes in Wi-Fi (e.g. memory leaks, stability under stress), SPI improvements, and FreeRTOS task handling may positively impact miner reliability and efficiency under sustained load.

https://github.com/espressif/esp-idf/releases/tag/v5.4.2