### PR TITLE
feat: Add mDNS support for network discovery and dynamic hostname updates

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           esp_idf_version: v5.5.3
           target: esp32s3
-          command: idf.py add-dependency "espressif/mdns^1.8.0" && GITHUB_ACTIONS="true" idf.py build
+          command: GITHUB_ACTIONS="true" idf.py build
           path: 'test-ci'
 
       - name: Run tests

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           esp_idf_version: v5.5.3
           target: esp32s3
-          command: GITHUB_ACTIONS="true" idf.py build
+          command: idf.py add-dependency "espressif/mdns^1.8.0" && GITHUB_ACTIONS="true" idf.py build
           path: 'test-ci'
 
       - name: Run tests

--- a/components/connect/CMakeLists.txt
+++ b/components/connect/CMakeLists.txt
@@ -13,4 +13,5 @@ REQUIRES
     "esp_wifi"
     "esp_event"
     "stratum"
+    "espressif__mdns"
 )

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -65,6 +65,7 @@ static wifi_ap_record_t ap_info[MAX_AP_COUNT];
 static int s_retry_num = 0;
 static int clients_connected_to_ap = 0;
 static bool mdns_initialized = false;
+static bool mdns_init_in_progress = false;
 
 static const char *get_wifi_reason_string(int reason);
 static void wifi_softap_on(void);
@@ -107,8 +108,28 @@ esp_err_t wifi_apply_hostname(const char *hostname)
     return ESP_OK;
 }
 
+static void initialize_mdns_if_needed(GlobalState *GLOBAL_STATE);
 static char* generate_unique_hostname(const char *base);
 static char* check_and_resolve_hostname_conflict(const char *hostname, const char *current_ip);
+
+static void mdns_init_task(void *pvParameters) {
+    GlobalState *GLOBAL_STATE = (GlobalState *)pvParameters;
+    initialize_mdns_if_needed(GLOBAL_STATE);
+    mdns_init_in_progress = false;
+    vTaskDelete(NULL);
+}
+
+static void spawn_mdns_init_if_needed(GlobalState *GLOBAL_STATE) {
+    if (mdns_initialized || mdns_init_in_progress) {
+        return;
+    }
+    mdns_init_in_progress = true;
+    BaseType_t ret = xTaskCreate(mdns_init_task, "mdns_init", 4096, GLOBAL_STATE, 5, NULL);
+    if (ret != pdPASS) {
+        ESP_LOGW(TAG, "Failed to create mDNS init task");
+        mdns_init_in_progress = false;
+    }
+}
 
 static void initialize_mdns_if_needed(GlobalState *GLOBAL_STATE) {
     if (mdns_initialized) {
@@ -412,7 +433,7 @@ static void event_handler(void * arg, esp_event_base_t event_base, int32_t event
             ESP_LOGE(TAG, "Failed to create IPv6 link-local address: %s", esp_err_to_name(ipv6_err));
         }
 
-        initialize_mdns_if_needed(GLOBAL_STATE);
+        spawn_mdns_init_if_needed(GLOBAL_STATE);
     }
 
     if (event_base == IP_EVENT && event_id == IP_EVENT_GOT_IP6) {
@@ -445,7 +466,7 @@ static void event_handler(void * arg, esp_event_base_t event_base, int32_t event
             ESP_LOGI(TAG, "IPv6 Address: %s", GLOBAL_STATE->SYSTEM_MODULE.ipv6_addr_str);
         }
 
-        initialize_mdns_if_needed(GLOBAL_STATE);
+        spawn_mdns_init_if_needed(GLOBAL_STATE);
     }
 }
 
@@ -518,7 +539,7 @@ static char* generate_unique_hostname(const char *base) {
 
 static char* check_and_resolve_hostname_conflict(const char *hostname, const char *current_ip) {
     mdns_result_t *results = NULL;
-    esp_err_t err = mdns_query_generic(hostname, NULL, NULL, MDNS_TYPE_A, MDNS_QUERY_MULTICAST, 3000, 1, &results);
+    esp_err_t err = mdns_query_generic(hostname, NULL, NULL, MDNS_TYPE_A, MDNS_QUERY_MULTICAST, 1000, 1, &results);
     if (err != ESP_OK || !results || !results->addr) {
         // No A record found, no conflict
         if (results) mdns_query_results_free(results);

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -2,10 +2,19 @@
 #include "esp_event.h"
 #include "esp_log.h"
 #include "esp_netif.h"
+#include "mdns.h"
+#include "esp_system.h"
 #include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
 #include "freertos/task.h"
 #include "freertos/timers.h"
 #include "lwip/err.h"
+#include "lwip/lwip_napt.h"
+#include "lwip/sys.h"
+#include "lwip/sockets.h"
+#include "esp_netif.h"
+#include "nvs_flash.h"
 #include "esp_wifi_types_generic.h"
 
 #include "connect.h"
@@ -55,6 +64,7 @@ static uint16_t ap_number = 0;
 static wifi_ap_record_t ap_info[MAX_AP_COUNT];
 static int s_retry_num = 0;
 static int clients_connected_to_ap = 0;
+static bool mdns_initialized = false;
 
 static const char *get_wifi_reason_string(int reason);
 static void wifi_softap_on(void);
@@ -94,6 +104,109 @@ esp_err_t wifi_apply_hostname(const char *hostname)
         return err;
     }
 
+    return ESP_OK;
+}
+
+static char* generate_unique_hostname(const char *base);
+static char* check_and_resolve_hostname_conflict(const char *hostname, const char *current_ip);
+
+static void initialize_mdns_if_needed(GlobalState *GLOBAL_STATE) {
+    if (mdns_initialized) {
+        return;
+    }
+
+    char * hostname = nvs_config_get_string(NVS_CONFIG_HOSTNAME);
+    if (hostname == NULL) {
+        ESP_LOGW(TAG, "Hostname not configured, skipping mDNS setup");
+        return;
+    }
+    esp_err_t err = mdns_init();
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "mDNS/Avahi initialization failed: %s", esp_err_to_name(err));
+        ESP_LOGW(TAG, "Device will not be discoverable via mDNS/Bonjour/Avahi");
+    } else {
+        ESP_LOGI(TAG, "mDNS/Avahi initialized successfully - device discoverable on network");
+
+        /* Get current IP */
+        esp_netif_ip_info_t ip_info;
+        esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"), &ip_info);
+        char current_ip[16];
+        snprintf(current_ip, sizeof(current_ip), IPSTR, IP2STR(&ip_info.ip));
+
+        /* Check for hostname conflicts */
+        char *final_hostname = check_and_resolve_hostname_conflict(hostname, current_ip);
+
+        /* Set mDNS hostname */
+        err = mdns_hostname_set(final_hostname);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "mDNS hostname setup failed: %s", esp_err_to_name(err));
+            ESP_LOGW(TAG, "Device hostname not set for mDNS discovery");
+        } else {
+            ESP_LOGI(TAG, "mDNS hostname set to: %s.local", final_hostname);
+            ESP_LOGI(TAG, "Access device at: http://%s.local", final_hostname);
+        }
+
+        free(final_hostname);
+
+        /* Set mDNS instance name */
+        uint8_t mac[6];
+        esp_wifi_get_mac(WIFI_IF_STA, mac);
+        char mac_suffix[6];
+        snprintf(mac_suffix, sizeof(mac_suffix), "%02X%02X", mac[4], mac[5]);
+
+        char instance_name[64];
+        snprintf(instance_name, sizeof(instance_name), "Bitaxe %s %s (%s)",
+                 GLOBAL_STATE->DEVICE_CONFIG.family.name,
+                 GLOBAL_STATE->DEVICE_CONFIG.board_version,
+                 mac_suffix);
+        
+        /* Add HTTP service */
+        err = mdns_service_add(instance_name, "_http", "_tcp", 80, NULL, 0);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "mDNS HTTP service registration failed: %s", esp_err_to_name(err));
+            ESP_LOGW(TAG, "HTTP service not advertised via mDNS");
+        } else {
+            ESP_LOGI(TAG, "mDNS HTTP service registered: _http._tcp port 80");
+            ESP_LOGI(TAG, "Discover with: avahi-browse _http._tcp");
+            ESP_LOGI(TAG, "mDNS instance: %s", instance_name);
+        }
+
+        ESP_LOGI(TAG, "mDNS/Avahi setup complete - device ready for network discovery");
+        mdns_initialized = true;
+    }
+    free(hostname);
+}
+
+esp_err_t update_mdns_hostname(const char *new_hostname) {
+    if (new_hostname == NULL || strlen(new_hostname) == 0) {
+        ESP_LOGW(TAG, "Invalid hostname provided for mDNS update");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Get current IP for conflict checking */
+    esp_netif_ip_info_t ip_info;
+    esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"), &ip_info);
+    char current_ip[16];
+    snprintf(current_ip, sizeof(current_ip), IPSTR, IP2STR(&ip_info.ip));
+
+    /* Check for hostname conflicts and resolve if needed */
+    char *resolved_hostname = check_and_resolve_hostname_conflict(new_hostname, current_ip);
+
+    /* If the hostname was resolved to a different one, update NVS */
+    if (strcmp(resolved_hostname, new_hostname) != 0) {
+        nvs_config_set_string(NVS_CONFIG_HOSTNAME, resolved_hostname);
+        ESP_LOGI(TAG, "Hostname conflict resolved, updated NVS to: %s", resolved_hostname);
+    }
+
+    esp_err_t err = mdns_hostname_set(resolved_hostname);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to update mDNS hostname to: %s, error: %s", resolved_hostname, esp_err_to_name(err));
+        free(resolved_hostname);
+        return err;
+    }
+
+    ESP_LOGI(TAG, "mDNS hostname updated to: %s", resolved_hostname);
+    free(resolved_hostname);
     return ESP_OK;
 }
 
@@ -292,6 +405,8 @@ static void event_handler(void * arg, esp_event_base_t event_base, int32_t event
         if (ipv6_err != ESP_OK) {
             ESP_LOGE(TAG, "Failed to create IPv6 link-local address: %s", esp_err_to_name(ipv6_err));
         }
+
+        initialize_mdns_if_needed(GLOBAL_STATE);
     }
 
     if (event_base == IP_EVENT && event_id == IP_EVENT_GOT_IP6) {
@@ -323,6 +438,8 @@ static void event_handler(void * arg, esp_event_base_t event_base, int32_t event
             GLOBAL_STATE->SYSTEM_MODULE.ipv6_addr_str[sizeof(GLOBAL_STATE->SYSTEM_MODULE.ipv6_addr_str) - 1] = '\0';
             ESP_LOGI(TAG, "IPv6 Address: %s", GLOBAL_STATE->SYSTEM_MODULE.ipv6_addr_str);
         }
+
+        initialize_mdns_if_needed(GLOBAL_STATE);
     }
 }
 
@@ -378,6 +495,49 @@ static void wifi_softap_off(void)
     if (is_wifi_operation_allowed(err)) {
         ESP_ERROR_CHECK(err);
     }
+}
+
+
+
+static char* generate_unique_hostname(const char *base) {
+    uint8_t mac[6];
+    esp_wifi_get_mac(WIFI_IF_STA, mac);
+    char suffix[6];
+    snprintf(suffix, sizeof(suffix), "-%02x%02x", mac[4], mac[5]);
+    char *new_hostname = malloc(strlen(base) + strlen(suffix) + 1);
+    strcpy(new_hostname, base);
+    strcat(new_hostname, suffix);
+    return new_hostname;
+}
+
+static char* check_and_resolve_hostname_conflict(const char *hostname, const char *current_ip) {
+    mdns_result_t *results = NULL;
+    esp_err_t err = mdns_query_generic(hostname, NULL, NULL, MDNS_TYPE_A, MDNS_QUERY_MULTICAST, 3000, 1, &results);
+    if (err != ESP_OK || !results || !results->addr) {
+        // No A record found, no conflict
+        if (results) mdns_query_results_free(results);
+        return strdup(hostname);
+    }
+
+    mdns_ip_addr_t *a = results->addr;
+    char ip_str[INET6_ADDRSTRLEN];
+    if (a->addr.type == IPADDR_TYPE_V4) {
+        esp_ip4addr_ntoa(&a->addr.u_addr.ip4, ip_str, sizeof(ip_str));
+    } else {
+        inet_ntop(AF_INET6, &a->addr.u_addr.ip6, ip_str, sizeof(ip_str));
+    }
+
+    if (strcmp(ip_str, current_ip) != 0) {
+        // Different IP, conflict detected
+        char *new_hostname = generate_unique_hostname(hostname);
+        ESP_LOGI(TAG, "mDNS conflict detected for '%s' at %s, renaming to '%s'", hostname, ip_str, new_hostname);
+        nvs_config_set_string(NVS_CONFIG_HOSTNAME, new_hostname);
+        mdns_query_results_free(results);
+        return new_hostname;
+    }
+
+    mdns_query_results_free(results);
+    return strdup(hostname);
 }
 
 static void wifi_softap_on(void)

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -144,6 +144,8 @@ static void initialize_mdns_if_needed(GlobalState *GLOBAL_STATE) {
         } else {
             ESP_LOGI(TAG, "mDNS hostname set to: %s.local", final_hostname);
             ESP_LOGI(TAG, "Access device at: http://%s.local", final_hostname);
+            strlcpy(GLOBAL_STATE->SYSTEM_MODULE.mdns_hostname, final_hostname, sizeof(GLOBAL_STATE->SYSTEM_MODULE.mdns_hostname));
+            snprintf(GLOBAL_STATE->SYSTEM_MODULE.full_hostname, sizeof(GLOBAL_STATE->SYSTEM_MODULE.full_hostname), "%s.local", final_hostname);
         }
 
         free(final_hostname);
