### PR TITLE
Introduction Sensitive Data Service

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -272,10 +272,10 @@
                         <span>User</span>
                     </div>
 
-                    <span class="start">
+                    <span class="start" sensitive-content>
                         {{ activePoolUser.substring(0, activePoolUser.length - 20) }}
                     </span>
-                    <span class="end">
+                    <span class="end" sensitive-content>
                         {{ activePoolUser.substring(activePoolUser.length - 20) }}
                     </span>
                 </div>

--- a/main/http_server/axe-os/src/app/components/system/system.component.html
+++ b/main/http_server/axe-os/src/app/components/system/system.component.html
@@ -38,7 +38,7 @@
                     </tr>
                     <tr>
                         <td>MAC Address:</td>
-                        <td>{{info.macAddr}}</td>
+                        <td sensitive-content>{{info.macAddr}}</td>
                     </tr>
                     <tr>
                         <td>Free Heap Memory:</td>

--- a/main/http_server/axe-os/src/app/layout/app.layout.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.layout.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, Renderer2, ViewChild } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { filter, Subscription } from 'rxjs';
+import { filter, Subscription, Subject, takeUntil } from 'rxjs';
+import { SensitiveData } from 'src/app/services/sensitive-data.service';
 import { LayoutService } from "./service/app.layout.service";
 import { AppSidebarComponent } from "./app.sidebar.component";
 import { AppTopBarComponent } from './app.topbar.component';
