### PR TITLE
Replace deprecated HttpClientModule

### DIFF
--- a/main/http_server/axe-os/src/app/app.module.ts
+++ b/main/http_server/axe-os/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import 'chartjs-adapter-moment';
 
 import { CommonModule, HashLocationStrategy, LocationStrategy } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
@@ -31,7 +31,7 @@ import { PrimeNGModule } from './prime-ng.module';
 import { MessageModule } from 'primeng/message';
 import { TooltipModule } from 'primeng/tooltip';
 import { DialogModule } from 'primeng/dialog';
-import { DynamicDialogModule, DialogService as PrimeDialogService } from 'primeng/dynamicdialog';
+import { DialogService as PrimeDialogService } from 'primeng/dynamicdialog';
 import { DialogService, DialogListComponent } from './services/dialog.service';
 
 const components = [
@@ -65,7 +65,6 @@ const components = [
   imports: [
     BrowserModule,
     AppRoutingModule,
-    HttpClientModule,
     ReactiveFormsModule,
     FormsModule,
     ToastrModule.forRoot({
@@ -77,13 +76,13 @@ const components = [
     AppLayoutModule,
     MessageModule,
     TooltipModule,
-    DialogModule,
-    DynamicDialogModule
+    DialogModule
   ],
   providers: [
     { provide: LocationStrategy, useClass: HashLocationStrategy },
     DialogService,
-    PrimeDialogService
+    PrimeDialogService,
+    provideHttpClient()
   ],
   bootstrap: [AppComponent]
 })


### PR DESCRIPTION
In Angular 18, the `HttpClientModule` has been deprecated and replaced with a more efficient method using the [provideHttpClient()](https://angular.dev/guide/http/setup) function. This change was made to simplify the setup of HTTP services and reduce redundancy, as the HttpClientModule was essentially providing the same functionality as `provideHttpClient()`.

- [x] Replace `HttpClientModule`
- [x] Remove unused `DynamicDialogModule`