### PR TITLE
Run frontend test in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Build Firmware
 on: [push, pull_request]
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,8 @@ on:
       - '.devcontainer/**'
     branches: [ master ]
   workflow_dispatch:
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
   contents: read

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [prereleased]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   checks: write
   pull-requests: write

--- a/.github/workflows/release-factory-beta.yml
+++ b/.github/workflows/release-factory-beta.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [prereleased]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   checks: write
   pull-requests: write

--- a/.github/workflows/release-factory.yml
+++ b/.github/workflows/release-factory.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   checks: write
   pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   checks: write
   pull-requests: write

--- a/.github/workflows/unittest-results.yml
+++ b/.github/workflows/unittest-results.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["Unit Test"]
     types:
       - completed
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 permissions: {}
 
 jobs:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,5 +1,7 @@
 name: Unit Test
 on: [push, pull_request]
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
   contents: read

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -47,3 +47,29 @@ jobs:
             echo "::error ::Detected $FAILURES test failures."
             exit 1
           fi
+
+  frontend-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          submodules: 'recursive'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.14.0'
+
+      - name: Run frontend tests
+        working-directory: ./main/http_server/axe-os
+        run: |
+          npm ci
+          npm run test:ci
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-test-results
+          path: main/http_server/axe-os/report.xml

--- a/main/http_server/axe-os/angular.json
+++ b/main/http_server/axe-os/angular.json
@@ -98,6 +98,7 @@
               "zone.js/testing"
             ],
             "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",

--- a/main/http_server/axe-os/karma.conf.js
+++ b/main/http_server/axe-os/karma.conf.js
@@ -1,0 +1,43 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('karma-junit-reporter'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {
+        // you can add configuration options for Jasmine here
+      },
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/axe-os'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    junitReporter: {
+      outputDir: '.',
+      outputFile: 'report.xml',
+      useBrowserName: false
+    },
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/main/http_server/axe-os/package-lock.json
+++ b/main/http_server/axe-os/package-lock.json
@@ -16,7 +16,6 @@
         "@angular/platform-browser": "^18.2.13",
         "@angular/platform-browser-dynamic": "^18.2.13",
         "@angular/router": "^18.2.13",
-        "@xterm/xterm": "^5.5.0",
         "chart.js": "^4.4.7",
         "chartjs-adapter-moment": "^1.0.1",
         "moment": "^2.30.1",
@@ -24,7 +23,6 @@
         "primeflex": "^3.3.1",
         "primeng": "^17.18.15",
         "rxjs": "^7.8.1",
-        "tslib": "^2.8.1",
         "zone.js": "^0.14.10"
       },
       "devDependencies": {
@@ -32,7 +30,6 @@
         "@angular/cli": "^18.2.19",
         "@angular/compiler-cli": "^18.2.13",
         "@types/jasmine": "^5.1.5",
-        "chokidar": "^3.6.0",
         "gzipper": "^8.2.0",
         "jasmine-core": "^5.5.0",
         "karma": "^6.4.4",
@@ -40,8 +37,10 @@
         "karma-coverage": "^2.2.1",
         "karma-jasmine": "^5.1.0",
         "karma-jasmine-html-reporter": "^2.1.0",
+        "karma-junit-reporter": "^2.0.1",
         "ng-openapi-gen": "^1.0.5",
         "rimraf": "^6.1.3",
+        "sass": "^1.77.6",
         "typescript": "^5.5.4",
         "webpack-bundle-analyzer": "^4.10.2"
       },
@@ -4856,12 +4855,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@xterm/xterm": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
-      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -8925,6 +8918,23 @@
       "integrity": "sha512-VYz/BjjmC3klLJlLwA4Kw8ytk0zDSmbbDLNs794VnWmkcCB7I9aAL/D48VNQtmITyPvea2C3jdUMfc3kAoy0PQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/karma-junit-reporter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/karma-junit-reporter/-/karma-junit-reporter-2.0.1.tgz",