@@ -10,6 +11,9 @@ import { AppTopBarComponent } from './app.topbar.component';
     templateUrl: './app.layout.component.html'
 })
 export class AppLayoutComponent implements OnDestroy {
+    private destroy$ = new Subject<void>();
+
+    public sensitiveDataHidden: boolean = false;
 
     overlayMenuOpenSubscription: Subscription;
 
@@ -21,13 +25,18 @@ export class AppLayoutComponent implements OnDestroy {
 
     @ViewChild(AppTopBarComponent) appTopbar!: AppTopBarComponent;
 
-    constructor(public layoutService: LayoutService, public renderer: Renderer2, public router: Router) {
+    constructor(
+      public layoutService: LayoutService,
+      public renderer: Renderer2,
+      public router: Router,
+      private sensitiveData: SensitiveData,
+    ) {
         this.overlayMenuOpenSubscription = this.layoutService.overlayOpen$.subscribe(() => {
             if (!this.menuOutsideClickListener) {
                 this.menuOutsideClickListener = this.renderer.listen('document', 'click', event => {
-                    const isOutsideClicked = !(this.appSidebar.el.nativeElement.isSameNode(event.target) || this.appSidebar.el.nativeElement.contains(event.target) 
+                    const isOutsideClicked = !(this.appSidebar.el.nativeElement.isSameNode(event.target) || this.appSidebar.el.nativeElement.contains(event.target)
                         || this.appTopbar.menuButton.nativeElement.isSameNode(event.target) || this.appTopbar.menuButton.nativeElement.contains(event.target));
-                    
+
                     if (isOutsideClicked) {
                         this.hideMenu();
                     }
@@ -105,7 +114,8 @@ export class AppLayoutComponent implements OnDestroy {
             'layout-overlay-active': this.layoutService.state.overlayMenuActive,
             'layout-mobile-active': this.layoutService.state.staticMenuMobileActive,
             'p-input-filled': this.layoutService.config().inputStyle === 'filled',
-            'p-ripple-disabled': !this.layoutService.config().ripple
+            'p-ripple-disabled': !this.layoutService.config().ripple,
+            'sensitive-content-hidden': this.sensitiveDataHidden,
         }
     }
 
@@ -113,7 +123,18 @@ export class AppLayoutComponent implements OnDestroy {
         return this.router.url.startsWith('/ap');
     }
 
+    ngOnInit() {
+        this.sensitiveData.hidden
+          .pipe(takeUntil(this.destroy$))
+          .subscribe((hidden: boolean) => {
+              this.sensitiveDataHidden = hidden;
+          });
+    }
+
     ngOnDestroy() {
+        this.destroy$.next();
+        this.destroy$.complete();
+
         if (this.overlayMenuOpenSubscription) {
             this.overlayMenuOpenSubscription.unsubscribe();
         }

--- a/main/http_server/axe-os/src/app/layout/app.menu.component.html
+++ b/main/http_server/axe-os/src/app/layout/app.menu.component.html
@@ -1,6 +1,11 @@
 <ng-container *ngIf="isMobile()">
     <ul *ngIf="info$ | async as info" class="flex lg:hidden list-none absolute flex p-0 mt-0 mr-4 mt-3 gap-4 right-0 top-0">
         <li>
+            <a class="block text-white" (click)="toggleSensitiveData()">
+                <i class="pi pi-{{sensitiveDataHidden ? 'eye-slash' : 'eye'}} block" style="font-size: 1.4rem;"></i>
+            </a>
+        </li>
+        <li>
             <a routerLink="network" class="block">
                 <figure class="wifi-icon"
                     [ngClass]="{

--- a/main/http_server/axe-os/src/app/layout/app.topbar.component.html
+++ b/main/http_server/axe-os/src/app/layout/app.topbar.component.html
@@ -24,6 +24,15 @@
 
         <ul *ngIf="isDesktop()" class="hidden lg:flex ml-auto list-none p-0 gap-4">
             <li>
+                <a class="block py-2 text-white cursor-pointer"
+                    tooltipPosition="bottom"
+                    pTooltip="Sensitive data {{sensitiveDataHidden ? 'hidden' : 'visible'}}"
+                    (click)="toggleSensitiveData()"
+                >
+                    <i class="pi pi-{{sensitiveDataHidden ? 'eye-slash' : 'eye'}} block" style="font-size: 1.4rem;"></i>
+                </a>
+            </li>
+            <li>
                 <a routerLink="network"
                     class="block py-2"
                     tooltipPosition="bottom"

--- a/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
@@ -1,20 +1,22 @@
-import { Component, ElementRef, Input, ViewChild } from '@angular/core';
-import { Observable, shareReplay } from 'rxjs';
+import { Component, ElementRef, Input, ViewChild, OnInit, OnDestroy } from '@angular/core';
+import { Observable, shareReplay, Subject, takeUntil } from 'rxjs';
 import { ToastrService } from 'ngx-toastr';
 import { SystemService } from 'src/app/services/system.service';
-import { ISystemInfo } from 'src/models/ISystemInfo';
 import { LayoutService } from './service/app.layout.service';
+import { SensitiveData } from 'src/app/services/sensitive-data.service';
+import { ISystemInfo } from 'src/models/ISystemInfo';
 import { MenuItem } from 'primeng/api';
 
 @Component({
   selector: 'app-topbar',
   templateUrl: './app.topbar.component.html'
 })
-export class AppTopBarComponent {
+export class AppTopBarComponent implements OnInit, OnDestroy {
+  private destroy$ = new Subject<void>();
 
   public info$!: Observable<ISystemInfo>;
-
-  items!: MenuItem[];
+  public sensitiveDataHidden: boolean = false;
+  public items!: MenuItem[];
 
   @Input() isAPMode: boolean = false;
 
@@ -28,13 +30,33 @@ export class AppTopBarComponent {
     public layoutService: LayoutService,
     private systemService: SystemService,
     private toastr: ToastrService,
+    private sensitiveData: SensitiveData,
   ) {
     this.info$ = this.systemService.getInfo().pipe(shareReplay({refCount: true, bufferSize: 1}))
   }
 
+  ngOnInit() {
+    this.sensitiveData.hidden
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((hidden: boolean) => {
+        this.sensitiveDataHidden = hidden;
+      });
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  public toggleSensitiveData() {
+    this.sensitiveData.toggle();
+  }
+
   public restart() {
-    this.systemService.restart().subscribe(() => {});
-    this.toastr.success('Success!', 'Bitaxe restarted');
+    this.systemService.restart().subscribe({
+      next: () => this.toastr.success('Device restarted'),
+      error: () => this.toastr.error('Restart failed')
+    });
   }
 
   public isDesktop() {

--- a/main/http_server/axe-os/src/app/layout/styles/layout/_utils.scss
+++ b/main/http_server/axe-os/src/app/layout/styles/layout/_utils.scss
@@ -75,3 +75,14 @@
         opacity: 1;
     }
 }
+
+.sensitive-content-hidden {
+    [sensitive-content] {
+        font-size: 0;
+
+        &::before {
+            content: '•••••';
+            font-size: $scale;
+        }
+    }
+}

--- a/main/http_server/axe-os/src/app/services/sensitive-data.service.ts
+++ b/main/http_server/axe-os/src/app/services/sensitive-data.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { LocalStorageService } from 'src/app/local-storage.service';
+
+const SENSITIVE_DATA_HIDDEN = 'SENSITIVE_DATA_HIDDEN';
+
+@Injectable({ providedIn: 'root' })
+export class SensitiveData {
+  private hidden$: BehaviorSubject<boolean>;
+
+  constructor(private localStorageService: LocalStorageService) {
+    const storedState = this.localStorageService.getBool(SENSITIVE_DATA_HIDDEN);
+
+    this.hidden$ = new BehaviorSubject<boolean>(storedState !== false);
+  }
+
+  get hidden() {
+    return this.hidden$.asObservable();
+  }
+
+  toggle() {
+    const newState = !this.hidden$.value;
+
+    this.hidden$.next(newState);
+    this.localStorageService.setBool(SENSITIVE_DATA_HIDDEN, newState);
+  }
+}


### PR DESCRIPTION
@mutatrum [had an idea](https://github.com/bitaxeorg/ESP-Miner/pull/1104#issuecomment-3024607392) to introduce a data privacy feature that would hide sensitive data, such as pool user and MAC address. This PR adds a toggle that controls the visibility of sensitive data.

The switch is located in the top bar and can be accessed from each page. On mobile devices, the icon is located in the menu alongside the other icons.

By default, sensitive data is displayed. Sensitive data can be hidden by clicking the eye icon. This setting is saved, so the data remains hidden when the page is reloaded. This allows users to permanently protect their data.

To mark a data field as sensitive, just add the `sensitive-content` attribute to the HTML element. This allows other fields to be declared sensitive at any time.

The following fields are declared as sensitive:
- Pool User
- MAC address

If you would like to mark additional data as sensitive, I can include this in this pull request.

**Desktop**


https://github.com/user-attachments/assets/73ef8d17-1d42-4a35-8d32-75f882b0547e



**Mobile**
<img width="410" alt="Screenshot 2025-07-06 at 10 55 41" src="https://github.com/user-attachments/assets/a26d5dcb-2f9e-425e-bc36-193feca8f202" />
