### PR TITLE
Remove clean_jobs check in create_jobs_task

### DIFF
--- a/main/tasks/create_jobs_task.c
+++ b/main/tasks/create_jobs_task.c
@@ -65,9 +65,6 @@ void create_jobs_task(void *pvParameters)
 
             extranonce_2 = 0;
 
-            if (!current_mining_notification->clean_jobs) {
-                continue;
-            }
         } else {
             if (current_mining_notification == NULL) {
                 vTaskDelay(100 / portTICK_PERIOD_MS);


### PR DESCRIPTION
Remove unnecessary check for clean_jobs in job creation task.

When a `mining.notify` with `cleanJob=false` was received (e.g. after a `mining.set_difficulty` or new mempool transactions), `create_jobs_task` skipped calling `generate_work()` due to an early `continue`. This meant the ASIC never received the new job and kept mining the previous nonce space. Once the ASIC exhausted and wrapped its nonce range, it resubmitted previously found solutions, causing persistent duplicate share rejections until the next `cleanJob=true` notify arrived.

The `cleanJob` flag is already handled correctly in `stratum_task.c`, which flushes the stratum queue when `cleanJob=true`. The flag should only control whether queued jobs are discarded — not whether the ASIC receives new work.

Removed the `cleanJob=false` guard in `create_jobs_task.c` so that every `mining.notify` results in `generate_work()` being called.

Fixes #1587