### PR TITLE
Show/Hide pool advanced options

### DIFF
--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -34,24 +34,35 @@
                             [type]="showPassword[pool] ? 'text' : 'password'" />
                     </div>
                 </div>
-                <div class="field grid p-fluid">
-                    <label [htmlFor]="pool + 'SuggestedDifficulty'" class="col-12 md:col-2 md:mb-0">Suggested Difficulty</label>
-                    <div class="col-12 md:col-10">
-                        <input pInputText [id]="pool + 'SuggestedDifficulty'" [formControlName]="pool + 'SuggestedDifficulty'" type="number" />
+
+                <fieldset class="m-0 p-0 mt-4 border-200 border-bottom-none border-left-none border-right-none">
+                    <legend class="p-0 pr-3">
+                        <label class="cursor-pointer">
+                            <input type="checkbox" hidden (click)="showAdvancedOptions = !showAdvancedOptions">
+                            <i class="pi pi-angle-{{showAdvancedOptions ? 'down' : 'right'}} text-sm -ml-1 mr-1"></i>
+                            {{showAdvancedOptions ? 'Hide' : 'Show'}} Advanced Options
+                        </label>
+                    </legend>
+
+                    <div *ngIf="showAdvancedOptions" class="field grid p-fluid mt-4">
+                        <label [htmlFor]="pool + 'SuggestedDifficulty'" class="col-12 md:col-2 md:mb-0">Suggested Difficulty</label>
+                        <div class="col-12 md:col-10">
+                            <input pInputText [id]="pool + 'SuggestedDifficulty'" [formControlName]="pool + 'SuggestedDifficulty'" type="number" />
+                        </div>
                     </div>
-                </div>
-                <div class="field-checkbox grid mb-0">
-                    <div class="col-1 md:col-10 md:flex-order-2">
-                        <p-checkbox [name]="pool + 'ExtranonceSubscribe'" [inputId]="pool + 'ExtranonceSubscribe'" [formControlName]="pool + 'ExtranonceSubscribe'"
-                            [binary]="true"></p-checkbox>
+                    <div *ngIf="showAdvancedOptions" class="field-checkbox grid mb-0">
+                        <div class="col-1 md:col-10 md:flex-order-2">
+                            <p-checkbox [name]="pool + 'ExtranonceSubscribe'" [inputId]="pool + 'ExtranonceSubscribe'" [formControlName]="pool + 'ExtranonceSubscribe'"
+                                [binary]="true"></p-checkbox>
+                        </div>
+                        <label [htmlFor]="pool + 'ExtranonceSubscribe'" class="col-11 m-0 pl-3 md:col-2 md:flex-order-1 md:p-2">
+                            Enable Extranonce <span class="white-space-nowrap">
+                                Subscribe
+                                <i class="pi pi-info-circle text-xs px-1" pTooltip="Required by some pools, check the pool documentation."></i>
+                            </span>
+                        </label>
                     </div>
-                    <label [htmlFor]="pool + 'ExtranonceSubscribe'" class="col-11 m-0 pl-3 md:col-2 md:flex-order-1 md:p-2">
-                        Enable Extranonce <span class="white-space-nowrap">
-                            Subscribe
-                            <i class="pi pi-info-circle text-xs px-1" pTooltip="Required by some pools, check the pool documentation."></i>
-                        </span>
-                    </label>
-                </div>
+                </fieldset>
             </div>
         </ng-container>
 

--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -45,7 +45,9 @@
                     </legend>
 
                     <div *ngIf="showAdvancedOptions[pool]" class="field grid p-fluid mt-4">
-                        <label [htmlFor]="pool + 'SuggestedDifficulty'" class="col-12 md:col-2 md:mb-0">Suggested Difficulty</label>
+                        <label [htmlFor]="pool + 'SuggestedDifficulty'" class="col-12 md:col-2 md:mb-0">Suggested Difficulty
+                            <i class="pi pi-info-circle text-xs px-1" pTooltip="The minimum difficulty at which you device submits a share."></i>
+                        </label>
                         <div class="col-12 md:col-10">
                             <input pInputText [id]="pool + 'SuggestedDifficulty'" [formControlName]="pool + 'SuggestedDifficulty'" type="number" />
                         </div>

