### PR TITLE
Refactor hashrate to float and timestamps to ms

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,7 +55,15 @@
         "cmath": "c",
         "utils.h": "c",
         "task.h": "c",
-        "stdlib.h": "c"
+        "stdlib.h": "c",
+        "esp_heap_caps.h": "c",
+        "common.h": "c",
+        "device_config.h": "c",
+        "statistics_task.h": "c",
+        "http_server.h": "c",
+        "algorithm": "c",
+        "bm1370.h": "c",
+        "sha256.h": "c"
     },
     "editor.formatOnSave": false,
     "cSpell.words": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,15 +55,6 @@
         "cmath": "c",
         "utils.h": "c",
         "task.h": "c",
-        "stdlib.h": "c",
-        "esp_heap_caps.h": "c",
-        "common.h": "c",
-        "device_config.h": "c",
-        "statistics_task.h": "c",
-        "http_server.h": "c",
-        "algorithm": "c",
-        "bm1370.h": "c",
-        "sha256.h": "c"
     },
     "editor.formatOnSave": false,
     "cSpell.words": [

--- a/components/stratum/include/utils.h
+++ b/components/stratum/include/utils.h
@@ -38,6 +38,8 @@ double networkDifficulty(uint32_t nBits);
 
 void suffixString(uint64_t val, char * buf, size_t bufsiz, int sigdigits);
 
+float hashCounterToHashrate(uint32_t duration_ms, uint32_t counter);
+
 #define STRATUM_DEFAULT_VERSION_MASK 0x1fffe000
 
 #endif // STRATUM_UTILS_H

--- a/components/stratum/utils.c
+++ b/components/stratum/utils.c
@@ -6,6 +6,8 @@
 
 #include "mbedtls/sha256.h"
 
+#define HASH_CNT_LSB 0x100000000uLL // 2^32 hashes for difficulty 1
+
 #ifndef bswap_16
 #define bswap_16(a) ((((uint16_t)(a) << 8) & 0xff00) | (((uint16_t)(a) >> 8) & 0xff))
 #endif
@@ -373,4 +375,10 @@ void suffixString(uint64_t val, char * buf, size_t bufsiz, int sigdigits)
 
         snprintf(buf, bufsiz, "%*.*f %s", sigdigits + 1, ndigits, dval, suffix);
     }
+}
+
+float hashCounterToHashrate(uint32_t duration_ms, uint32_t counter)
+{
+    if (duration_ms == 0) return 0.0f;
+    return counter / (duration_ms / 1000.0) * (float)HASH_CNT_LSB; // Make sure it stays in float
 }

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -26,12 +26,12 @@ typedef struct {
 
 typedef struct
 {
-    double duration_start;
+    uint32_t duration_start;
     int historical_hashrate_rolling_index;
-    double historical_hashrate_time_stamps[HISTORY_LENGTH];
-    double historical_hashrate[HISTORY_LENGTH];
+    uint32_t historical_hashrate_time_stamps[HISTORY_LENGTH];
+    uint16_t historical_hashrate[HISTORY_LENGTH];
     int historical_hashrate_init;
-    double current_hashrate;
+    float current_hashrate;
     int64_t start_time;
     uint64_t shares_accepted;
     uint64_t shares_rejected;

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -416,34 +416,34 @@ bool self_test(void * pvParameters)
     //(*GLOBAL_STATE->ASIC_functions.send_work_fn)(GLOBAL_STATE, &job);
     ASIC_send_work(GLOBAL_STATE, &job);
     
-    double start = esp_timer_get_time();
-    double sum = 0;
-    double duration = 0;
-    double hash_rate = 0;
-    double hashtest_timeout = 5;
+    uint32_t start_ms = esp_timer_get_time() / 1000;
+    uint32_t duration_ms = 0;
+    uint32_t counter = 0;
+    float hashrate = 0;
+    uint32_t hashtest_ms = 5000;
 
-    while (duration < hashtest_timeout) {
+    while (duration_ms < hashtest_ms) {
         task_result * asic_result = ASIC_process_work(GLOBAL_STATE);
         if (asic_result != NULL) {
             // check the nonce difficulty
             double nonce_diff = test_nonce_value(&job, asic_result->nonce, asic_result->rolled_version);
-            sum += DIFFICULTY;
-            
-            hash_rate = (sum * 4294967296) / (duration * 1000000000);
+            counter += DIFFICULTY;
+            duration_ms = (esp_timer_get_time() / 1000) - start_ms;
+            hashrate = hashCounterToHashrate(duration_ms, counter) / 1e9f;
+
             ESP_LOGI(TAG, "Nonce %lu Nonce difficulty %.32f.", asic_result->nonce, nonce_diff);
-            ESP_LOGI(TAG, "%f Gh/s  , duration %f",hash_rate, duration);
+            ESP_LOGI(TAG, "%f Gh/s  , duration %dms", hashrate, duration_ms);
         }
-        duration = (double) (esp_timer_get_time() - start) / 1000000;
     }
 
-    ESP_LOGI(TAG, "Hashrate: %f", hash_rate);
+    ESP_LOGI(TAG, "Hashrate: %f", hashrate);
 
     float expected_hashrate_mhs = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value 
                                 * GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count 
                                 * GLOBAL_STATE->DEVICE_CONFIG.family.asic.hashrate_test_percentage_target
                                 / 1000.0f;
 
-    if (hash_rate < expected_hashrate_mhs) {
+    if (hashrate < expected_hashrate_mhs) {
         display_msg("HASHRATE:FAIL", GLOBAL_STATE);
         tests_done(GLOBAL_STATE, false);
     }

--- a/main/tasks/statistics_task.h
+++ b/main/tasks/statistics_task.h
@@ -7,7 +7,7 @@ typedef struct StatisticsData * StatisticsNextNodePtr;
 struct StatisticsData
 {
     int64_t timestamp;
-    double hashrate;
+    float hashrate;
     float chipTemperature;
     float vrTemperature;
     float power;


### PR DESCRIPTION
From the [documentation](https://docs.espressif.com/projects/esp-idf/en/v5.5.1/esp32s2/api-guides/performance/speed.html#improving-overall-speed):

 > Avoid using double precision floating point arithmetic double. These calculations are emulated in software and are very slow. If possible then use an integer-based representation, or single-precision floating point.

As for hashrate, floats are precise enough, the calculations have been refactored. For the same reason times used for hashrate calculations are now in milliseconds, which fit in `uint32_t`. This saves some memory for f.e. statistics.