### PR TITLE
Added blockFound to the info API endpoint (and dashboard)

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -22,6 +22,10 @@
         text="Firmware ({{info.version}}) and AxeOS ({{info.axeOSVersion}}) versions do not match. Please make sure to update both www.bin and esp-miner.bin.">
     </p-message>
 
+    <p-message *ngIf="info.blockFound" severity="success" styleClass="w-full mb-4 py-4 border-round-xl"
+        text="Today is your lucky day! Your device has found a block 🎉">
+    </p-message>
+
     <div class="grid">
         <div class="col-12 md:col-6 xl:col-3">
             <div class="card mb-0">

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -88,6 +88,8 @@ export class SystemService {
         blockHeight: 811111,
         scriptsig: "..%..h..,H...ckpool.eu/solo.ckpool.org/",
         networkDifficulty: "25.3T",
+
+        blockFound: 0,
       }
     ).pipe(delay(1000));
   }

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -69,4 +69,6 @@ export interface ISystemInfo {
     blockHeight?: number,
     scriptsig?: string,
     networkDifficulty?: string,
+
+    blockFound: number,
 }

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -720,6 +720,8 @@ static esp_err_t GET_system_info(httpd_req_t * req)
 
     cJSON_AddNumberToObject(root, "statsFrequency", nvs_config_get_u16(NVS_CONFIG_STATISTICS_FREQUENCY, 0));
 
+    cJSON_AddNumberToObject(root, "blockFound", GLOBAL_STATE->SYSTEM_MODULE.FOUND_BLOCK);
+
     if (GLOBAL_STATE->SYSTEM_MODULE.power_fault > 0) {
         cJSON_AddStringToObject(root, "power_fault", VCORE_get_fault_string(GLOBAL_STATE));
     }

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -148,6 +148,7 @@ components:
         - blockHeight
         - scriptsig
         - networkDifficulty
+        - blockFound
       properties:
         ASICModel:
           type: string
@@ -331,6 +332,9 @@ components:
         networkDifficulty:
           type: string
           description: Current network difficulty in human-readable format
+        blockFound:
+          type: number
+          description: Whether a block was found (0=no, 1=yes)
 
     Settings:
       type: object


### PR DESCRIPTION
This PR adds `blockFound` to the `info` API endpoint. At the same time, a condition has been added to the dashboard that triggers a notification as soon as a block is found. Feel free to suggest a nicer message text.

```
{
    ...
	"statsFrequency":	0,
	"blockFound":	0,
	"blockHeight":	914841,
	"networkDifficulty":	"136.04 T"
}
```

**Desktop Notification**
<img width="1274" height="946" alt="Screenshot 2025-09-15 at 20 07 17" src="https://github.com/user-attachments/assets/595ce245-d8cb-4113-a79d-60ab76c11a7e" />