--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -38,19 +38,19 @@
                 <fieldset class="m-0 p-0 mt-4 border-200 border-bottom-none border-left-none border-right-none">
                     <legend class="p-0 pr-3">
                         <label class="cursor-pointer">
-                            <input type="checkbox" hidden (click)="showAdvancedOptions = !showAdvancedOptions">
-                            <i class="pi pi-angle-{{showAdvancedOptions ? 'down' : 'right'}} text-sm -ml-1 mr-1"></i>
-                            {{showAdvancedOptions ? 'Hide' : 'Show'}} Advanced Options
+                            <input type="checkbox" hidden (click)="showAdvancedOptions[pool] = !showAdvancedOptions[pool]">
+                            <i class="pi pi-angle-{{showAdvancedOptions[pool] ? 'down' : 'right'}} text-sm -ml-1 mr-1"></i>
+                            {{showAdvancedOptions[pool] ? 'Hide' : 'Show'}} Advanced Options
                         </label>
                     </legend>
 
-                    <div *ngIf="showAdvancedOptions" class="field grid p-fluid mt-4">
+                    <div *ngIf="showAdvancedOptions[pool]" class="field grid p-fluid mt-4">
                         <label [htmlFor]="pool + 'SuggestedDifficulty'" class="col-12 md:col-2 md:mb-0">Suggested Difficulty</label>
                         <div class="col-12 md:col-10">
                             <input pInputText [id]="pool + 'SuggestedDifficulty'" [formControlName]="pool + 'SuggestedDifficulty'" type="number" />
                         </div>
                     </div>
-                    <div *ngIf="showAdvancedOptions" class="field-checkbox grid mb-0">
+                    <div *ngIf="showAdvancedOptions[pool]" class="field-checkbox grid mb-0">
                         <div class="col-1 md:col-10 md:flex-order-2">
                             <p-checkbox [name]="pool + 'ExtranonceSubscribe'" [inputId]="pool + 'ExtranonceSubscribe'" [formControlName]="pool + 'ExtranonceSubscribe'"
                                 [binary]="true"></p-checkbox>

--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -45,9 +45,7 @@
                     </legend>
 
                     <div *ngIf="showAdvancedOptions[pool]" class="field grid p-fluid mt-4">
-                        <label [htmlFor]="pool + 'SuggestedDifficulty'" class="col-12 md:col-2 md:mb-0">Suggested Difficulty
-                            <i class="pi pi-info-circle text-xs px-1" pTooltip="The minimum difficulty at which you device submits a share."></i>
-                        </label>
+                        <label [htmlFor]="pool + 'SuggestedDifficulty'" class="col-12 md:col-2 md:mb-0">Suggested Difficulty</label>
                         <div class="col-12 md:col-10">
                             <input pInputText [id]="pool + 'SuggestedDifficulty'" [formControlName]="pool + 'SuggestedDifficulty'" type="number" />
                         </div>

--- a/main/http_server/axe-os/src/app/components/pool/pool.component.ts
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.ts
@@ -18,6 +18,7 @@ export class PoolComponent implements OnInit {
 
   public pools: PoolType[] = ['stratum', 'fallbackStratum'];
   public showPassword = {'stratum': false, 'fallbackStratum': false};
+  public showAdvancedOptions = false;
 
   @Input() uri = '';
 

--- a/main/http_server/axe-os/src/app/components/pool/pool.component.ts
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.ts
@@ -18,7 +18,7 @@ export class PoolComponent implements OnInit {
 
   public pools: PoolType[] = ['stratum', 'fallbackStratum'];
   public showPassword = {'stratum': false, 'fallbackStratum': false};
-  public showAdvancedOptions = false;
+  public showAdvancedOptions = {'stratum': false, 'fallbackStratum': false};
 
   @Input() uri = '';
 


### PR DESCRIPTION
Since v2.9.0, I've often seen people asking for the new pool options, `Suggested Difficulty` and `Extranonce Subscribe`. To avoid confusing beginners and reduce the number of support requests, this pull request puts both options in a show/hide wrapper and marks them as "advanced" fields.


https://github.com/user-attachments/assets/9a8ba46b-6c5e-4fbb-ba57-0e1d5d1c60fe

