### PR TITLE
Add mDNS hostname advertisement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
       with:
         esp_idf_version: v5.4.2
         target: esp32s3
-        command: GITHUB_ACTIONS="true" idf.py build
+        command: |
+          GITHUB_ACTIONS="true" idf.py add-dependency "espressif/mdns^1.8.2"
+          GITHUB_ACTIONS="true" idf.py build
         path: '.'
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -19,7 +19,9 @@ jobs:
       with:
         esp_idf_version: v5.4.2
         target: esp32s3
-        command: GITHUB_ACTIONS="true" idf.py build
+        command: |
+          GITHUB_ACTIONS="true" idf.py add-dependency "espressif/mdns^1.8.2"
+          GITHUB_ACTIONS="true" idf.py build
         path: 'test-ci'
     - name: Run tests and show result
       uses: bitaxeorg/esp32-qemu-test-action@main

--- a/components/connect/CMakeLists.txt
+++ b/components/connect/CMakeLists.txt
@@ -13,4 +13,5 @@ REQUIRES
     "esp_wifi"
     "esp_event"
     "stratum"
+    "mdns"
 )

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -64,6 +64,7 @@ PRIV_REQUIRES
     "spiffs"
     "vfs"
     "esp_driver_i2c"
+    "mdns"
 
 EMBED_FILES "http_server/recovery_page.html"
 )

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,8 +1,9 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  lvgl/lvgl: "9.3.0"
-  espressif/esp_lvgl_port: "^2.6.0"
-  esp_lcd_sh1107: "^1"  
+  lvgl/lvgl: 9.3.0
+  espressif/esp_lvgl_port: ^2.6.0
+  esp_lcd_sh1107: ^1
   ## Required IDF version
   idf:
-    version: ">=5.4.0"
+    version: '>=5.4.0'
+  espressif/mdns: ^1.8.2


### PR DESCRIPTION
This PR adds Espressif's mDNS component, enabling consistent hostname-based access of Bitaxe devices in varying network topologies.