### PR TITLE
Init hashrate register statistics data if hashrate registers are not available

### DIFF
--- a/main/tasks/hashrate_monitor_task.c
+++ b/main/tasks/hashrate_monitor_task.c
@@ -79,11 +79,20 @@ void hashrate_monitor_task(void *pvParameters)
     HASHRATE_MONITOR_MODULE->domain_3_measurement = malloc(asic_count * sizeof(measurement_t));
     HASHRATE_MONITOR_MODULE->error_measurement = malloc(asic_count * sizeof(measurement_t));
 
+    // Initialize all measurement arrays to zero to prevent garbage data on chips without register support
+    clear_measurements(HASHRATE_MONITOR_MODULE, asic_count);
+
     HASHRATE_MONITOR_MODULE->is_initialized = true;
+
+    // Only BM1370 supports register-based hashrate monitoring
+    // adding BM1366 and BM1368 later
+    bool supports_register_reading = (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id == BM1370);
 
     TickType_t taskWakeTime = xTaskGetTickCount();
     while (1) {
-        ASIC_read_registers(GLOBAL_STATE);
+        if (supports_register_reading) {
+            ASIC_read_registers(GLOBAL_STATE);
+        }
 
         vTaskDelay(100 / portTICK_PERIOD_MS);
 


### PR DESCRIPTION
closes #1262 

the issue was that the register reading was technically only supported on the bm1370 but it would try to read this on any chip, and if it's not present it would read garbage from the allocated malloc which is not inited with zeros