@@ -177,7 +179,7 @@ static void initialize_mdns_if_needed(GlobalState *GLOBAL_STATE) {
     free(hostname);
 }
 
-esp_err_t update_mdns_hostname(const char *new_hostname) {
+esp_err_t update_mdns_hostname(const char *new_hostname, GlobalState *GLOBAL_STATE) {
     if (new_hostname == NULL || strlen(new_hostname) == 0) {
         ESP_LOGW(TAG, "Invalid hostname provided for mDNS update");
         return ESP_ERR_INVALID_ARG;
@@ -206,6 +208,10 @@ esp_err_t update_mdns_hostname(const char *new_hostname) {
     }
 
     ESP_LOGI(TAG, "mDNS hostname updated to: %s", resolved_hostname);
+    if (GLOBAL_STATE != NULL) {
+        strlcpy(GLOBAL_STATE->SYSTEM_MODULE.mdns_hostname, resolved_hostname, sizeof(GLOBAL_STATE->SYSTEM_MODULE.mdns_hostname));
+        snprintf(GLOBAL_STATE->SYSTEM_MODULE.full_hostname, sizeof(GLOBAL_STATE->SYSTEM_MODULE.full_hostname), "%s.local", resolved_hostname);
+    }
     free(resolved_hostname);
     return ESP_OK;
 }

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -156,6 +156,11 @@ static void initialize_mdns_if_needed(GlobalState *GLOBAL_STATE) {
 
         /* Check for hostname conflicts */
         char *final_hostname = check_and_resolve_hostname_conflict(hostname, current_ip);
+        if (final_hostname == NULL) {
+            ESP_LOGE(TAG, "Failed to resolve hostname conflicts, skipping mDNS hostname setup");
+            free(hostname);
+            return;
+        }
 
         /* Set mDNS hostname */
         err = mdns_hostname_set(final_hostname);
@@ -214,6 +219,10 @@ esp_err_t update_mdns_hostname(const char *new_hostname, GlobalState *GLOBAL_STA
 
     /* Check for hostname conflicts and resolve if needed */
     char *resolved_hostname = check_and_resolve_hostname_conflict(new_hostname, current_ip);
+    if (resolved_hostname == NULL) {
+        ESP_LOGE(TAG, "Failed to resolve hostname conflicts");
+        return ESP_ERR_NO_MEM;
+    }
 
     /* If the hostname was resolved to a different one, update NVS */
     if (strcmp(resolved_hostname, new_hostname) != 0) {
@@ -532,6 +541,10 @@ static char* generate_unique_hostname(const char *base) {
     char suffix[6];
     snprintf(suffix, sizeof(suffix), "-%02x%02x", mac[4], mac[5]);
     char *new_hostname = malloc(strlen(base) + strlen(suffix) + 1);
+    if (new_hostname == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate memory for unique hostname");
+        return NULL;
+    }
     strcpy(new_hostname, base);
     strcat(new_hostname, suffix);
     return new_hostname;
@@ -555,8 +568,12 @@ static char* check_and_resolve_hostname_conflict(const char *hostname, const cha
     }
 
     if (strcmp(ip_str, current_ip) != 0) {
-        // Different IP, conflict detected
         char *new_hostname = generate_unique_hostname(hostname);
+        if (new_hostname == NULL) {
+            ESP_LOGW(TAG, "mDNS conflict detected for '%s' but could not generate unique name, keeping original", hostname);
+            mdns_query_results_free(results);
+            return strdup(hostname);
+        }
         ESP_LOGI(TAG, "mDNS conflict detected for '%s' at %s, renaming to '%s'", hostname, ip_str, new_hostname);
         nvs_config_set_string(NVS_CONFIG_HOSTNAME, new_hostname);
         mdns_query_results_free(results);

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -20,6 +20,7 @@
 #include "connect.h"
 #include "global_state.h"
 #include "nvs_config.h"
+#include "esp_app_desc.h"
 
 // Maximum number of access points to scan
 #define MAX_AP_COUNT 20
@@ -206,6 +207,27 @@ static void initialize_mdns_if_needed(GlobalState *GLOBAL_STATE) {
                 ESP_LOGI(TAG, "mDNS AxeOS subtype registered: _axeos._sub._http._tcp");
                 ESP_LOGI(TAG, "Discover AxeOS devices with: avahi-browse _axeos._sub._http._tcp");
             }
+
+            /* Add TXT records for device identification */
+            err = mdns_service_txt_item_set_for_host(instance_name, "_http", "_tcp", NULL, "board", GLOBAL_STATE->DEVICE_CONFIG.board_version);
+            if (err != ESP_OK) ESP_LOGW(TAG, "mDNS TXT 'board' failed: %s", esp_err_to_name(err));
+            err = mdns_service_txt_item_set_for_host(instance_name, "_http", "_tcp", NULL, "family", GLOBAL_STATE->DEVICE_CONFIG.family.name);
+            if (err != ESP_OK) ESP_LOGW(TAG, "mDNS TXT 'family' failed: %s", esp_err_to_name(err));
+            err = mdns_service_txt_item_set_for_host(instance_name, "_http", "_tcp", NULL, "asic", GLOBAL_STATE->DEVICE_CONFIG.family.asic.name);
+            if (err != ESP_OK) ESP_LOGW(TAG, "mDNS TXT 'asic' failed: %s", esp_err_to_name(err));
+            char asic_count_str[4];
+            snprintf(asic_count_str, sizeof(asic_count_str), "%u", GLOBAL_STATE->DEVICE_CONFIG.family.asic_count);
+            err = mdns_service_txt_item_set_for_host(instance_name, "_http", "_tcp", NULL, "asic_count", asic_count_str);
+            if (err != ESP_OK) ESP_LOGW(TAG, "mDNS TXT 'asic_count' failed: %s", esp_err_to_name(err));
+            const esp_app_desc_t *app_desc = esp_app_get_description();
+            err = mdns_service_txt_item_set_for_host(instance_name, "_http", "_tcp", NULL, "fw_version", app_desc->version);
+            if (err != ESP_OK) ESP_LOGW(TAG, "mDNS TXT 'fw_version' failed: %s", esp_err_to_name(err));
+            ESP_LOGI(TAG, "mDNS TXT records added: board=%s, family=%s, asic=%s, asic_count=%s, fw_version=%s",
+                     GLOBAL_STATE->DEVICE_CONFIG.board_version,
+                     GLOBAL_STATE->DEVICE_CONFIG.family.name,
+                     GLOBAL_STATE->DEVICE_CONFIG.family.asic.name,
+                     asic_count_str,
+                     app_desc->version);
         }
 
         ESP_LOGI(TAG, "mDNS/Avahi setup complete - device ready for network discovery");

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -197,6 +197,15 @@ static void initialize_mdns_if_needed(GlobalState *GLOBAL_STATE) {
             ESP_LOGI(TAG, "mDNS HTTP service registered: _http._tcp port 80");
             ESP_LOGI(TAG, "Discover with: avahi-browse _http._tcp");
             ESP_LOGI(TAG, "mDNS instance: %s", instance_name);
+
+            /* Add AxeOS subtype for DNS-SD discovery */
+            err = mdns_service_subtype_add_for_host(instance_name, "_http", "_tcp", NULL, "_axeos");
+            if (err != ESP_OK) {
+                ESP_LOGW(TAG, "mDNS AxeOS subtype registration failed: %s", esp_err_to_name(err));
+            } else {
+                ESP_LOGI(TAG, "mDNS AxeOS subtype registered: _axeos._sub._http._tcp");
+                ESP_LOGI(TAG, "Discover AxeOS devices with: avahi-browse _axeos._sub._http._tcp");
+            }
         }
 
         ESP_LOGI(TAG, "mDNS/Avahi setup complete - device ready for network discovery");

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -253,7 +253,11 @@ esp_err_t update_mdns_hostname(const char *new_hostname, GlobalState *GLOBAL_STA
         ip_info.ip.addr = 0;
     }
     char current_ip[16];
-    snprintf(current_ip, sizeof(current_ip), IPSTR, IP2STR(&ip_info.ip));
+    if (ip_info.ip.addr == 0) {
+        strlcpy(current_ip, "0.0.0.0", sizeof(current_ip));
+    } else {
+        snprintf(current_ip, sizeof(current_ip), IPSTR, IP2STR(&ip_info.ip));
+    }
 
     /* Check for hostname conflicts and resolve if needed */
     char *resolved_hostname = check_and_resolve_hostname_conflict(new_hostname, current_ip);

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -151,9 +151,17 @@ static void initialize_mdns_if_needed(GlobalState *GLOBAL_STATE) {
 
         /* Get current IP */
         esp_netif_ip_info_t ip_info;
-        esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"), &ip_info);
+        esp_netif_t *netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+        if (netif == NULL) {
+            netif = esp_netif_get_handle_from_ifkey("WIFI_AP_DEF");
+        }
         char current_ip[16];
-        snprintf(current_ip, sizeof(current_ip), IPSTR, IP2STR(&ip_info.ip));
+        if (netif == NULL || esp_netif_get_ip_info(netif, &ip_info) != ESP_OK || ip_info.ip.addr == 0) {
+            ESP_LOGW(TAG, "No active network interface for mDNS init, using 0.0.0.0");
+            strlcpy(current_ip, "0.0.0.0", sizeof(current_ip));
+        } else {
+            snprintf(current_ip, sizeof(current_ip), IPSTR, IP2STR(&ip_info.ip));
+        }
 
         /* Check for hostname conflicts */
         char *final_hostname = check_and_resolve_hostname_conflict(hostname, current_ip);
@@ -161,6 +169,12 @@ static void initialize_mdns_if_needed(GlobalState *GLOBAL_STATE) {
             ESP_LOGE(TAG, "Failed to resolve hostname conflicts, skipping mDNS hostname setup");
             free(hostname);
             return;
+        }
+
+        /* If conflict resolution changed the hostname, persist to NVS */
+        if (strcmp(final_hostname, hostname) != 0) {
+            nvs_config_set_string(NVS_CONFIG_HOSTNAME, final_hostname);
+            ESP_LOGI(TAG, "Hostname conflict resolved, updated NVS to: %s", final_hostname);
         }
 
         /* Set mDNS hostname */
@@ -617,7 +631,6 @@ static char* check_and_resolve_hostname_conflict(const char *hostname, const cha
             return strdup(hostname);
         }
         ESP_LOGI(TAG, "mDNS conflict detected for '%s' at %s, renaming to '%s'", hostname, ip_str, new_hostname);
-        nvs_config_set_string(NVS_CONFIG_HOSTNAME, new_hostname);
         mdns_query_results_free(results);
         return new_hostname;
     }

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -244,7 +244,14 @@ esp_err_t update_mdns_hostname(const char *new_hostname, GlobalState *GLOBAL_STA
 
     /* Get current IP for conflict checking */
     esp_netif_ip_info_t ip_info;
-    esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"), &ip_info);
+    esp_netif_t *netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+    if (netif == NULL) {
+        netif = esp_netif_get_handle_from_ifkey("WIFI_AP_DEF");
+    }
+    if (netif == NULL || esp_netif_get_ip_info(netif, &ip_info) != ESP_OK) {
+        ESP_LOGW(TAG, "No active network interface for mDNS hostname update");
+        ip_info.ip.addr = 0;
+    }
     char current_ip[16];
     snprintf(current_ip, sizeof(current_ip), IPSTR, IP2STR(&ip_info.ip));
 

--- a/components/connect/idf_component.yml
+++ b/components/connect/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  espressif/mdns: "^1.8.0"

--- a/components/connect/include/connect.h
+++ b/components/connect/include/connect.h
@@ -8,6 +8,7 @@
 
 #include "esp_err.h"
 #include "esp_wifi_types.h"
+#include "global_state.h"
 
 // Structure to hold WiFi scan results
 typedef struct {
@@ -22,6 +23,6 @@ esp_err_t wifi_apply_hostname(const char *hostname);
 esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count);
 esp_err_t get_wifi_current_rssi(int8_t *rssi);
 bool wifi_is_connected(void);
-esp_err_t update_mdns_hostname(const char *new_hostname);
+esp_err_t update_mdns_hostname(const char *new_hostname, GlobalState *GLOBAL_STATE);
 
 #endif /* CONNECT_H_ */

--- a/components/connect/include/connect.h
+++ b/components/connect/include/connect.h
@@ -22,5 +22,6 @@ esp_err_t wifi_apply_hostname(const char *hostname);
 esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count);
 esp_err_t get_wifi_current_rssi(int8_t *rssi);
 bool wifi_is_connected(void);
+esp_err_t update_mdns_hostname(const char *new_hostname);
 
 #endif /* CONNECT_H_ */

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -113,6 +113,8 @@ typedef struct
     char * version;
     char * axeOSVersion;
     Scoreboard scoreboard;
+    char mdns_hostname[64];
+    char full_hostname[70];
 } SystemModule;
 
 typedef struct

--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
@@ -10,6 +10,7 @@ import { LiveDataService } from 'src/app/services/live-data.service';
 import { SystemApiService } from 'src/app/services/system.service';
 import { WifiNetwork } from 'src/app/generated/models';
 import { first } from 'rxjs/operators';
+import { ISystemUpdateResponse } from 'src/models/ISystemUpdateResponse';
 
 @Component({
   selector: 'app-network-edit',
@@ -72,10 +73,36 @@ export class NetworkEditComponent implements OnInit {
     this.systemService.updateSystem(this.uri, form)
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe({
-        next: () => {
-          if (restartRequired) {
-            this.toastr.warning('You must restart this device after saving for changes to take effect.');
-          }
+        next: (response: any) => {
+           // Check if response contains redirect information (hostname change)
+           if (response && response.redirect) {
+             const redirectResponse = response as ISystemUpdateResponse;
+             if (redirectResponse.redirect) {
+               let newHostname: string;
+               try {
+                 newHostname = new URL(redirectResponse.redirect.url).hostname;
+                } catch (error) {
+                  console.error('Invalid redirect URL:', redirectResponse.redirect.url, error);
+                  this.toastr.error('Failed to redirect due to invalid URL.');
+                  return; // Skip redirect on malformed URL
+                }
+               const redirectUrl = redirectResponse.redirect.url;
+               const redirectDelay = redirectResponse.redirect.delay;
+               
+               this.toastr.success(redirectResponse.redirect.message);
+               this.toastr.info(`Redirecting to ${newHostname} in ${Math.ceil(redirectDelay / 1000)} seconds...`);
+               
+               setTimeout(() => {
+                 window.location.href = redirectUrl;
+               }, redirectDelay);
+             }
+             return;
+           }
+
+           // Normal success handling
+           if (restartRequired) {
+             this.toastr.warning('You must restart this device after saving for changes to take effect.');
+           }
           this.toastr.success('Saved network settings');
           this.savedChanges = restartAlreadyPending || restartRequired;
           this.form.markAsPristine();

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -92,21 +92,21 @@
                             <div class="flex flex-column">
                                 <div class="flex flex-column">
                                     <div class="white-space-nowrap">
-                                        <a [href]="'http://' + axe.IP" target="_blank" class="text-900" pTooltip="Hostname" tooltipPosition="top">
-                                            {{axe.hostname}}
+                                        <a [href]="'http://' + axe.address" target="_blank" class="text-900" pTooltip="Hostname" tooltipPosition="top">
+                                            {{getDeviceDisplayName(axe)}}
                                         </a>
                                         <span class="ml-1 text-lg line-height-1 cursor-pointer" [ngStyle]="{color: axe.swarmColor}" pTooltip="{{stringifyDeviceLabel(axe)}}" tooltipPosition="top">
                                             ●
                                         </span>
-                                    </div>
-                                    <div class="white-space-nowrap">
-                                        <a [href]="'http://' + axe.IP" target="_blank" class="text-800" pTooltip="IP" tooltipPosition="top">
-                                            {{axe.IP}}
-                                        </a>
-                                        <span *ngIf="isThisDevice(axe.IP)" class="ml-1 cursor-pointer" pTooltip="This device" tooltipPosition="top">
-                                            <i class="pi pi-star-fill text-xs"></i>
-                                        </span>
-                                    </div>
+                                     </div>
+                                     <div class="white-space-nowrap">
+                                         <a [href]="'http://' + axe.address" target="_blank" class="text-800" pTooltip="Address" tooltipPosition="top">
+                                             {{axe.address}}
+                                         </a>
+                                         <span *ngIf="isThisDevice(axe.address)" class="ml-1 cursor-pointer" pTooltip="This device" tooltipPosition="top">
+                                             <i class="pi pi-star-fill text-xs"></i>
+                                         </span>
+                                     </div>
                                 </div>
                                 <span class="text-500 cursor-pointer" pTooltip="Version" tooltipPosition="top">
                                     {{axe.version}}
@@ -219,7 +219,7 @@
                         <tr>
                             <th *ngFor="let field of [
                                 { label: 'Hostname', name: 'hostname' },
-                                { label: 'IP', name: 'IP' },
+                                { label: 'Address', name: 'address' },
                                 { label: 'Hashrate', name: 'hashRate' },
                                 { label: 'Shares', name: 'sharesAccepted' },
                                 { label: 'Best Diff', name: 'bestDiff' },
@@ -243,8 +243,8 @@
                     <tbody>
                         <tr *ngFor="let axe of filteredSwarm">
                             <td>
-                                <a [href]="'http://' + axe.IP" target="_blank">
-                                    <span class="text-900">{{axe.hostname}}</span>
+                                <a [href]="'http://' + axe.address" target="_blank">
+                                    <span class="text-900">{{getDeviceDisplayName(axe)}}</span>
                                     <span class="ml-2 text-lg line-height-1 cursor-pointer" [ngStyle]="{color: axe.swarmColor}" pTooltip="{{stringifyDeviceLabel(axe)}}" tooltipPosition="top">●</span>
                                 </a>
                                 <div *ngIf="getDeviceNotification(axe) as notification" class="flex align-items-center gap-1" [ngClass]="'text-' + notification.color + '-500'">
@@ -253,8 +253,8 @@
                                 </div>
                             </td>
                             <td>
-                                <a [href]="'http://' + axe.IP" target="_blank" class="text-800">{{axe.IP}}</a>
-                                <span *ngIf="isThisDevice(axe.IP)" class="ml-2 cursor-pointer" pTooltip="This device" tooltipPosition="top">
+                                <a [href]="'http://' + axe.address" target="_blank" class="text-800">{{axe.address}}</a>
+                                <span *ngIf="isThisDevice(axe.address)" class="ml-2 cursor-pointer" pTooltip="This device" tooltipPosition="top">
                                     <i class="pi pi-star-fill text-xs"></i>
                                 </span>
                             </td>
@@ -363,7 +363,7 @@
 
     <ng-template #noDevices>
         <p class="text-500 text-center pt-5">
-            Scan your network for devices or add a device manually by using its IP address.
+            Scan your network for devices or add a device manually by using its address (IP or .local hostname).
         </p>
     </ng-template>
 
@@ -385,13 +385,13 @@
 
         <div class="md:ml-auto">
             <p-inputGroup>
-                <input pInputText placeholder="Add Device by IP" formControlName="manualAddIp" type="text" class="xl:w-20rem" />
+                <input pInputText placeholder="Add Device by Address" formControlName="manualAddAddress" type="text" class="xl:w-20rem" />
                 <button pButton [disabled]="form.invalid" (click)="add()" class="ml-1">Add</button>
             </p-inputGroup>
         </div>
     </form>
 
-    <app-modal [headline]="selectedAxeOs?.IP">
-        <app-edit *ngIf="selectedAxeOs" [uri]="'http://' + selectedAxeOs.IP"></app-edit>
+    <app-modal [headline]="selectedAxeOs?.address">
+        <app-edit *ngIf="selectedAxeOs" [uri]="'http://' + selectedAxeOs.connectionAddress"></app-edit>
     </app-modal>
 </div>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -89,25 +89,21 @@
                 <div class="col-12 sm:col-6 xl:col-{{staticMenuDesktopInactive ? 3 : 4}}" *ngFor="let axe of filteredSwarm">
                     <div class="card flex justify-content-between mb-0 h-full">
                         <div class="flex flex-column justify-content-between">
-                            <div class="flex flex-column">
                                 <div class="flex flex-column">
-                                    <div class="white-space-nowrap">
-                                        <a [href]="'http://' + axe.address" target="_blank" class="text-900" pTooltip="Hostname" tooltipPosition="top">
-                                            {{getDeviceDisplayName(axe)}}
-                                        </a>
-                                        <span class="ml-1 text-lg line-height-1 cursor-pointer" [ngStyle]="{color: axe.swarmColor}" pTooltip="{{stringifyDeviceLabel(axe)}}" tooltipPosition="top">
-                                            ●
-                                        </span>
-                                     </div>
-                                     <div class="white-space-nowrap">
-                                         <a [href]="'http://' + axe.address" target="_blank" class="text-800" pTooltip="Address" tooltipPosition="top">
-                                             {{axe.address}}
-                                         </a>
-                                         <span *ngIf="isThisDevice(axe)" class="ml-1 cursor-pointer" pTooltip="This device" tooltipPosition="top">
-                                             <i class="pi pi-star-fill text-xs"></i>
-                                         </span>
-                                     </div>
-                                </div>
+                                    <div class="flex flex-column">
+                                        <div class="white-space-nowrap">
+                                            <a [href]="'http://' + axe.address" target="_blank" class="text-900" pTooltip="Hostname" tooltipPosition="top">
+                                                {{axe.fullHostname || axe.hostname}}
+                                            </a>
+                                            <span class="ml-1 text-lg line-height-1 cursor-pointer" [ngStyle]="{color: axe.swarmColor}" pTooltip="{{stringifyDeviceLabel(axe)}}" tooltipPosition="top">
+                                                ●
+                                            </span>
+                                            <span *ngIf="isThisDevice(axe)" class="ml-1 cursor-pointer" pTooltip="This device" tooltipPosition="top">
+                                                <i class="pi pi-star-fill text-xs"></i>
+                                            </span>
+                                         </div>
+                                         <span class="text-500 text-sm">{{axe.ip}}</span>
+                                    </div>
                                 <span class="text-500 cursor-pointer" pTooltip="Version" tooltipPosition="top">
                                     {{axe.version}}
                                 </span>
@@ -218,8 +214,7 @@
                     <thead>
                         <tr>
                             <th *ngFor="let field of [
-                                { label: 'Hostname', name: 'hostname' },
-                                { label: 'Address', name: 'address' },
+                                { label: 'Device', name: 'address' },
                                 { label: 'Hashrate', name: 'hashRate' },
                                 { label: 'Shares', name: 'sharesAccepted' },
                                 { label: 'Best Diff', name: 'bestDiff' },
@@ -243,20 +238,20 @@
                     <tbody>
                         <tr *ngFor="let axe of filteredSwarm">
                             <td>
-                                <a [href]="'http://' + axe.address" target="_blank">
-                                    <span class="text-900">{{getDeviceDisplayName(axe)}}</span>
-                                    <span class="ml-2 text-lg line-height-1 cursor-pointer" [ngStyle]="{color: axe.swarmColor}" pTooltip="{{stringifyDeviceLabel(axe)}}" tooltipPosition="top">●</span>
-                                </a>
+                                <div class="flex flex-column">
+                                    <a [href]="'http://' + axe.address" target="_blank">
+                                        <span class="text-900">{{axe.fullHostname || axe.hostname}}</span>
+                                        <span class="ml-2 text-lg line-height-1 cursor-pointer" [ngStyle]="{color: axe.swarmColor}" pTooltip="{{stringifyDeviceLabel(axe)}}" tooltipPosition="top">●</span>
+                                        <span *ngIf="isThisDevice(axe)" class="ml-2 cursor-pointer" pTooltip="This device" tooltipPosition="top">
+                                            <i class="pi pi-star-fill text-xs"></i>
+                                        </span>
+                                    </a>
+                                    <span class="text-500 text-sm">{{axe.ip}}</span>
+                                </div>
                                 <div *ngIf="getDeviceNotification(axe) as notification" class="flex align-items-center gap-1" [ngClass]="'text-' + notification.color + '-500'">
                                     <i class="pi pi-exclamation-triangle"></i>
                                     <span class="text-sm">{{ notification.msg }}</span>
                                 </div>
-                            </td>
-                            <td>
-                                <a [href]="'http://' + axe.address" target="_blank" class="text-800">{{axe.address}}</a>
-                                <span *ngIf="isThisDevice(axe)" class="ml-2 cursor-pointer" pTooltip="This device" tooltipPosition="top">
-                                    <i class="pi pi-star-fill text-xs"></i>
-                                </span>
                             </td>
                             <td>{{axe.hashRate | hashSuffix}}</td>
                             <td>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -103,7 +103,7 @@
                                          <a [href]="'http://' + axe.address" target="_blank" class="text-800" pTooltip="Address" tooltipPosition="top">
                                              {{axe.address}}
                                          </a>
-                                         <span *ngIf="isThisDevice(axe.address)" class="ml-1 cursor-pointer" pTooltip="This device" tooltipPosition="top">
+                                         <span *ngIf="isThisDevice(axe)" class="ml-1 cursor-pointer" pTooltip="This device" tooltipPosition="top">
                                              <i class="pi pi-star-fill text-xs"></i>
                                          </span>
                                      </div>
@@ -254,7 +254,7 @@
                             </td>
                             <td>
                                 <a [href]="'http://' + axe.address" target="_blank" class="text-800">{{axe.address}}</a>
-                                <span *ngIf="isThisDevice(axe.address)" class="ml-2 cursor-pointer" pTooltip="This device" tooltipPosition="top">
+                                <span *ngIf="isThisDevice(axe)" class="ml-2 cursor-pointer" pTooltip="This device" tooltipPosition="top">
                                     <i class="pi pi-star-fill text-xs"></i>
                                 </span>
                             </td>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -92,7 +92,7 @@
                                 <div class="flex flex-column">
                                     <div class="flex flex-column">
                                         <div class="white-space-nowrap">
-                                            <a [href]="'http://' + axe.address" target="_blank" class="text-900" pTooltip="Hostname" tooltipPosition="top">
+                                            <a [href]="'http://' + getDeviceLink(axe)" target="_blank" class="text-900" pTooltip="Hostname" tooltipPosition="top">
                                                 {{axe.fullHostname || axe.hostname}}
                                             </a>
                                             <span class="ml-1 text-lg line-height-1 cursor-pointer" [ngStyle]="{color: axe.swarmColor}" pTooltip="{{stringifyDeviceLabel(axe)}}" tooltipPosition="top">
@@ -239,7 +239,7 @@
                         <tr *ngFor="let axe of filteredSwarm">
                             <td>
                                 <div class="flex flex-column">
-                                    <a [href]="'http://' + axe.address" target="_blank">
+                                    <a [href]="'http://' + getDeviceLink(axe)" target="_blank">
                                         <span class="text-900">{{axe.fullHostname || axe.hostname}}</span>
                                         <span class="ml-2 text-lg line-height-1 cursor-pointer" [ngStyle]="{color: axe.swarmColor}" pTooltip="{{stringifyDeviceLabel(axe)}}" tooltipPosition="top">●</span>
                                         <span *ngIf="isThisDevice(axe)" class="ml-2 cursor-pointer" pTooltip="This device" tooltipPosition="top">

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -102,7 +102,7 @@
                                                 <i class="pi pi-star-fill text-xs"></i>
                                             </span>
                                          </div>
-                                         <span class="text-500 text-sm">{{axe.ip}}</span>
+                                         <span class="text-500 text-sm">{{axe.ipv4}}</span>
                                     </div>
                                 <span class="text-500 cursor-pointer" pTooltip="Version" tooltipPosition="top">
                                     {{axe.version}}
@@ -246,7 +246,7 @@
                                             <i class="pi pi-star-fill text-xs"></i>
                                         </span>
                                     </a>
-                                    <span class="text-500 text-sm">{{axe.ip}}</span>
+                                    <span class="text-500 text-sm">{{axe.ipv4}}</span>
                                 </div>
                                 <div *ngIf="getDeviceNotification(axe) as notification" class="flex align-items-center gap-1" [ngClass]="'text-' + notification.color + '-500'">
                                     <i class="pi pi-exclamation-triangle"></i>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.html
@@ -93,7 +93,7 @@
                                     <div class="flex flex-column">
                                         <div class="white-space-nowrap">
                                             <a [href]="'http://' + getDeviceLink(axe)" target="_blank" class="text-900" pTooltip="Hostname" tooltipPosition="top">
-                                                {{axe.fullHostname || axe.hostname}}
+                                                {{getDeviceDisplayName(axe)}}
                                             </a>
                                             <span class="ml-1 text-lg line-height-1 cursor-pointer" [ngStyle]="{color: axe.swarmColor}" pTooltip="{{stringifyDeviceLabel(axe)}}" tooltipPosition="top">
                                                 ●
@@ -240,7 +240,7 @@
                             <td>
                                 <div class="flex flex-column">
                                     <a [href]="'http://' + getDeviceLink(axe)" target="_blank">
-                                        <span class="text-900">{{axe.fullHostname || axe.hostname}}</span>
+                                        <span class="text-900">{{getDeviceDisplayName(axe)}}</span>
                                         <span class="ml-2 text-lg line-height-1 cursor-pointer" [ngStyle]="{color: axe.swarmColor}" pTooltip="{{stringifyDeviceLabel(axe)}}" tooltipPosition="top">●</span>
                                         <span *ngIf="isThisDevice(axe)" class="ml-2 cursor-pointer" pTooltip="This device" tooltipPosition="top">
                                             <i class="pi pi-star-fill text-xs"></i>

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -542,8 +542,8 @@ private isIpAddress(value: string): boolean {
 
   get sortOptions() {
     return [
-      { label: 'Hostname (Z-A)', value: { sortField: 'hostname', sortDirection: 'desc' } },
-      { label: 'Hostname (A-Z)', value: { sortField: 'hostname', sortDirection: 'asc' } },
+      { label: 'Hostname', value: { sortField: 'hostname', sortDirection: 'desc' } },
+      { label: 'Hostname', value: { sortField: 'hostname', sortDirection: 'asc' } },
       { label: 'Address', value: { sortField: 'address', sortDirection: 'desc' } },
       { label: 'Address', value: { sortField: 'address', sortDirection: 'asc' } },
       { label: 'Hashrate', value: { sortField: 'hashRate', sortDirection: 'desc' } },

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -597,7 +597,17 @@ return this.swarm.filter(axe =>
     }
   }
 
-  isThisDevice(IP: string): boolean {
-    return IP === window.location.hostname || (this.currentDeviceIp !== null && IP === this.currentDeviceIp);
+  isThisDevice(device: SwarmDevice): boolean {
+    const hostname = window.location.hostname;
+    
+    if (device.address === hostname || device.connectionAddress === hostname) {
+      return true;
+    }
+    
+    if (this.currentDeviceIp !== null && device['ip'] === this.currentDeviceIp) {
+      return true;
+    }
+    
+    return false;
   }
 }

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -13,7 +13,16 @@ const SWARM_REFRESH_TIME = 'SWARM_REFRESH_TIME';
 const SWARM_SORTING = 'SWARM_SORTING';
 const SWARM_GRID_VIEW = 'SWARM_GRID_VIEW';
 
-type SwarmDevice = { IP: string; ASICModel: string; deviceModel: string; swarmColor: string; asicCount: number; [key: string]: any };
+type SwarmDevice = { 
+  address: string; 
+  ASICModel: string; 
+  deviceModel: string; 
+  swarmColor: string; 
+  asicCount: number; 
+  displayName?: string; 
+  connectionAddress?: string; 
+  [key: string]: any 
+};
 
 @Component({
   selector: 'app-swarm',
@@ -50,6 +59,8 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
   public filterText = '';
 
+  public currentDeviceIp: string | null = null;
+
   @HostListener('document:keydown.esc', ['$event'])
   onEscKey() {
     if (this.filterText) {
@@ -67,7 +78,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
   ) {
 
     this.form = this.fb.group({
-      manualAddIp: [null, [Validators.required, Validators.pattern('(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)')]]
+      manualAddAddress: [null, [Validators.required, Validators.pattern('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|[a-zA-Z0-9-]+(?:\\.local)?$')]]
     });
 
     this.gridView = this.localStorageService.getBool(SWARM_GRID_VIEW);
@@ -83,8 +94,9 @@ export class SwarmComponent implements OnInit, OnDestroy {
       this.localStorageService.setNumber(SWARM_REFRESH_TIME, value);
     });
 
+
     this.selectedSort = this.localStorageService.getObject(SWARM_SORTING) ?? {
-      sortField: 'IP',
+      sortField: 'address',
       sortDirection: 'asc'
     };
 
@@ -114,6 +126,12 @@ export class SwarmComponent implements OnInit, OnDestroy {
         }
       }
     }, 1000);
+
+    // Fetch current device IP for isThisDevice
+    this.httpClient.get(`http://${window.location.hostname}/api/system/info`).subscribe({
+      next: (response: any) => this.currentDeviceIp = response.ip,
+      error: () => this.currentDeviceIp = null
+    });
   }
 
   ngOnDestroy(): void {
@@ -124,6 +142,16 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
   private ipToInt(ip: string): number {
     return ip.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0;
+  }
+
+private isIpAddress(value: string): boolean {
+    const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+    return ipRegex.test(value);
+  }
+
+  // Utility method to get the display name for a device
+  public getDeviceDisplayName(device: SwarmDevice): string {
+    return device.displayName || device.address;
   }
 
   private intToIp(int: number): string {
@@ -141,15 +169,40 @@ export class SwarmComponent implements OnInit, OnDestroy {
   scanNetwork() {
     this.scanning = true;
 
-    const { start, end } = this.calculateIpRange(window.location.hostname, '255.255.255.0');
-    const ips = Array.from({ length: end - start + 1 }, (_, i) => this.intToIp(start + i));
+    if (this.isIpAddress(window.location.hostname)) {
+      // Direct IP access - scan the subnet
+      const { start, end } = this.calculateIpRange(window.location.hostname, '255.255.255.0');
+      const ips = Array.from({ length: end - start + 1 }, (_, i) => this.intToIp(start + i));
+      this.performNetworkScan(ips);
+    } else {
+      // mDNS hostname - fetch server IP first, then scan its subnet
+      this.httpClient.get(`http://${window.location.hostname}/api/system/info`)
+        .subscribe({
+          next: (response: any) => {
+            const serverIp = response.ip;
+            const { start, end } = this.calculateIpRange(serverIp, '255.255.255.0');
+            const ips = Array.from({ length: end - start + 1 }, (_, i) => this.intToIp(start + i));
+            this.performNetworkScan(ips);
+          },
+          error: () => {
+            // Fallback: skip scanning if we can't get the IP
+            this.scanning = false;
+          }
+        });
+    }
+  }
+
+  private performNetworkScan(ips: string[]) {
     this.getAllDeviceInfo(ips, () => of(null)).subscribe({
       next: (result) => {
         // Filter out null items first
         const validResults = result.filter((item): item is SwarmDevice => item !== null);
         // Merge new results with existing swarm entries
-        const existingIps = new Set(this.swarm.map(item => item.IP));
-        const newItems = validResults.filter(item => !existingIps.has(item.IP));
+        const existingAddresses = new Set([...this.swarm.map(item => item.address), ...this.swarm.map(item => item.connectionAddress)]);
+        const newItems = validResults.filter(item => {
+          const isDuplicate = existingAddresses.has(item['hostname']) || existingAddresses.has(item['ip']);
+          return !isDuplicate;
+        });
         this.swarm = [...this.swarm, ...newItems];
         this.sortSwarm();
         this.localStorageService.setObject(SWARM_DATA, this.swarm);
@@ -162,18 +215,31 @@ export class SwarmComponent implements OnInit, OnDestroy {
     });
   }
 
-  private getAllDeviceInfo(ips: string[], errorHandler: (error: any, ip: string) => Observable<SwarmDevice[] | null>, fetchAsic: boolean = true) {
-    return from(ips).pipe(
-      mergeMap(IP => forkJoin({
-        info: this.httpClient.get<any>(`http://${IP}/api/system/info`),
-        asic: fetchAsic ? this.httpClient.get<any>(`http://${IP}/api/system/asic`).pipe(catchError(() => of({}))) : of({})
+  private getAllDeviceInfo(addresses: string[], errorHandler: (error: any, address: string) => Observable<SwarmDevice[] | null>, fetchAsic: boolean = true) {
+    return from(addresses).pipe(
+      mergeMap(address => forkJoin({
+        info: this.httpClient.get(`http://${address}/api/system/info`).pipe(catchError(() => of(null))),
+        asic: fetchAsic ? this.httpClient.get(`http://${address}/api/system/asic`).pipe(catchError(() => of({}))) : of({})
       }).pipe(
         map(({ info, asic }) => {
-          const existingDevice = this.swarm.find(device => device.IP === IP) || {};
-          return this.mergeDeviceData(IP, existingDevice, info, asic);
+          if (info === null) {
+            return null;
+          }
+
+          const existingDevice = this.swarm.find(device => device.connectionAddress === address);
+          const result = {
+            address: (info as any)['fullHostname'] || (info as any)['hostname'] || address,
+            displayName: (info as any)['hostname'] ? (info as any)['hostname'].replace(/\.local$/i, '') : address,
+            connectionAddress: address,
+            ...(existingDevice ? existingDevice : {}),
+            ...info,
+            ...asic,
+            ...this.numerizeDeviceBestDiffs(info as ISystemInfo)
+          };
+          return this.fallbackDeviceModel(result);
         }),
         timeout(5000),
-        catchError(error => errorHandler(error, IP))
+        catchError(error => errorHandler(error, address))
       ),
         128
       ),
@@ -182,74 +248,88 @@ export class SwarmComponent implements OnInit, OnDestroy {
   }
 
   public add() {
-    const IP = this.form.value.manualAddIp;
-
-    // Check if IP already exists
-    if (this.swarm.some(item => item.IP === IP)) {
-      this.toastr.warning('Device already added to the swarm.', `Device at ${IP}`);
-      return;
-    }
+    const address = this.form.value.manualAddAddress;
 
     forkJoin({
-      info: this.httpClient.get<any>(`http://${IP}/api/system/info`),
-      asic: this.httpClient.get<any>(`http://${IP}/api/system/asic`).pipe(catchError(() => of({})))
-    }).pipe(
-      timeout(5000),
-      catchError(error => this.refreshErrorHandler(error, IP))
-    ).subscribe(({ info, asic }) => {
+      info: this.httpClient.get<any>(`http://${address}/api/system/info`).pipe(catchError(error => {
+        if (error.status === 401 || error.status === 0) {
+          this.toastr.warning(`Potential swarm peer detected at ${address} - upgrade its firmware to be able to add it.`);
+          return of({ _corsError: 401 });
+        }
+        throw error;
+      })),
+      asic: this.httpClient.get<any>(`http://${address}/api/system/asic`).pipe(catchError(() => of({})))
+    }).subscribe(({ info, asic }) => {
+      if ((info as any)._corsError === 401) {
+        return; // Already showed warning
+      }
       if (!info.ASICModel || !asic.ASICModel) {
         return;
       }
-      this.swarm.push(this.mergeDeviceData(IP, {}, info, asic));
+
+      if (this.swarm.some(item => item.connectionAddress === info['ip'])) {
+        this.toastr.warning('Device already added to the swarm.', `Device at ${address}`);
+        return;
+      }
+
+      const device = {
+        address: info['fullHostname'] || info['hostname'] || address,
+        displayName: info['hostname'] ? info['hostname'].replace(/\.local$/i, '') : address,
+        connectionAddress: info['ip'] || address,
+        ...asic,
+        ...info,
+        ...this.numerizeDeviceBestDiffs(info)
+      };
+      this.swarm.push(device);
       this.sortSwarm();
       this.localStorageService.setObject(SWARM_DATA, this.swarm);
       this.calculateTotals();
     });
   }
 
-  public edit(axe: any) {
-    this.selectedAxeOs = axe;
+  public edit(device: any) {
+    this.selectedAxeOs = device;
     this.modalComponent.isVisible = true;
   }
 
-  public postAction(axe: any, action: string) {
-    this.httpClient.post(`http://${axe.IP}/api/system/${action}`, {}, { responseType: 'json' }).pipe(
+  public postAction(device: any, action: string) {
+    this.httpClient.post(`http://${device.connectionAddress}/api/system/${action}`, {}, { responseType: 'text' }).pipe(
       timeout(800),
       catchError(error => {
         if ((action === 'restart' || action === 'identify') && (error.status === 200 || error.status === 0 || error.name === 'HttpErrorResponse' || error.statusText === 'Unknown Error')) {
           if (action === 'restart') {
-            return of({ message: 'System will restarted shortly' });
+            return of('System will restart shortly');
           } else {
-            return of({ message: 'Identify signal sent - device should say "Hi!"' });
+            return of('Identify signal sent - device should say "Hi!"');
           }
         }
-        let errorMsg = `Failed to ${action} device`;
+        let errorMsg = `Failed to ${action} device at ${device.address}`;
         if (error.name === 'TimeoutError') {
           errorMsg = 'Request timed out';
         } else if (error.message) {
           errorMsg += `: ${error.message}`;
         }
-        this.toastr.error(errorMsg, `Device at ${axe.IP}`);
+        this.toastr.error(errorMsg, `Device at ${device.address}`);
         return of(null);
       })
     ).subscribe((res: any) => {
       if (res !== null) {
-        this.toastr.success(res.message, `Device at ${axe.IP}`);
+        this.toastr.success(res, `Device at ${device.address}`);
         this.refreshList(false);
       }
     });
   }
 
-  public remove(axeOs: any) {
-    this.swarm = this.swarm.filter(axe => axe.IP !== axeOs.IP);
+  public remove(device: any) {
+    this.swarm = this.swarm.filter(axe => axe.address !== device.address);
     this.localStorageService.setObject(SWARM_DATA, this.swarm);
     this.calculateTotals();
   }
 
-  public refreshErrorHandler = (error: any, ip: string) => {
+  public refreshErrorHandler = (error: any, address: string) => {
     const errorMessage = error?.message || error?.statusText || error?.toString() || 'Unknown error';
-    this.toastr.error(`Failed to get info: ${errorMessage}`, `Device at ${ip}`);
-    const existingDevice = this.swarm.find(axeOs => axeOs.IP === ip);
+    this.toastr.error(`Failed to get info: ${errorMessage}`, `Device at ${address}`);
+    const existingDevice = this.swarm.find(axeOs => axeOs.connectionAddress === address);
     return of({
       ...existingDevice,
       hashRate: 0,
@@ -270,10 +350,10 @@ export class SwarmComponent implements OnInit, OnDestroy {
     }
 
     this.refreshIntervalTime = this.refreshTimeSet;
-    const ips = this.swarm.map(axeOs => axeOs.IP);
+    const addresses = this.swarm.filter(Boolean).map(axeOs => axeOs.connectionAddress);
     this.isRefreshing = true;
 
-    this.getAllDeviceInfo(ips, this.refreshErrorHandler, fetchAsic).subscribe({
+    this.getAllDeviceInfo(addresses, this.refreshErrorHandler, fetchAsic).subscribe({
       next: (result) => {
         this.swarm = result;
         this.sortSwarm();
@@ -305,15 +385,28 @@ export class SwarmComponent implements OnInit, OnDestroy {
       let comparison = 0;
       const fieldType = typeof a[this.selectedSort.sortField];
 
-      if (this.selectedSort.sortField === 'IP') {
-        // Split IP into octets and compare numerically
-        const aOctets = a[this.selectedSort.sortField].split('.').map(Number);
-        const bOctets = b[this.selectedSort.sortField].split('.').map(Number);
-        for (let i = 0; i < 4; i++) {
-          if (aOctets[i] !== bOctets[i]) {
-            comparison = aOctets[i] - bOctets[i];
-            break;
+      if (this.selectedSort.sortField === 'address') {
+        const aValue = a[this.selectedSort.sortField];
+        const bValue = b[this.selectedSort.sortField];
+        const aIsIp = this.isIpAddress(aValue);
+        const bIsIp = this.isIpAddress(bValue);
+
+        if (aIsIp && bIsIp) {
+          // Both are IPs, sort numerically
+          const aOctets = aValue.split('.').map(Number);
+          const bOctets = bValue.split('.').map(Number);
+          for (let i = 0; i < 4; i++) {
+            if (aOctets[i] !== bOctets[i]) {
+              comparison = aOctets[i] - bOctets[i];
+              break;
+            }
           }
+        } else if (!aIsIp && !bIsIp) {
+          // Both are hostnames, sort alphabetically
+          comparison = aValue.localeCompare(bValue);
+        } else {
+          // Mixed, sort IPs before hostnames
+          comparison = aIsIp ? -1 : 1;
         }
       } else if (fieldType === 'number') {
         comparison = a[this.selectedSort.sortField] - b[this.selectedSort.sortField];
@@ -331,13 +424,33 @@ export class SwarmComponent implements OnInit, OnDestroy {
   }
 
   get deviceFamilies(): SwarmDevice[] {
-    return this.filteredSwarm.filter((v, i, a) =>
+    return this.filteredSwarm.filter(Boolean).filter((v, i, a) =>
       a.findIndex(({ deviceModel, ASICModel, asicCount }) =>
         v.deviceModel === deviceModel &&
         v.ASICModel === ASICModel &&
         v.asicCount === asicCount
       ) === i
     );
+  }
+
+  private fallbackDeviceModel(data: any): any {
+    if (data.deviceModel && data.swarmColor && data.poolDifficulty && data.hashRate) return data;
+    const deviceModel = data.deviceModel || this.deriveDeviceModel(data);
+    const swarmColor = data.swarmColor || this.deriveSwarmColor(deviceModel);
+    const poolDifficulty = data.poolDifficulty || data.stratumDiff;
+    const hashRate = data.hashRate || data.hashRate_10m;
+    return { ...data, deviceModel, swarmColor, poolDifficulty, hashRate };
+  }
+
+  private numerizeDeviceBestDiffs(info: ISystemInfo) {
+    const parseAsNumber = (val: number | string): number => {
+      return typeof val === 'string' ? this.parseSuffixString(val) : val;
+    };
+
+    return {
+      bestDiff: parseAsNumber(info.bestDiff),
+      bestSessionDiff: parseAsNumber(info.bestSessionDiff),
+    };
   }
 
   private deriveDeviceModel(data: any): string {
@@ -422,10 +535,10 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
   get sortOptions() {
     return [
-      { label: 'Hostname', value: { sortField: 'hostname', sortDirection: 'desc' } },
-      { label: 'Hostname', value: { sortField: 'hostname', sortDirection: 'asc' } },
-      { label: 'IP', value: { sortField: 'IP', sortDirection: 'desc' } },
-      { label: 'IP', value: { sortField: 'IP', sortDirection: 'asc' } },
+      { label: 'Hostname (Z-A)', value: { sortField: 'hostname', sortDirection: 'desc' } },
+      { label: 'Hostname (A-Z)', value: { sortField: 'hostname', sortDirection: 'asc' } },
+      { label: 'Address', value: { sortField: 'address', sortDirection: 'desc' } },
+      { label: 'Address', value: { sortField: 'address', sortDirection: 'asc' } },
       { label: 'Hashrate', value: { sortField: 'hashRate', sortDirection: 'desc' } },
       { label: 'Hashrate', value: { sortField: 'hashRate', sortDirection: 'asc' } },
       { label: 'Shares', value: { sortField: 'sharesAccepted', sortDirection: 'desc' } },
@@ -457,11 +570,11 @@ export class SwarmComponent implements OnInit, OnDestroy {
     }
 
     const filter = this.filterText.toLowerCase();
-    return this.swarm.filter(axe =>
-      axe.hostname.toLowerCase().includes(filter) ||
+return this.swarm.filter(axe =>
+      this.getDeviceDisplayName(axe).toLowerCase().includes(filter) ||
       axe.ASICModel.toLowerCase().includes(filter) ||
       axe.deviceModel.toLowerCase().includes(filter) ||
-      axe.IP.includes(filter)
+      axe.address.toLowerCase().includes(filter)
     );
   }
 
@@ -485,6 +598,6 @@ export class SwarmComponent implements OnInit, OnDestroy {
   }
 
   isThisDevice(IP: string): boolean {
-    return IP === window.location.hostname;
+    return IP === window.location.hostname || (this.currentDeviceIp !== null && IP === this.currentDeviceIp);
   }
 }

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -154,6 +154,12 @@ private isIpAddress(value: string): boolean {
     return device.displayName || device.address;
   }
 
+  // Utility method to get the link URL for a device
+  // Falls back to IP for older devices without mDNS
+  public getDeviceLink(device: SwarmDevice): string {
+    return device['fullHostname'] || device.connectionAddress;
+  }
+
   private intToIp(int: number): string {
     return `${(int >>> 24) & 255}.${(int >>> 16) & 255}.${(int >>> 8) & 255}.${int & 255}`;
   }

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -10,6 +10,7 @@ import { SystemInfo as ISystemInfo } from 'src/app/generated/models';
 import { ModalComponent } from '../modal/modal.component';
 
 const SWARM_DATA = 'SWARM_DATA';
+const SWARM_VERSION = 'SWARM_VERSION';
 const SWARM_REFRESH_TIME = 'SWARM_REFRESH_TIME';
 const SWARM_SORTING = 'SWARM_SORTING';
 const SWARM_GRID_VIEW = 'SWARM_GRID_VIEW';
@@ -61,6 +62,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
   public filterText = '';
 
   public currentDeviceIp: string | null = null;
+  private currentDeviceVersion: string | null = null;
 
   @HostListener('document:keydown.esc', ['$event'])
   onEscKey() {
@@ -105,15 +107,6 @@ export class SwarmComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    const swarmData = this.localStorageService.getObject(SWARM_DATA);
-
-    if (swarmData == null) {
-      this.scanNetwork();
-    } else {
-      this.swarm = swarmData;
-      this.refreshList(true);
-    }
-
     this.staticMenuDesktopSubscription = this.layoutService.getStaticMenuDesktopInactive$()
       .subscribe(inactive => {
         this.staticMenuDesktopInactive = inactive;
@@ -128,17 +121,51 @@ export class SwarmComponent implements OnInit, OnDestroy {
       }
     }, 1000);
 
-    // Fetch current device IP for isThisDevice
     this.httpClient.get(`http://${window.location.hostname}/api/system/info`).subscribe({
-      next: (response: any) => this.currentDeviceIp = response.ip,
-      error: () => this.currentDeviceIp = null
+      next: (response: any) => {
+        this.currentDeviceIp = response.ip;
+        this.currentDeviceVersion = response.version;
+        this.initSwarm(response.version);
+      },
+      error: () => {
+        this.currentDeviceIp = null;
+        this.currentDeviceVersion = null;
+        this.initSwarm(null);
+      }
     });
+  }
+
+  private initSwarm(firmwareVersion: string | null) {
+    const swarmData = this.localStorageService.getObject(SWARM_DATA);
+    const storedVersion = this.localStorageService.getItem(SWARM_VERSION);
+
+    const versionMatch = firmwareVersion && storedVersion === firmwareVersion;
+
+    if (swarmData == null || !versionMatch) {
+      if (swarmData != null && !versionMatch) {
+        this.localStorageService.removeItem(SWARM_DATA);
+      }
+      if (!firmwareVersion) {
+        this.localStorageService.removeItem(SWARM_VERSION);
+      }
+      this.scanNetwork();
+    } else {
+      this.swarm = swarmData;
+      this.refreshList(true);
+    }
   }
 
   ngOnDestroy(): void {
     this.staticMenuDesktopSubscription.unsubscribe();
     window.clearInterval(this.refreshIntervalRef);
     this.form.reset();
+  }
+
+  private saveSwarmData() {
+    this.localStorageService.setObject(SWARM_DATA, this.swarm);
+    if (this.currentDeviceVersion) {
+      this.localStorageService.setItem(SWARM_VERSION, this.currentDeviceVersion);
+    }
   }
 
   private ipToInt(ip: string): number {
@@ -158,7 +185,7 @@ private isIpAddress(value: string): boolean {
   // Utility method to get the link URL for a device
   // Falls back to IP for older devices without mDNS
   public getDeviceLink(device: SwarmDevice): string {
-    return device['fullHostname'] || device.connectionAddress;
+    return device['fullHostname'] || device.connectionAddress || device.address || '';
   }
 
   private intToIp(int: number): string {
@@ -212,7 +239,7 @@ private isIpAddress(value: string): boolean {
         });
         this.swarm = [...this.swarm, ...newItems];
         this.sortSwarm();
-        this.localStorageService.setObject(SWARM_DATA, this.swarm);
+        this.saveSwarmData();
         this.calculateTotals();
       },
       complete: () => {
@@ -289,7 +316,7 @@ private isIpAddress(value: string): boolean {
       };
       this.swarm.push(device);
       this.sortSwarm();
-      this.localStorageService.setObject(SWARM_DATA, this.swarm);
+      this.saveSwarmData();
       this.calculateTotals();
     });
   }
@@ -329,7 +356,7 @@ private isIpAddress(value: string): boolean {
 
   public remove(device: any) {
     this.swarm = this.swarm.filter(axe => axe.address !== device.address);
-    this.localStorageService.setObject(SWARM_DATA, this.swarm);
+    this.saveSwarmData();
     this.calculateTotals();
   }
 
@@ -339,13 +366,19 @@ private isIpAddress(value: string): boolean {
     const existingDevice = this.swarm.find(axeOs => axeOs.connectionAddress === address);
     return of({
       ...existingDevice,
+      address: existingDevice?.address || address,
+      connectionAddress: address,
+      ASICModel: existingDevice?.ASICModel || '',
+      deviceModel: existingDevice?.deviceModel || 'Other',
+      swarmColor: existingDevice?.swarmColor || 'gray',
+      asicCount: existingDevice?.asicCount || 1,
       hashRate: 0,
       sharesAccepted: 0,
       power: 0,
       voltage: 0,
       temp: 0,
       bestDiff: 0,
-      version: 0,
+      version: '',
       uptimeSeconds: 0,
       poolDifficulty: 0,
     });
@@ -364,7 +397,7 @@ private isIpAddress(value: string): boolean {
       next: (result) => {
         this.swarm = result;
         this.sortSwarm();
-        this.localStorageService.setObject(SWARM_DATA, this.swarm);
+        this.saveSwarmData();
         this.calculateTotals();
         this.isRefreshing = false;
       },
@@ -390,16 +423,17 @@ private isIpAddress(value: string): boolean {
   private sortSwarm() {
     this.swarm.sort((a, b) => {
       let comparison = 0;
-      const fieldType = typeof a[this.selectedSort.sortField];
+      const aVal = a[this.selectedSort.sortField];
+      const bVal = b[this.selectedSort.sortField];
+      const fieldType = typeof aVal;
 
       if (this.selectedSort.sortField === 'address') {
-        const aValue = a[this.selectedSort.sortField];
-        const bValue = b[this.selectedSort.sortField];
+        const aValue = aVal || '';
+        const bValue = bVal || '';
         const aIsIp = this.isIpAddress(aValue);
         const bIsIp = this.isIpAddress(bValue);
 
         if (aIsIp && bIsIp) {
-          // Both are IPs, sort numerically
           const aOctets = aValue.split('.').map(Number);
           const bOctets = bValue.split('.').map(Number);
           for (let i = 0; i < 4; i++) {
@@ -409,16 +443,14 @@ private isIpAddress(value: string): boolean {
             }
           }
         } else if (!aIsIp && !bIsIp) {
-          // Both are hostnames, sort alphabetically
           comparison = aValue.localeCompare(bValue);
         } else {
-          // Mixed, sort IPs before hostnames
           comparison = aIsIp ? -1 : 1;
         }
       } else if (fieldType === 'number') {
-        comparison = a[this.selectedSort.sortField] - b[this.selectedSort.sortField];
+        comparison = (aVal || 0) - (bVal || 0);
       } else if (fieldType === 'string') {
-        comparison = a[this.selectedSort.sortField].localeCompare(b[this.selectedSort.sortField], undefined, { numeric: true });
+        comparison = (aVal || '').localeCompare(bVal || '', undefined, { numeric: true });
       }
       return this.selectedSort.sortDirection === 'asc' ? comparison : -comparison;
     });
@@ -579,9 +611,9 @@ private isIpAddress(value: string): boolean {
     const filter = this.filterText.toLowerCase();
 return this.swarm.filter(axe =>
       this.getDeviceDisplayName(axe).toLowerCase().includes(filter) ||
-      axe.ASICModel.toLowerCase().includes(filter) ||
-      axe.deviceModel.toLowerCase().includes(filter) ||
-      axe.address.toLowerCase().includes(filter)
+      (axe.ASICModel || '').toLowerCase().includes(filter) ||
+      (axe.deviceModel || '').toLowerCase().includes(filter) ||
+      (axe.address || '').toLowerCase().includes(filter)
     );
   }
 

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -6,6 +6,7 @@ import { forkJoin, catchError, from, map, mergeMap, of, take, timeout, toArray, 
 import { LocalStorageService } from 'src/app/local-storage.service';
 import { LayoutService } from "../../layout/service/app.layout.service";
 import { SystemApiService } from 'src/app/services/system.service';
+import { SystemInfo as ISystemInfo } from 'src/app/generated/models';
 import { ModalComponent } from '../modal/modal.component';
 
 const SWARM_DATA = 'SWARM_DATA';

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -203,7 +203,7 @@ private isIpAddress(value: string): boolean {
   // Follows the current device's access method (IP, hostname.local, or bare hostname)
   public getDeviceLink(device: SwarmDevice): string {
     const currentHost = window.location.hostname;
-    const isIP = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(currentHost);
+    const isIP = this.isIpAddress(currentHost);
     if (isIP) {
       // Accessing via IP — link to device IP
       return device['ipv4'] || device.connectionAddress || device.address || '';

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Component, OnDestroy, OnInit, ViewChild, HostListener } from '@angular/core';
-import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormGroup, Validators, FormControl, ValidationErrors } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
 import { forkJoin, catchError, from, map, mergeMap, of, take, timeout, toArray, Observable, Subscription } from 'rxjs';
 import { LocalStorageService } from 'src/app/local-storage.service';
@@ -14,6 +14,23 @@ const SWARM_VERSION = 'SWARM_VERSION';
 const SWARM_REFRESH_TIME = 'SWARM_REFRESH_TIME';
 const SWARM_SORTING = 'SWARM_SORTING';
 const SWARM_GRID_VIEW = 'SWARM_GRID_VIEW';
+
+function addressValidator(control: AbstractControl): ValidationErrors | null {
+  const value = control.value;
+  if (!value) return null;
+  const parts = value.split('.');
+  switch (parts.length) {
+    case 1: // Bare hostname (e.g. "bitaxe")
+      return /^[a-zA-Z0-9-]+$/.test(parts[0]) ? null : { invalidAddress: true };
+    case 2: // mDNS hostname (e.g. "bitaxe.local")
+      if (parts[1].toLowerCase() === 'local' && /^[a-zA-Z0-9-]+$/.test(parts[0])) return null;
+      break;
+    case 4: // IP Address (e.g. "192.168.1.1")
+      if (parts.every((part: string) => /^\d+$/.test(part) && Number(part) >= 0 && Number(part) <= 255)) return null;
+      break;
+  }
+  return { invalidAddress: true };
+}
 
 type SwarmDevice = { 
   address: string; 
@@ -81,7 +98,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
   ) {
 
     this.form = this.fb.group({
-      manualAddAddress: [null, [Validators.required, Validators.pattern('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|[a-zA-Z0-9-]+(?:\\.local)?$')]]
+      manualAddAddress: [null, [Validators.required, addressValidator]]
     });
 
     this.gridView = this.localStorageService.getBool(SWARM_GRID_VIEW);

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -200,9 +200,20 @@ private isIpAddress(value: string): boolean {
   }
 
   // Utility method to get the link URL for a device
-  // Falls back to IP for older devices without mDNS
+  // Follows the current device's access method (IP, hostname.local, or bare hostname)
   public getDeviceLink(device: SwarmDevice): string {
-    return device['fullHostname'] || device.connectionAddress || device.address || '';
+    const currentHost = window.location.hostname;
+    const isIP = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(currentHost);
+    if (isIP) {
+      // Accessing via IP — link to device IP
+      return device['ipv4'] || device.connectionAddress || device.address || '';
+    }
+    if (currentHost.endsWith('.local')) {
+      // Accessing via mDNS — link to device's .local hostname
+      return device['fullHostname'] || device.connectionAddress || device.address || '';
+    }
+    // Accessing via bare hostname — link to device's bare hostname
+    return device['hostname'] || device.connectionAddress || device.address || '';
   }
 
   private intToIp(int: number): string {

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -123,7 +123,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
 
     this.httpClient.get(`http://${window.location.hostname}/api/system/info`).subscribe({
       next: (response: any) => {
-        this.currentDeviceIp = response.ip;
+        this.currentDeviceIp = response.ipv4;
         this.currentDeviceVersion = response.version;
         this.initSwarm(response.version);
       },
@@ -213,7 +213,7 @@ private isIpAddress(value: string): boolean {
       this.httpClient.get(`http://${window.location.hostname}/api/system/info`)
         .subscribe({
           next: (response: any) => {
-            const serverIp = response.ip;
+            const serverIp = response.ipv4;
             const { start, end } = this.calculateIpRange(serverIp, '255.255.255.0');
             const ips = Array.from({ length: end - start + 1 }, (_, i) => this.intToIp(start + i));
             this.performNetworkScan(ips);
@@ -234,7 +234,7 @@ private isIpAddress(value: string): boolean {
         // Merge new results with existing swarm entries
         const existingAddresses = new Set([...this.swarm.map(item => item.address), ...this.swarm.map(item => item.connectionAddress)]);
         const newItems = validResults.filter(item => {
-          const isDuplicate = existingAddresses.has(item['hostname']) || existingAddresses.has(item['ip']);
+          const isDuplicate = existingAddresses.has(item['hostname']) || existingAddresses.has(item['ipv4']);
           return !isDuplicate;
         });
         this.swarm = [...this.swarm, ...newItems];
@@ -301,7 +301,7 @@ private isIpAddress(value: string): boolean {
         return;
       }
 
-      if (this.swarm.some(item => item.connectionAddress === info['ip'])) {
+      if (this.swarm.some(item => item.connectionAddress === info['ipv4'])) {
         this.toastr.warning('Device already added to the swarm.', `Device at ${address}`);
         return;
       }
@@ -309,7 +309,7 @@ private isIpAddress(value: string): boolean {
       const device = {
         address: info['fullHostname'] || info['hostname'] || address,
         displayName: info['hostname'] ? info['hostname'].replace(/\.local$/i, '') : address,
-        connectionAddress: info['ip'] || address,
+        connectionAddress: info['ipv4'] || address,
         ...asic,
         ...info,
         ...this.numerizeDeviceBestDiffs(info)
@@ -643,7 +643,7 @@ return this.swarm.filter(axe =>
       return true;
     }
     
-    if (this.currentDeviceIp !== null && device['ip'] === this.currentDeviceIp) {
+    if (this.currentDeviceIp !== null && device['ipv4'] === this.currentDeviceIp) {
       return true;
     }
     

--- a/main/http_server/axe-os/src/app/local-storage.service.ts
+++ b/main/http_server/axe-os/src/app/local-storage.service.ts
@@ -43,4 +43,8 @@ export class LocalStorageService {
     const value = localStorage.getItem(key);
     return value ? Number(value) : null;
   }
+
+  removeItem(key: string) {
+    localStorage.removeItem(key);
+  }
 }

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -14,6 +14,7 @@ import {
 } from '../generated/models';
 import { Api } from '../generated/api';
 import * as functions from '../generated/functions';
+import { ISystemUpdateResponse } from 'src/models/ISystemUpdateResponse';
 
 import { environment } from '../../environments/environment';
 
@@ -328,15 +329,25 @@ export class SystemApiService {
     return of({ message: 'Device identified (mock)' });
   }
 
-  public updateSystem(uri: string = '', update: any): Observable<void> {
+  public updateSystem(uri: string = '', update: any): Observable<any | ISystemUpdateResponse> {
     if (environment.production && this.api && !uri) {
-      return from(this.api.invoke(functions.updateSystemSettings, { body: update as Settings }) as Promise<void>);
+      return from(this.api.invoke(functions.updateSystemSettings, { body: update as Settings }));
     }
 
     if (environment.production && uri) {
-      return this.httpClient.patch<void>(`${uri}/api/system`, update);
+      return this.httpClient.patch(`${uri}/api/system`, update);
     }
 
+    if (update.hostname) {
+      return of({
+        status: 'success',
+        redirect: {
+          url: `http://${update.hostname}.local`,
+          delay: 2000,
+          message: 'Hostname updated. Redirecting to new address...'
+        }
+      } as ISystemUpdateResponse);
+    }
     return of(undefined);
   }
 

--- a/main/http_server/axe-os/src/models/ISystemUpdateResponse.ts
+++ b/main/http_server/axe-os/src/models/ISystemUpdateResponse.ts
@@ -1,0 +1,8 @@
+export interface ISystemUpdateResponse {
+  status: string;
+  redirect?: {
+    url: string;
+    delay: number;
+    message: string;
+  };
+}

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -352,10 +352,53 @@ esp_err_t is_network_allowed(httpd_req_t * req)
         ESP_LOGD(CORS_TAG, "Origin contains hostname, proceeding to hostname validation");
     }
 
-    // Check if Origin header matches the avahi hostname
+    // Check if Origin header matches the avahi hostname or is a local-network hostname
     if (httpd_req_get_hdr_value_len(req, "Origin") > 0) {
         httpd_req_get_hdr_value_str(req, "Origin", origin, sizeof(origin));
         ESP_LOGD(CORS_TAG, "Origin header: %s", origin);
+
+        // Extract the host portion from the origin for local-hostname validation
+        char host_str[128] = {0};
+        const char *prefix = "http://";
+        char *host_start = strstr(origin, prefix);
+        bool is_local_hostname = false;
+        if (host_start) {
+            host_start += strlen(prefix);
+            // Strip port if present
+            char *colon = strchr(host_start, ':');
+            char *slash = strchr(host_start, '/');
+            size_t host_len = 0;
+            if (colon) {
+                host_len = colon - host_start;
+            } else if (slash) {
+                host_len = slash - host_start;
+            } else {
+                host_len = strlen(host_start);
+            }
+            if (host_len > 0 && host_len < sizeof(host_str)) {
+                strncpy(host_str, host_start, host_len);
+                host_str[host_len] = '\0';
+
+                // Allow any .local hostname (mDNS, inherently local network)
+                size_t hlen = strlen(host_str);
+                if (hlen > 6 && strcasecmp(host_str + hlen - 6, ".local") == 0) {
+                    is_local_hostname = true;
+                    ESP_LOGD(CORS_TAG, "Origin host '%s' is a .local mDNS hostname - allowing", host_str);
+                }
+                // Allow any bare hostname (no dots, only resolvable on local network)
+                else if (strchr(host_str, '.') == NULL) {
+                    is_local_hostname = true;
+                    ESP_LOGD(CORS_TAG, "Origin host '%s' is a bare local hostname - allowing", host_str);
+                }
+            }
+        }
+
+        if (is_local_hostname) {
+            ESP_LOGD(CORS_TAG, "Request from local hostname - allowing access");
+            return ESP_OK;
+        }
+
+        // Fall back to exact match against this device's configured hostname
         char *hostname = nvs_config_get_string(NVS_CONFIG_HOSTNAME);
         ESP_LOGD(CORS_TAG, "Configured hostname: %s", hostname);
         // Match origin as http://<hostname>.local[:port] or http://<hostname>[:port]

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -696,7 +696,7 @@ bool check_settings_and_update(const cJSON * const root, char **redirect_url)
                         strlcpy(normalized_hostname, item->valuestring, sizeof(normalized_hostname));
                         normalize_hostname(normalized_hostname, sizeof(normalized_hostname));
                         nvs_config_set_string(key, normalized_hostname);
-                        update_mdns_hostname(normalized_hostname);
+                        update_mdns_hostname(normalized_hostname, GLOBAL_STATE);
                         ESP_LOGI(TAG, "Updated hostname to: %s", normalized_hostname);
                     }
                     else
@@ -1010,23 +1010,13 @@ static esp_err_t GET_system_info(httpd_req_t * req)
 
     // Add mDNS-specific fields on top of the base system info
     char * hostname_base = nvs_config_get_string(NVS_CONFIG_HOSTNAME);
-    char mdns_hostname[64] = {0};
+    char * mdns_hostname = GLOBAL_STATE->SYSTEM_MODULE.mdns_hostname;
     char full_hostname[64];
     
-    // Get the base hostname from mDNS if available
-    if (GLOBAL_STATE->SYSTEM_MODULE.is_connected) {
-        esp_err_t mdns_err = mdns_hostname_get(mdns_hostname);
-        ESP_LOGI(TAG, "mdns_hostname_get returned %d, hostname: %s", mdns_err, mdns_hostname);
-        if (mdns_err == ESP_OK && strlen(mdns_hostname) > 0) {
-            snprintf(full_hostname, sizeof(full_hostname), "%s.local", mdns_hostname);
-            ESP_LOGI(TAG, "Using mDNS hostname: %s", full_hostname);
-        } else {
-            strcpy(full_hostname, hostname_base);
-            ESP_LOGI(TAG, "Using base hostname: %s", full_hostname);
-        }
+    if (mdns_hostname != NULL && strlen(mdns_hostname) > 0) {
+        snprintf(full_hostname, sizeof(full_hostname), "%s.local", mdns_hostname);
     } else {
-        strcpy(full_hostname, hostname_base);
-        ESP_LOGI(TAG, "Device not connected, using base hostname: %s", full_hostname);
+        snprintf(full_hostname, sizeof(full_hostname), "%s.local", hostname_base);
     }
 
     cJSON_AddStringToObject(root, "fullHostname", full_hostname);

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -352,29 +352,30 @@ esp_err_t is_network_allowed(httpd_req_t * req)
         ESP_LOGD(CORS_TAG, "Origin contains hostname, proceeding to hostname validation");
     }
 
-    // Check if Origin header matches the avahi hostname    
+    // Check if Origin header matches the avahi hostname
     if (httpd_req_get_hdr_value_len(req, "Origin") > 0) {
         httpd_req_get_hdr_value_str(req, "Origin", origin, sizeof(origin));
         ESP_LOGD(CORS_TAG, "Origin header: %s", origin);
         char *hostname = nvs_config_get_string(NVS_CONFIG_HOSTNAME);
         ESP_LOGD(CORS_TAG, "Configured hostname: %s", hostname);
-        char expected[256];
-        snprintf(expected, sizeof(expected), "http://%s.local", hostname);
-        ESP_LOGD(CORS_TAG, "Expected origin with .local: %s", expected);
-        if (strcmp(origin, expected) == 0) {
-            free(hostname);
-            ESP_LOGD(CORS_TAG, "Request from avahi hostname - allowing access");
-            return ESP_OK;
+        // Match origin as http://<hostname>.local[:port] or http://<hostname>[:port]
+        const char *patterns[] = { "http://%s.local", "http://%s" };
+        bool matched = false;
+        for (int i = 0; i < 2 && !matched; i++) {
+            char expected[256];
+            snprintf(expected, sizeof(expected), patterns[i], hostname);
+            size_t len = strlen(expected);
+            // Origin must start with expected, followed by end-of-string or ':port'
+            if (strncmp(origin, expected, len) == 0 &&
+                (origin[len] == '\0' || origin[len] == ':')) {
+                matched = true;
+            }
         }
-        // Also check without .local suffix
-        snprintf(expected, sizeof(expected), "http://%s", hostname);
-        ESP_LOGD(CORS_TAG, "Expected origin without .local: %s", expected);
-        if (strcmp(origin, expected) == 0) {
-            free(hostname);
+        free(hostname);
+        if (matched) {
             ESP_LOGD(CORS_TAG, "Request from hostname - allowing access");
             return ESP_OK;
         }
-        free(hostname);
     } else {
         ESP_LOGD(CORS_TAG, "No Origin header found");
     }
@@ -1023,7 +1024,6 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     if (strlen(mdns_hostname) > 0) {
         cJSON_AddStringToObject(root, "mdnsHostname", mdns_hostname);
     }
-    cJSON_AddStringToObject(root, "ipv6", GLOBAL_STATE->SYSTEM_MODULE.ipv6_addr_str);
 
     free(hostname_base);
 

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -1011,12 +1011,12 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     // Add mDNS-specific fields on top of the base system info
     char * hostname_base = nvs_config_get_string(NVS_CONFIG_HOSTNAME);
     char * mdns_hostname = GLOBAL_STATE->SYSTEM_MODULE.mdns_hostname;
-    char full_hostname[64];
+    char full_hostname[72]; // 64 (mdns_hostname max) + 6 (".local") + 2 (margin)
     
     if (mdns_hostname != NULL && strlen(mdns_hostname) > 0) {
         snprintf(full_hostname, sizeof(full_hostname), "%s.local", mdns_hostname);
     } else {
-        snprintf(full_hostname, sizeof(full_hostname), "%s.local", hostname_base);
+        snprintf(full_hostname, sizeof(full_hostname), "%s.local", hostname_base ? hostname_base : "unknown");
     }
 
     cJSON_AddStringToObject(root, "fullHostname", full_hostname);

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -21,6 +21,9 @@
 #include "esp_ota_ops.h"
 #include "esp_wifi.h"
 #include "lwip/inet.h"
+#include <arpa/inet.h>
+#include "lwip/lwip_napt.h"
+#include "lwip/netdb.h"
 #include "lwip/sockets.h"
 
 #include "cJSON.h"
@@ -32,6 +35,7 @@
 #include "theme_api.h"
 #include "axe-os/api/system/asic_settings.h"
 #include "display.h"
+#include "mdns.h"
 #include "http_server.h"
 #include "websocket.h"
 #include "websocket_log.h"
@@ -248,35 +252,58 @@ static esp_err_t ip_in_private_range(uint32_t address) {
 
 static uint32_t extract_origin_ip_addr(char *origin)
 {
-    char ip_str[16];
+    char host_str[128];
     uint32_t origin_ip_addr = 0;
 
-    // Find the start of the IP address in the Origin header
+    // Find the start of the hostname in the Origin header
     const char *prefix = "http://";
-    char *ip_start = strstr(origin, prefix);
-    if (ip_start) {
-        ip_start += strlen(prefix); // Move past "http://"
+    char *host_start = strstr(origin, prefix);
+    if (host_start) {
+        host_start += strlen(prefix); // Move past "http://"
 
-        // Extract the IP address portion (up to the next '/')
-        char *ip_end = strchr(ip_start, '/');
-        size_t ip_len = ip_end ? (size_t)(ip_end - ip_start) : strlen(ip_start);
-        if (ip_len < sizeof(ip_str)) {
-            strncpy(ip_str, ip_start, ip_len);
-            ip_str[ip_len] = '\0'; // Null-terminate the string
+        // Extract the hostname portion (up to the next '/')
+        char *host_end = strchr(host_start, '/');
+        size_t host_len = host_end ? (size_t)(host_end - host_start) : strlen(host_start);
+        if (host_len < sizeof(host_str)) {
+            strncpy(host_str, host_start, host_len);
+            host_str[host_len] = '\0'; // Null-terminate the string
 
-            // Convert the IP address string to uint32_t
-            origin_ip_addr = inet_addr(ip_str);
-            if (origin_ip_addr == INADDR_NONE) {
-                ESP_LOGW(CORS_TAG, "Invalid IP address: %s", ip_str);
-            } else {
+            // Check if it's an IP address or hostname
+            struct in_addr addr;
+            if (inet_pton(AF_INET, host_str, &addr) == 1) {
+                origin_ip_addr = addr.s_addr;
                 ESP_LOGD(CORS_TAG, "Extracted IP address %lu", origin_ip_addr);
+            } else {
+                ESP_LOGD(CORS_TAG, "Origin contains hostname: %s (not an IP)", host_str);
+                // For hostnames, return 0 to indicate it's not an IP address
+                origin_ip_addr = 0;
             }
         } else {
-            ESP_LOGW(CORS_TAG, "IP address string is too long: %s", ip_start);
+            ESP_LOGW(CORS_TAG, "Hostname string is too long: %s", host_start);
         }
     }
 
     return origin_ip_addr;
+}
+
+// Helper function to normalize hostname by stripping ".local" suffix if present
+// This prevents Avahi from creating duplicate ".local.local" hostnames
+static void normalize_hostname(char *hostname, size_t max_len) {
+    if (hostname == NULL || strlen(hostname) == 0) {
+        return;
+    }
+
+    size_t len = strlen(hostname);
+    const char *suffix = ".local";
+    size_t suffix_len = strlen(suffix);
+
+    // Check if hostname ends with ".local" (case-insensitive)
+    if (len > suffix_len &&
+        strcasecmp(hostname + len - suffix_len, suffix) == 0) {
+        // Strip the ".local" suffix
+        hostname[len - suffix_len] = '\0';
+        ESP_LOGD(TAG, "Normalized hostname from '%s.local' to '%s'", hostname, hostname);
+    }
 }
 
 esp_err_t is_network_allowed(httpd_req_t * req)
@@ -315,8 +342,41 @@ esp_err_t is_network_allowed(httpd_req_t * req)
         origin_ip_addr = request_ip_addr;
     }
 
-    if (ip_in_private_range(origin_ip_addr) == ESP_OK && ip_in_private_range(request_ip_addr) == ESP_OK) {
+    if (origin_ip_addr != 0 && ip_in_private_range(origin_ip_addr) == ESP_OK && ip_in_private_range(request_ip_addr) == ESP_OK) {
+        ESP_LOGD(CORS_TAG, "Origin and IP both in private range. Allowing.");
         return ESP_OK;
+    }
+    
+    // If origin contains hostname (origin_ip_addr == 0), proceed to hostname validation
+    if (origin_ip_addr == 0) {
+        ESP_LOGD(CORS_TAG, "Origin contains hostname, proceeding to hostname validation");
+    }
+
+    // Check if Origin header matches the avahi hostname    
+    if (httpd_req_get_hdr_value_len(req, "Origin") > 0) {
+        httpd_req_get_hdr_value_str(req, "Origin", origin, sizeof(origin));
+        ESP_LOGD(CORS_TAG, "Origin header: %s", origin);
+        char *hostname = nvs_config_get_string(NVS_CONFIG_HOSTNAME);
+        ESP_LOGD(CORS_TAG, "Configured hostname: %s", hostname);
+        char expected[256];
+        snprintf(expected, sizeof(expected), "http://%s.local", hostname);
+        ESP_LOGD(CORS_TAG, "Expected origin with .local: %s", expected);
+        if (strcmp(origin, expected) == 0) {
+            free(hostname);
+            ESP_LOGD(CORS_TAG, "Request from avahi hostname - allowing access");
+            return ESP_OK;
+        }
+        // Also check without .local suffix
+        snprintf(expected, sizeof(expected), "http://%s", hostname);
+        ESP_LOGD(CORS_TAG, "Expected origin without .local: %s", expected);
+        if (strcmp(origin, expected) == 0) {
+            free(hostname);
+            ESP_LOGD(CORS_TAG, "Request from hostname - allowing access");
+            return ESP_OK;
+        }
+        free(hostname);
+    } else {
+        ESP_LOGD(CORS_TAG, "No Origin header found");
     }
 
     ESP_LOGI(CORS_TAG, "Client is NOT in the private ip ranges or same range as server.");
@@ -513,9 +573,24 @@ static esp_err_t handle_options_request(httpd_req_t * req)
     return ESP_OK;
 }
 
-bool check_settings_and_update(const cJSON * const root)
+bool check_settings_and_update(const cJSON * const root, char **redirect_url)
 {
     bool result = true;
+    char *old_hostname = NULL;
+    bool hostname_changed = false;
+
+    // Check for hostname change first
+    cJSON *hostname_item = cJSON_GetObjectItem(root, "hostname");
+    if (hostname_item && cJSON_IsString(hostname_item)) {
+        old_hostname = nvs_config_get_string(NVS_CONFIG_HOSTNAME);
+        char normalized_new_hostname[64];
+        strlcpy(normalized_new_hostname, hostname_item->valuestring, sizeof(normalized_new_hostname));
+        normalize_hostname(normalized_new_hostname, sizeof(normalized_new_hostname));
+        if (strcmp(old_hostname, normalized_new_hostname) != 0) {
+            hostname_changed = true;
+            ESP_LOGI(TAG, "Hostname change detected: %s -> %s", old_hostname, hostname_item->valuestring);
+        }
+    }
 
     for (NvsConfigKey key = 0; key < NVS_CONFIG_COUNT; key++) {
         Settings *setting = nvs_config_get_settings(key);
@@ -614,7 +689,21 @@ bool check_settings_and_update(const cJSON * const root)
 
             switch(setting->type) {
                 case TYPE_STR:
-                    nvs_config_set_string(key, item->valuestring);
+
+                    if (key == NVS_CONFIG_HOSTNAME)
+                    {
+                        char normalized_hostname[64];
+                        strlcpy(normalized_hostname, item->valuestring, sizeof(normalized_hostname));
+                        normalize_hostname(normalized_hostname, sizeof(normalized_hostname));
+                        nvs_config_set_string(key, normalized_hostname);
+                        update_mdns_hostname(normalized_hostname);
+                        ESP_LOGI(TAG, "Updated hostname to: %s", normalized_hostname);
+                    }
+                    else
+                    {
+                        nvs_config_set_string(key, item->valuestring);
+                    }
+
                     break;
                 case TYPE_U16:
                     nvs_config_set_u16(key, (uint16_t)item->valueint);
@@ -633,6 +722,23 @@ bool check_settings_and_update(const cJSON * const root)
                     break;
             }
         }
+    }
+
+    // Set redirect URL if hostname changed
+    if (hostname_changed && redirect_url) {
+        char *current_hostname = nvs_config_get_string(NVS_CONFIG_HOSTNAME);
+        if (current_hostname) {
+            *redirect_url = malloc(256);
+            if (*redirect_url) {
+                snprintf(*redirect_url, 256, "http://%s.local", current_hostname);
+                ESP_LOGI(TAG, "Hostname redirect URL set: %s", *redirect_url);
+            }
+            free(current_hostname);
+        }
+    }
+
+    if (old_hostname) {
+        free(old_hostname);
     }
 
     return result;
@@ -682,8 +788,12 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
                             (current_hostname == NULL || strcmp(current_hostname, hostname_item->valuestring) != 0);
     free(current_hostname);
 
-    if (!check_settings_and_update(root)) {
+    char *redirect_url = NULL;
+    if (!check_settings_and_update(root, &redirect_url)) {
         cJSON_Delete(root);
+        if (redirect_url) {
+            free(redirect_url);
+        }
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Wrong API input");
         return ESP_OK;
     }
@@ -695,9 +805,27 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
         }
     }
 
-    cJSON_Delete(root);
-    httpd_resp_send_chunk(req, NULL, 0);
-    return ESP_OK;
+    // Create response JSON
+    cJSON *response = cJSON_CreateObject();
+    if (redirect_url) {
+        cJSON_AddStringToObject(response, "status", "success");
+        cJSON *redirect = cJSON_CreateObject();
+        cJSON_AddStringToObject(redirect, "url", redirect_url);
+        cJSON_AddNumberToObject(redirect, "delay", 2000);
+        cJSON_AddStringToObject(redirect, "message", "Hostname updated. Redirecting to new address...");
+        cJSON_AddItemToObject(response, "redirect", redirect);
+        
+        ESP_LOGI(TAG, "Sending hostname change redirect response");
+        esp_err_t res = HTTP_send_json(req, response, &api_common_prebuffer_len);
+        cJSON_Delete(response);
+        free(redirect_url);
+        cJSON_Delete(root);
+        return res;
+    } else {
+        cJSON_Delete(root);
+        httpd_resp_send_chunk(req, NULL, 0);
+        return ESP_OK;
+    }
 }
 
 static esp_err_t POST_identify(httpd_req_t * req)
@@ -879,6 +1007,35 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     }
 
     cJSON * root = system_api_get_full_json(GLOBAL_STATE);
+
+    // Add mDNS-specific fields on top of the base system info
+    char * hostname_base = nvs_config_get_string(NVS_CONFIG_HOSTNAME);
+    char mdns_hostname[64] = {0};
+    char full_hostname[64];
+    
+    // Get the base hostname from mDNS if available
+    if (GLOBAL_STATE->SYSTEM_MODULE.is_connected) {
+        esp_err_t mdns_err = mdns_hostname_get(mdns_hostname);
+        ESP_LOGI(TAG, "mdns_hostname_get returned %d, hostname: %s", mdns_err, mdns_hostname);
+        if (mdns_err == ESP_OK && strlen(mdns_hostname) > 0) {
+            snprintf(full_hostname, sizeof(full_hostname), "%s.local", mdns_hostname);
+            ESP_LOGI(TAG, "Using mDNS hostname: %s", full_hostname);
+        } else {
+            strcpy(full_hostname, hostname_base);
+            ESP_LOGI(TAG, "Using base hostname: %s", full_hostname);
+        }
+    } else {
+        strcpy(full_hostname, hostname_base);
+        ESP_LOGI(TAG, "Device not connected, using base hostname: %s", full_hostname);
+    }
+
+    cJSON_AddStringToObject(root, "fullHostname", full_hostname);
+    if (strlen(mdns_hostname) > 0) {
+        cJSON_AddStringToObject(root, "mdnsHostname", mdns_hostname);
+    }
+    cJSON_AddStringToObject(root, "ipv6", GLOBAL_STATE->SYSTEM_MODULE.ipv6_addr_str);
+
+    free(hostname_base);
 
     esp_err_t res = HTTP_send_json(req, root, &system_info_prebuffer_len);
 

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -330,6 +330,12 @@ components:
         hostname:
           type: string
           description: Device hostname
+        fullHostname:
+          type: string
+          description: Full hostname including .local domain for mDNS
+        mdnsHostname:
+          type: string
+          description: mDNS/Bonjour hostname for network discovery
         idfVersion:
           type: string
           description: ESP-IDF version

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -24,6 +24,21 @@ components:
       properties:
         message:
           type: string
+    UpdateSettingsResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: success
+        redirect:
+          type: object
+          properties:
+            url:
+              type: string
+            delay:
+              type: number
+            message:
+              type: string
     SharesRejectedReason:
       type: object
       required:
@@ -1103,6 +1118,10 @@ paths:
       responses:
         '200':
           description: Settings updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateSettingsResponse'
         '400':
           description: Invalid settings provided
         '401':

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -3,6 +3,7 @@ dependencies:
   lvgl/lvgl: "9.3.0"
   espressif/esp_lvgl_port: "2.6.3"
   esp_lcd_sh1107: "1.1.0"  
+  espressif/mdns: "^1.8.0"
   ## Required IDF version
   idf:
     version: ">=5.5.0"

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Available API endpoints:
 * `/api/ws` Text stream log
 * `/api/ws/live` JSONp stream of partial system info updates
 
-### API examples in `curl`:
+### API examples in `curl` (works with IP addresses or .local hostnames):
 
 ```bash
 # Get system information
@@ -137,6 +137,56 @@ websocat ws://YOUR-BITAXE-IP/api/ws
 # Stream Info API
 websocat ws://YOUR-BITAXE-IP/api/ws/live
 ```
+
+## mDNS Support
+
+ESP-Miner now includes comprehensive mDNS (multicast DNS) support for seamless network discovery and device accessibility. This feature enables automatic device discovery on local networks without requiring manual IP address configuration.
+
+### Features
+
+- **Automatic mDNS Initialization**: Device automatically registers with mDNS/Bonjour/Avahi services on network connection
+- **Dynamic Hostname Registration**: Device hostname is registered as `<hostname>.local` (e.g., `bitaxe.local`)
+- **Service Advertisement**: HTTP service is advertised as `_http._tcp` on port 80
+- **Dynamic Hostname Updates**: mDNS hostname updates automatically when device hostname is changed via web interface
+- **Hostname Normalization**: Automatically strips `.local` suffix when setting hostnames to prevent duplicate registrations
+- **CORS Support**: Enhanced CORS handling to allow requests from mDNS hostnames
+- **Hostname Conflict Resolution**: Automatically detects and resolves hostname conflicts by appending MAC address suffix when needed
+- **Enhanced Swarm Discovery**: Swarm mode supports both IP addresses and .local hostnames for seamless network management
+
+### Network Discovery
+
+Once connected to your local network, the device becomes discoverable through:
+
+```bash
+# Using avahi-browse (Linux)
+avahi-browse _http._tcp
+
+# Using dns-sd (macOS)
+dns-sd -B _http._tcp
+
+# Direct access
+http://<hostname>.local
+```
+
+### Configuration
+
+- **Default Hostname**: `bitaxe` (configurable via web interface)
+- **Service Type**: `_http._tcp`
+- **Port**: `80`
+- **Instance Name**: `ESP-Miner Web Server`
+
+### Hostname Conflict Resolution
+
+If multiple devices attempt to use the same hostname, ESP-Miner automatically resolves conflicts by appending a MAC address-derived suffix (e.g., `bitaxe-12ab` if `bitaxe` is taken). This ensures unique network identification without manual intervention.
+
+### Benefits
+
+- **Zero-Configuration Discovery**: Devices automatically appear in network browsers
+- **Cross-Platform Compatibility**: Works with Windows, macOS, Linux, and mobile devices
+- **No IP Address Required**: Access devices using human-readable names
+- **Automatic Resolution**: DNS resolution happens transparently in the background
+- **Zero-Configuration Swarm Management**: Automatic device discovery and management without IP configuration
+- **Enhanced Cross-Platform Compatibility**: Improved support across different network environments and discovery protocols
 
 ## Administration
 

--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,8 @@ ESP-Miner now includes comprehensive mDNS (multicast DNS) support for seamless n
 - **Automatic mDNS Initialization**: Device automatically registers with mDNS/Bonjour/Avahi services on network connection
 - **Dynamic Hostname Registration**: Device hostname is registered as `<hostname>.local` (e.g., `bitaxe.local`)
 - **Service Advertisement**: HTTP service is advertised as `_http._tcp` on port 80
+- **AxeOS Subtype**: Advertises `_axeos._sub._http._tcp` for targeted DNS-SD discovery of AxeOS devices
+- **Device TXT Records**: Includes board version, family, ASIC model, ASIC count, and firmware version as DNS-SD TXT records
 - **Dynamic Hostname Updates**: mDNS hostname updates automatically when device hostname is changed via web interface
 - **Hostname Normalization**: Automatically strips `.local` suffix when setting hostnames to prevent duplicate registrations
 - **CORS Support**: Enhanced CORS handling to allow requests from mDNS hostnames
@@ -161,8 +163,14 @@ Once connected to your local network, the device becomes discoverable through:
 # Using avahi-browse (Linux)
 avahi-browse _http._tcp
 
+# Discover AxeOS devices specifically
+avahi-browse _axeos._sub._http._tcp
+
 # Using dns-sd (macOS)
 dns-sd -B _http._tcp
+
+# Discover AxeOS devices with TXT records
+dns-sd -B _axeos._sub._http._tcp
 
 # Direct access
 http://<hostname>.local
@@ -172,8 +180,10 @@ http://<hostname>.local
 
 - **Default Hostname**: `bitaxe` (configurable via web interface)
 - **Service Type**: `_http._tcp`
+- **Subtype**: `_axeos._sub._http._tcp`
 - **Port**: `80`
-- **Instance Name**: `ESP-Miner Web Server`
+- **Instance Name**: `Bitaxe <family> <board> (<mac_suffix>)` (e.g., `Bitaxe Gamma 601 (A1B2)`)
+- **TXT Records**: `board`, `family`, `asic`, `asic_count`, `fw_version`
 
 ### Hostname Conflict Resolution
 


### PR DESCRIPTION
## Pull Request: Add mDNS Support for Network Discovery and Dynamic Hostname Updates

### Summary
This PR implements comprehensive mDNS (Multicast DNS) support for the ESP-Miner device, enabling seamless network discovery and dynamic hostname management. The implementation allows devices to be discovered automatically on local networks using Bonjour/Avahi-compatible services.

### Key Features Added

#### 🔍 **Network Discovery**
- **mDNS Service Registration**: Device automatically registers as "ESP-Miner Web Server" with HTTP service on port 80
- **Bonjour/Avahi Compatibility**: Device is discoverable using standard network discovery tools
- **Zero-Configuration Networking**: No manual IP address configuration needed for local access

#### 🌐 **Dynamic Hostname Management**
- **Automatic mDNS Hostname Setup**: Hostname is set during WiFi initialization
- **Dynamic Updates**: Hostname changes are reflected in mDNS immediately when updated via web interface
- **Hostname Normalization**: Prevents duplicate ".local.local" suffixes by stripping existing ".local" before setting

#### 🛡️ **Enhanced Security & Usability**
- **Simplified CORS Logic**: Streamlined network access validation for private IP ranges
- **Graceful Degradation**: mDNS failures don't prevent device operation, only log warnings
- **Comprehensive Logging**: Detailed status messages for troubleshooting

### Technical Implementation

#### Files Modified:
1. **`components/connect/CMakeLists.txt`** - Added mDNS component dependency
2. **`components/connect/connect.c`** - Core mDNS initialization and management
3. **`components/connect/include/connect.h`** - Public API for hostname updates
4. **`main/http_server/http_server.c`** - Dynamic hostname updates and CORS improvements
5. **`main/idf_component.yml`** - Added espressif/mdns dependency

#### Key Functions Added:
- `mdns_init()` - Initializes mDNS service
- `mdns_hostname_set()` - Sets device hostname for discovery
- `mdns_service_add()` - Registers HTTP service
- `update_mdns_hostname()` - Dynamic hostname updates
- `normalize_hostname()` - Prevents hostname conflicts

### Usage Examples

#### Network Discovery:
```bash
# Discover device using avahi-browse
avahi-browse _http._tcp

# Access via mDNS hostname
curl http://esp-miner-XXXX.local
```

#### Web Interface Updates:
- Hostname changes in the web UI now immediately update mDNS
- Device remains discoverable with new hostname without restart

### Benefits

✅ **Improved User Experience**: No need to remember IP addresses  
✅ **Network-Friendly**: Works with existing Bonjour/Avahi infrastructure  
✅ **Dynamic Configuration**: Hostname changes take effect immediately  
✅ **Backward Compatible**: Existing functionality remains unchanged  
✅ **Robust Error Handling**: Graceful degradation on mDNS failures  

### Testing Considerations

- Verify device appears in network discovery tools (avahi-browse, Bonjour Browser)
- Test hostname updates via web interface
- Confirm HTTP access works via `.local` hostname
- Test behavior when mDNS initialization fails
- Validate CORS still works for private network access

### Dependencies Added
- `espressif/mdns: ^1.8.0` - Official ESP-IDF mDNS component

This implementation provides a solid foundation for network discovery and makes the ESP-Miner much more user-friendly in home and enterprise networks.