### PR TITLE
Fix checkbox hover/focus color

### DIFF
--- a/main/http_server/axe-os/src/styles.scss
+++ b/main/http_server/axe-os/src/styles.scss
@@ -58,14 +58,21 @@ p-chart>div {
 }
 
 .p-checkbox {
-    .p-checkbox-box {
-        &.p-highlight {
-            border-color: var(--checkbox-border);
-            background: var(--checkbox-bg);
-
+    &:not(.p-checkbox-disabled) {
+        .p-checkbox-box {
+            &.p-focus,
             &:hover {
-                background: var(--checkbox-hover-bg);
                 border-color: var(--checkbox-hover-bg);
+            }
+
+            &.p-highlight {
+                border-color: var(--checkbox-border);
+                background: var(--checkbox-bg);
+
+                &:hover {
+                    background: var(--checkbox-hover-bg);
+                    border-color: var(--checkbox-hover-bg);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR solves the issue that the checkbox focus/hover color not being applied after theme color change.

**Steps to reproduce**
1. Change theme color
2. Navigate to settings

**Before**

https://github.com/user-attachments/assets/22c7d7b6-dfb5-4476-ab22-b9df975b817d

**After**

https://github.com/user-attachments/assets/b815769e-72a0-4a87-b81d-db230e55bcd7

