### PR TITLE
Fix color representation for Nerdaxe devices

### DIFF
--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -121,7 +121,7 @@
             <tr>
                 <td>
                     <a
-                       [ngClass]="'text-'+axe.swarmColor+'-500'"
+                       [ngStyle]="{color: axe.swarmColor}"
                        [href]="'http://'+axe.IP"
                        target="_blank"
                        [pTooltip]="axe.deviceModel || 'Other'"
@@ -181,7 +181,7 @@
 
     <div class="flex flex-wrap gap-2 mt-3 text-sm justify-content-center">
         <div *ngFor="let item of getFamilies" class="flex align-items-center gap-1">
-            <span [class]="'text-' + item.swarmColor + '-500'">●</span>
+            <span [ngStyle]="{color: item.swarmColor}">●</span>
             <span>{{ item.deviceModel || 'Other' }} ({{item.asicCount > 1 ? item.asicCount + 'x ' : ''}}{{item.ASICModel}})</span>
         </div>
     </div>


### PR DESCRIPTION
Nerdaxe devices provide a hex color like `#e7cf00` as `swarmColor`. However, the current code cannot handle this because it expects a string like `orange` to build a corresponding CSS class `[ngClass]="'text-' + axe.swarmColor + '-500'"`. 

This PR solves the problem by outputting the color directly, regardless of whether it is a string or HEX value, instead of using the CSS class.

**Before**
<img width="2048" height="1536" alt="Before" src="https://github.com/user-attachments/assets/bb4b8867-b2c1-42f8-b920-90f3a4911d72" />

**After**
<img width="2048" height="1536" alt="After" src="https://github.com/user-attachments/assets/fa7543ef-99e4-466b-a3cb-aa4ab4521b65" />
