### PR TITLE
Quicklink service: Fix JS error when using local pool

### DIFF
--- a/main/http_server/axe-os/src/app/services/quicklink.service.ts
+++ b/main/http_server/axe-os/src/app/services/quicklink.service.ts
@@ -39,8 +39,8 @@ export class QuicklinkService {
             return pool.url;
           }
           if ('regex' in pool) {
-            const match = pool.regex.exec(stratumURL)!;
-            return pool.url.replace(/\$(\d+)/g, (_, group) => match[+group] ?? '');
+            const match = pool.regex.exec(stratumURL);
+            if (match) return pool.url.replace(/\$(\d+)/g, (_, group) => match[+group] ?? '');
           }
         }
 


### PR DESCRIPTION
**Current state**
An error appears on the dashboard as soon as a local pool is defined as the Stratum host.

```
TypeError: Cannot read properties of null (reading '1')
    at main.84746aa7a21cd575.js:1:616665
    at String.replace (<anonymous>)
    at t.getQuickLink ()
```

**Solution**
Add a match check to see if quick links are being used.