### PR TITLE
Remove fallback code for 7xx board versions

### DIFF
--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -338,7 +338,6 @@ export class SwarmComponent implements OnInit, OnDestroy {
       if (data.boardVersion[0] == "3") return "UltraHex";
       if (data.boardVersion[0] == "4") return "Supra";
       if (data.boardVersion[0] == "6") return "Gamma";
-      if (data.boardVersion[0] == "7") return "GammaHex";
       if (data.boardVersion[0] == "8") return "GammaTurbo";
     }
     return 'Other';
@@ -351,7 +350,6 @@ export class SwarmComponent implements OnInit, OnDestroy {
       case 'Supra':      return 'blue';
       case 'UltraHex':   return 'orange';
       case 'Gamma':      return 'green';
-      case 'GammaHex':   return 'lime'; // New color?
       case 'GammaTurbo': return 'cyan'; 
       default:           return 'gray';
     }


### PR DESCRIPTION
The fallback for the 7xx board versions should not have been added, as these are outside the OSMU repositories. They will fallback to 'Other', unless they add a `deviceModel` field.

Fixes #1119