### PR TITLE
ESP-IDF 6.0 with backward compatibility to 5.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # The following lines of boilerplate have to be in your project's CMakeLists
 # in this exact order for cmake to work correctly
-cmake_minimum_required(VERSION 3.5)
+# CMake 3.16+ supports both ESP-IDF 5.x and 6.x
+cmake_minimum_required(VERSION 3.16)
 
 # (Not part of the boilerplate)
 # This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.

--- a/components/asic/CMakeLists.txt
+++ b/components/asic/CMakeLists.txt
@@ -14,11 +14,19 @@ SRCS
 INCLUDE_DIRS 
     "include"
 
-REQUIRES 
+REQUIRES
     "freertos"
-    "driver"
     "stratum"
 )
+
+# ESP-IDF 6.0+ uses separate driver components, 5.x uses unified "driver"
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    idf_component_get_property(uart_lib esp_driver_uart COMPONENT_LIB)
+    target_link_libraries(${COMPONENT_LIB} PUBLIC ${uart_lib})
+else()
+    idf_component_get_property(driver_lib driver COMPONENT_LIB)
+    target_link_libraries(${COMPONENT_LIB} PUBLIC ${driver_lib})
+endif()
 
 
 # Include the header files from "main" directory

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -3,6 +3,7 @@
 #include "esp_log.h"
 #include "esp_system.h"
 #include "esp_wifi.h"
+#include "esp_idf_version.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 #include "freertos/task.h"
@@ -16,6 +17,15 @@
 #include "connect.h"
 #include "global_state.h"
 #include "nvs_config.h"
+
+// ESP-IDF 6.0 compatibility: WiFi interface constants were renamed
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    #define COMPAT_WIFI_IF_STA WIFI_IF_STA
+    #define COMPAT_WIFI_IF_AP  WIFI_IF_AP
+#else
+    #define COMPAT_WIFI_IF_STA ESP_IF_WIFI_STA
+    #define COMPAT_WIFI_IF_AP  ESP_IF_WIFI_AP
+#endif
 
 // Maximum number of access points to scan
 #define MAX_AP_COUNT 20
@@ -297,7 +307,7 @@ esp_netif_t * wifi_init_softap(char * ap_ssid)
     esp_netif_t * esp_netif_ap = esp_netif_create_default_wifi_ap();
 
     uint8_t mac[6];
-    esp_wifi_get_mac(ESP_IF_WIFI_AP, mac);
+    esp_wifi_get_mac(COMPAT_WIFI_IF_AP, mac);
     // Format the last 4 bytes of the MAC address as a hexadecimal string
     snprintf(ap_ssid, 32, "Bitaxe_%02X%02X", mac[4], mac[5]);
 
@@ -311,7 +321,7 @@ esp_netif_t * wifi_init_softap(char * ap_ssid)
     wifi_ap_config.ap.authmode = WIFI_AUTH_OPEN;
     wifi_ap_config.ap.pmf_cfg.required = false;
 
-    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &wifi_ap_config));
+    ESP_ERROR_CHECK(esp_wifi_set_config(COMPAT_WIFI_IF_AP, &wifi_ap_config));
 
     return esp_netif_ap;
 }
@@ -384,7 +394,7 @@ esp_netif_t * wifi_init_sta(const char * wifi_ssid, const char * wifi_pass)
     // strncpy((char *) wifi_sta_config.sta.password, wifi_pass, 63);
     // wifi_sta_config.sta.password[63] = '\0';
 
-    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_sta_config));
+    ESP_ERROR_CHECK(esp_wifi_set_config(COMPAT_WIFI_IF_STA, &wifi_sta_config));
 
     // IPv6 link-local address will be created after WiFi connection
     

--- a/components/stratum/CMakeLists.txt
+++ b/components/stratum/CMakeLists.txt
@@ -8,8 +8,16 @@ INCLUDE_DIRS
     "include"
 
 REQUIRES
-    "json"
     "mbedtls"
     "app_update"
     "esp_timer"
 )
+
+# ESP-IDF 6.0 renamed json to cjson
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    idf_component_get_property(json_lib cjson COMPONENT_LIB)
+    target_link_libraries(${COMPONENT_LIB} PUBLIC ${json_lib})
+else()
+    idf_component_get_property(json_lib json COMPONENT_LIB)
+    target_link_libraries(${COMPONENT_LIB} PUBLIC ${json_lib})
+endif()

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -59,7 +59,6 @@ INCLUDE_DIRS
 
 PRIV_REQUIRES
     "app_update"
