### PR TITLE
Fix last parsed request id not being updated

### DIFF
--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -162,8 +162,8 @@ void STRATUM_V1_parse(StratumApiV1Message * message, const char * stratum_json)
     int64_t parsed_id = -1;
     if (id_json != NULL && cJSON_IsNumber(id_json)) {
         parsed_id = id_json->valueint;
-        last_parsed_request_id = parsed_id;
     }
+    last_parsed_request_id = parsed_id;
     message->message_id = parsed_id;
 
     cJSON * method_json = cJSON_GetObjectItem(json, "method");


### PR DESCRIPTION
Previously, last_parsed_request_id was not updated when null requests were received. This led to stale or invalid values being used in timing calculations, sometimes resulting in extremely large and incorrect numbers. This fix ensures last_parsed_request_id is updated consistently to maintain correct request timing behavior.

```
₿ (96259630) stratum_task: Stratum response time: 34346352.92 ms
₿ (96259631) stratum_api: rx: {"params":[".....",false],"id":null,"method":"mining.notify"}
```