+      "integrity": "sha512-VtcGfE0JE4OE1wn0LK8xxDKaTP7slN8DO3I+4xg6gAi1IoAHAXOJ1V9G/y45Xg6sxdxPOR3THCFtDlAfBo9Afw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-is-absolute": "^1.0.0",
+        "xmlbuilder": "12.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      },
+      "peerDependencies": {
+        "karma": ">=0.9"
+      }
     },
     "node_modules/karma-source-map-support": {
       "version": "1.4.0",
@@ -14780,6 +14790,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-12.0.0.tgz",
+      "integrity": "sha512-lMo8DJ8u6JRWp0/Y4XLa/atVDr75H9litKlb2E5j3V3MesoL50EBgZDWoLT3F/LztVnG67GjPXLZpqcky/UMnQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/xtend": {

--- a/main/http_server/axe-os/package.json
+++ b/main/http_server/axe-os/package.json
@@ -11,6 +11,7 @@
     "build:no-api-gen": "ng build --configuration=production && gzipper compress --gzip --gzip-level 9 --exclude woff2 ./dist/axe-os && node only-gzip.js && node generate-version.js",
     "watch": "ng build --watch --configuration development",
     "test": "ng test --watch=false --browsers=ChromeHeadless",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadless --reporters junit",
     "generate:api": "rimraf ./src/app/generated && ng-openapi-gen",
     "bundle-report": "ng build --configuration=production --stats-json && webpack-bundle-analyzer dist/axe-os/stats.json"
   },
@@ -39,15 +40,16 @@
     "@angular/compiler-cli": "^18.2.13",
     "@types/jasmine": "^5.1.5",
     "gzipper": "^8.2.0",
-    "sass": "^1.77.6",
     "jasmine-core": "^5.5.0",
     "karma": "^6.4.4",
     "karma-chrome-launcher": "^3.2.0",
     "karma-coverage": "^2.2.1",
     "karma-jasmine": "^5.1.0",
     "karma-jasmine-html-reporter": "^2.1.0",
+    "karma-junit-reporter": "^2.0.1",
     "ng-openapi-gen": "^1.0.5",
     "rimraf": "^6.1.3",
+    "sass": "^1.77.6",
     "typescript": "^5.5.4",
     "webpack-bundle-analyzer": "^4.10.2"
   }

--- a/main/http_server/axe-os/package.json
+++ b/main/http_server/axe-os/package.json
@@ -11,7 +11,7 @@
     "build:no-api-gen": "ng build --configuration=production && gzipper compress --gzip --gzip-level 9 --exclude woff2 ./dist/axe-os && node only-gzip.js && node generate-version.js",
     "watch": "ng build --watch --configuration development",
     "test": "ng test --watch=false --browsers=ChromeHeadless",
-    "test:ci": "ng test --watch=false --browsers=ChromeHeadless --reporters junit",
+    "test:ci": "npm run generate:api && ng test --watch=false --browsers=ChromeHeadless --reporters junit",
     "generate:api": "rimraf ./src/app/generated && ng-openapi-gen",
     "bundle-report": "ng build --configuration=production --stats-json && webpack-bundle-analyzer dist/axe-os/stats.json"
   },

--- a/main/http_server/axe-os/src/app/components/scoreboard/scoreboard.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/scoreboard/scoreboard.component.spec.ts
@@ -1,6 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ScoreboardComponent } from './scoreboard.component';
+import { provideHttpClient } from '@angular/common/http';
+import { SystemApiService } from 'src/app/services/system.service';
+import { LoadingService } from 'src/app/services/loading.service';
+import { LocalStorageService } from 'src/app/local-storage.service';
 
 describe('ScoreboardComponent', () => {
   let component: ScoreboardComponent;
@@ -8,7 +12,13 @@ describe('ScoreboardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ScoreboardComponent]
+      declarations: [ScoreboardComponent],
+      providers: [
+        provideHttpClient(),
+        SystemApiService,
+        LoadingService,
+        LocalStorageService
+      ]
     })
     .compileComponents();
 


### PR DESCRIPTION
This PR adds a step in the unittest build to run the frontend tests.

It also opts into Node 24 for CI runners, as Node 20 will be sunset soon-ish:

 > Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

The `frontend-test` step is separate so it can run in parallel to the `build-and-test` step.

| Before | After |
| --- | --- |
| <img height="101" alt="image" src="https://github.com/user-attachments/assets/6a26ddc5-9bc7-412d-88ff-3207bdb02c6c" /> | <img height="100" alt="image" src="https://github.com/user-attachments/assets/be696df6-4c71-40b4-97da-3cc21eb89c9b" /> | 

(Not sure how to make sense of these numbers?)