-    "driver"
     "esp_adc"
     "esp_app_format"
     "esp_event"
@@ -68,14 +67,26 @@ PRIV_REQUIRES
     "esp_psram"
     "esp_timer"
     "esp_wifi"
-    "json"
     "nvs_flash"
     "spiffs"
     "vfs"
-    "esp_driver_i2c"
 
 EMBED_FILES "http_server/recovery_page.html"
 )
+
+# ESP-IDF 6.0+ uses separate driver components, 5.x uses unified "driver"
+# ESP-IDF 6.0 renamed json to cjson
+if(IDF_VERSION_MAJOR GREATER_EQUAL 6)
+    idf_component_get_property(uart_lib esp_driver_uart COMPONENT_LIB)
+    idf_component_get_property(gpio_lib esp_driver_gpio COMPONENT_LIB)
+    idf_component_get_property(i2c_lib esp_driver_i2c COMPONENT_LIB)
+    idf_component_get_property(json_lib cjson COMPONENT_LIB)
+    target_link_libraries(${COMPONENT_LIB} PRIVATE ${uart_lib} ${gpio_lib} ${i2c_lib} ${json_lib})
+else()
+    idf_component_get_property(driver_lib driver COMPONENT_LIB)
+    idf_component_get_property(json_lib json COMPONENT_LIB)
+    target_link_libraries(${COMPONENT_LIB} PRIVATE ${driver_lib} ${json_lib})
+endif()
 
 idf_build_set_property(COMPILE_OPTIONS "-DLV_CONF_INCLUDE_SIMPLE=1" APPEND)
 idf_build_set_property(COMPILE_OPTIONS "-DLV_CONF_PATH=\"${CMAKE_SOURCE_DIR}/main/lv_conf.h\"" APPEND)

--- a/main/thermal/EMC2101.h
+++ b/main/thermal/EMC2101.h
@@ -164,7 +164,7 @@ typedef enum
 
 esp_err_t EMC2101_set_fan_speed(float);
 uint16_t EMC2101_get_fan_speed(void);
-esp_err_t EMC2101_init();
+esp_err_t EMC2101_init(int temp_offset_param);
 float EMC2101_get_external_temp(void);
 float EMC2101_get_internal_temp(void);
 esp_err_t EMC2101_set_ideality_factor(uint8_t);

--- a/main/thermal/EMC2103.h
+++ b/main/thermal/EMC2103.h
@@ -62,7 +62,7 @@
 
 esp_err_t EMC2103_set_fan_speed(float);
 uint16_t EMC2103_get_fan_speed(void);
-esp_err_t EMC2103_init();
+esp_err_t EMC2103_init(int temp_offset_param);
 float EMC2103_get_external_temp(void);
 float EMC2103_get_external_temp2(void);
 esp_err_t EMC2103_set_ideality_factor(uint8_t);

--- a/readme.md
+++ b/readme.md
@@ -132,8 +132,7 @@ In order to unlock the Input fields for ASIC Frequency and ASIC Core Voltage you
 
 ### Prerequisites
 
-- Install the ESP-IDF toolchain from https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/
-- Install nodejs/npm from https://nodejs.org/en/download
+- Install the ESP-IDF toolchain 5.5 or 6.0 from https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/
 - (Optional) Install the ESP-IDF extension for VSCode from https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension
 
 ### Building


### PR DESCRIPTION
- Updated CMakeLists.txt (CMake 3.16 for dual version support)
- Updated component dependencies to use new driver components:
  - Added esp_driver_uart to components/asic
  - Added esp_driver_uart, esp_driver_gpio, esp_driver_i2c to main
- Fixed stratum component dependency: json → cjson (ESP-IDF 6.0 rename)
- Maintained IDF version requirement at >=5.5.0 for backward compatibility
- Implemented WiFi interface constant compatibility in components/connect/connect.c
  - ESP-IDF 6.0: WIFI_IF_STA/AP
  - ESP-IDF 5.5.x: ESP_IF_WIFI_STA/AP
  - Uses ESP_IDF_VERSION macros for conditional compilation
- Fixed thermal driver header signatures (EMC2101, EMC2103)
- Updated readme.md with ESP-IDF version requirements
- Updated EMC210x headers to match implementation: EMC210x_init(int) due to ESP-IDF 6.0's stricter compiler warnings