### PR TITLE
Implement automatic hashrate anomaly detection and ASIC recovery

### DIFF
--- a/main/tasks/hashrate_monitor_task.c
+++ b/main/tasks/hashrate_monitor_task.c
@@ -22,6 +22,11 @@
 #define DIV_10M (HASHRATE_1M_SIZE)
 #define DIV_1H (HASHRATE_10M_SIZE * DIV_10M)
 
+// Number of consecutive anomalous readings before triggering ASIC recovery
+#define ANOMALY_CONSECUTIVE_THRESHOLD 3
+// Stabilization delay after ASIC recovery to let tasks settle before frequency changes
+#define RECOVERY_STABILIZATION_DELAY_MS 2000
+
 static unsigned long poll_count = 0;
 static float hashrate_1m[HASHRATE_1M_SIZE];
 static float hashrate_10m_prev;
@@ -154,9 +159,15 @@ void check_hashrate_anomaly(void *pvParameters, float current_hashrate)
         return;
     }
 
-    if (current_hashrate < highest_hashrate
-        && (current_hashrate < expected_hashrate * lower_threshold_hashrate_pct
-            || current_hashrate > expected_hashrate * upper_threshold_hashrate_pct)) {
+    // Detect two types of anomaly independently:
+    // - Low hashrate: only after we've previously achieved a good hashrate (prevents
+    //   false triggers during initial ramp-up), current drops below the lower threshold
+    // - High hashrate spike: always anomalous regardless of previous highest
+    bool is_low_anomaly = current_hashrate < highest_hashrate
+                          && current_hashrate < expected_hashrate * lower_threshold_hashrate_pct;
+    bool is_high_anomaly = current_hashrate > expected_hashrate * upper_threshold_hashrate_pct;
+
+    if (is_low_anomaly || is_high_anomaly) {
         low_hashrate_count++;
         ESP_LOGW(TAG, "Abnormal hashrate detected: %.3f Gh/s (expected: %.3f Gh/s). Count: %d",
                  current_hashrate, expected_hashrate, low_hashrate_count);
@@ -165,7 +176,7 @@ void check_hashrate_anomaly(void *pvParameters, float current_hashrate)
         return;
     }
 
-    if (low_hashrate_count >= 3) {
+    if (low_hashrate_count >= ANOMALY_CONSECUTIVE_THRESHOLD) {
         reinitiate_count++;
         ESP_LOGW(TAG, "Reinitiating ASICs due to sustained abnormal hashrate. Reinitiate count: %d", reinitiate_count);
 
@@ -179,7 +190,7 @@ void check_hashrate_anomaly(void *pvParameters, float current_hashrate)
         vTaskDelay(100 / portTICK_PERIOD_MS);
 
         // Perform live recovery with stabilization delay
-        uint8_t chip_count = asic_initialize(GLOBAL_STATE, ASIC_INIT_RECOVERY, 2000);
+        uint8_t chip_count = asic_initialize(GLOBAL_STATE, ASIC_INIT_RECOVERY, RECOVERY_STABILIZATION_DELAY_MS);
 
         if (chip_count > 0) {
             ESP_LOGI(TAG, "ASIC recovery successful, resuming normal operation.");
@@ -203,10 +214,14 @@ void hashrate_monitor_task(void *pvParameters)
     int hash_domains = GLOBAL_STATE->DEVICE_CONFIG.family.asic.hash_domains;
 
     // Compute dynamic lower hashrate threshold based on hardware configuration.
-    // A single domain drop on one ASIC out of the total should be detectable.
+    // The formula detects when hashrate drops by more than twice the contribution
+    // of a single hash domain on a single ASIC. Multiplying by 2.0 provides a
+    // margin so that losing one domain triggers detection, while normal variance
+    // (which is less than one full domain) does not cause false positives.
     float expected_hr = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.expected_hashrate;
     if (expected_hr > 0.0f && asic_count > 0 && hash_domains > 0) {
-        lower_threshold_hashrate_pct = 1.0f - ((expected_hr / asic_count / hash_domains * 2.0f) / expected_hr);
+        float per_domain_contribution = expected_hr / asic_count / hash_domains;
+        lower_threshold_hashrate_pct = 1.0f - (per_domain_contribution * 2.0f / expected_hr);
         ESP_LOGI(TAG, "Hashrate anomaly lower threshold: %.0f%% of expected", lower_threshold_hashrate_pct * 100.0f);
     }
 

--- a/main/tasks/hashrate_monitor_task.c
+++ b/main/tasks/hashrate_monitor_task.c
@@ -38,9 +38,9 @@ static const char *TAG = "hashrate_monitor";
 
 // Hashrate anomaly detection state
 static float highest_hashrate = 0.0f;
-static uint8_t low_hashrate_count = 0;
+static uint8_t consecutive_anomaly_count = 0;
 static int reinitiate_count = 0;
-static float lower_threshold_hashrate_pct = 0.82f; // 82% of expected hashrate (recomputed at startup)
+static float lower_threshold_hashrate_pct = 0.82f; // Fallback threshold; recomputed dynamically once expected hashrate is known
 static float upper_threshold_hashrate_pct = 1.50f; // 150% of expected hashrate
 
 static float sum_hashrates(measurement_t * measurement, int asic_count)
@@ -168,15 +168,15 @@ void check_hashrate_anomaly(void *pvParameters, float current_hashrate)
     bool is_high_anomaly = current_hashrate > expected_hashrate * upper_threshold_hashrate_pct;
 
     if (is_low_anomaly || is_high_anomaly) {
-        low_hashrate_count++;
+        consecutive_anomaly_count++;
         ESP_LOGW(TAG, "Abnormal hashrate detected: %.3f Gh/s (expected: %.3f Gh/s). Count: %d",
-                 current_hashrate, expected_hashrate, low_hashrate_count);
+                 current_hashrate, expected_hashrate, consecutive_anomaly_count);
     } else {
-        low_hashrate_count = 0;
+        consecutive_anomaly_count = 0;
         return;
     }
 
-    if (low_hashrate_count >= ANOMALY_CONSECUTIVE_THRESHOLD) {
+    if (consecutive_anomaly_count >= ANOMALY_CONSECUTIVE_THRESHOLD) {
         reinitiate_count++;
         ESP_LOGW(TAG, "Reinitiating ASICs due to sustained abnormal hashrate. Reinitiate count: %d", reinitiate_count);
 
@@ -200,7 +200,7 @@ void check_hashrate_anomaly(void *pvParameters, float current_hashrate)
             ESP_LOGE(TAG, "ASIC recovery failed - chip count 0");
         }
 
-        low_hashrate_count = 0;
+        consecutive_anomaly_count = 0;
     }
 }
 
@@ -260,19 +260,21 @@ void hashrate_monitor_task(void *pvParameters)
             float current_hashrate = sum_hashrates(HASHRATE_MONITOR_MODULE->total_measurement, asic_count);
             float error_hashrate = sum_hashrates(HASHRATE_MONITOR_MODULE->error_measurement, asic_count);
 
-            // Track highest observed hashrate
-            if (current_hashrate > highest_hashrate) {
-                highest_hashrate = current_hashrate;
-                ESP_LOGI(TAG, "New highest hashrate: %.3f Gh/s", highest_hashrate);
-            }
-
             SYSTEM_MODULE->current_hashrate = current_hashrate;
             SYSTEM_MODULE->error_percentage = current_hashrate > 0 ? error_hashrate / current_hashrate * 100.f : 0;
 
             if (current_hashrate > 0.0f) update_hashrate_averages(SYSTEM_MODULE);
 
-            // Check for sustained hashrate anomalies and auto-recover if needed
+            // Check for sustained hashrate anomalies and auto-recover if needed.
+            // Must run before updating highest_hashrate so the low-anomaly guard
+            // (current < highest) correctly ignores the initial ramp-up phase.
             check_hashrate_anomaly(pvParameters, current_hashrate);
+
+            // Track highest observed hashrate (after anomaly check)
+            if (current_hashrate > highest_hashrate) {
+                highest_hashrate = current_hashrate;
+                ESP_LOGI(TAG, "New highest hashrate: %.3f Gh/s", highest_hashrate);
+            }
         } else {
             SYSTEM_MODULE->current_hashrate = 0;
         }

--- a/main/tasks/hashrate_monitor_task.c
+++ b/main/tasks/hashrate_monitor_task.c
@@ -8,6 +8,8 @@
 #include "asic_common.h"
 #include "asic.h"
 #include "utils.h"
+#include "asic_init.h"
+#include "driver/uart.h"
 
 #define EPSILON 0.0001f
 
@@ -28,6 +30,13 @@ static float hashrate_1h_prev;
 static float hashrate_1h[HASHRATE_1H_SIZE];
 
 static const char *TAG = "hashrate_monitor";
+
+// Hashrate anomaly detection state
+static float highest_hashrate = 0.0f;
+static uint8_t low_hashrate_count = 0;
+static int reinitiate_count = 0;
+static float lower_threshold_hashrate_pct = 0.82f; // 82% of expected hashrate (recomputed at startup)
+static float upper_threshold_hashrate_pct = 1.50f; // 150% of expected hashrate
 
 static float sum_hashrates(measurement_t * measurement, int asic_count)
 {
@@ -135,6 +144,55 @@ static void update_hashrate_averages(SystemModule * SYSTEM_MODULE)
     poll_count++;
 }
 
+void check_hashrate_anomaly(void *pvParameters, float current_hashrate)
+{
+    GlobalState * GLOBAL_STATE = (GlobalState *)pvParameters;
+    float expected_hashrate = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.expected_hashrate;
+
+    // Skip if expected hashrate is not set yet or mining is paused
+    if (expected_hashrate <= 0.0f || GLOBAL_STATE->SYSTEM_MODULE.mining_paused) {
+        return;
+    }
+
+    if (current_hashrate < highest_hashrate
+        && (current_hashrate < expected_hashrate * lower_threshold_hashrate_pct
+            || current_hashrate > expected_hashrate * upper_threshold_hashrate_pct)) {
+        low_hashrate_count++;
+        ESP_LOGW(TAG, "Abnormal hashrate detected: %.3f Gh/s (expected: %.3f Gh/s). Count: %d",
+                 current_hashrate, expected_hashrate, low_hashrate_count);
+    } else {
+        low_hashrate_count = 0;
+        return;
+    }
+
+    if (low_hashrate_count >= 3) {
+        reinitiate_count++;
+        ESP_LOGW(TAG, "Reinitiating ASICs due to sustained abnormal hashrate. Reinitiate count: %d", reinitiate_count);
+
+        // Mark ASIC as uninitialized to stop tasks from using UART
+        GLOBAL_STATE->ASIC_initalized = false;
+        // Give tasks time to complete any current UART operation
+        vTaskDelay(500 / portTICK_PERIOD_MS);
+
+        // Flush UART buffers to clear stale data
+        uart_flush(UART_NUM_1);
+        vTaskDelay(100 / portTICK_PERIOD_MS);
+
+        // Perform live recovery with stabilization delay
+        uint8_t chip_count = asic_initialize(GLOBAL_STATE, ASIC_INIT_RECOVERY, 2000);
+
+        if (chip_count > 0) {
+            ESP_LOGI(TAG, "ASIC recovery successful, resuming normal operation.");
+            // Reset measurements to avoid hashrate spike from stale counters
+            hashrate_monitor_reset_measurements(GLOBAL_STATE);
+        } else {
+            ESP_LOGE(TAG, "ASIC recovery failed - chip count 0");
+        }
+
+        low_hashrate_count = 0;
+    }
+}
+
 void hashrate_monitor_task(void *pvParameters)
 {
     GlobalState * GLOBAL_STATE = (GlobalState *)pvParameters;
@@ -143,6 +201,14 @@ void hashrate_monitor_task(void *pvParameters)
 
     int asic_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
     int hash_domains = GLOBAL_STATE->DEVICE_CONFIG.family.asic.hash_domains;
+
+    // Compute dynamic lower hashrate threshold based on hardware configuration.
+    // A single domain drop on one ASIC out of the total should be detectable.
+    float expected_hr = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.expected_hashrate;
+    if (expected_hr > 0.0f && asic_count > 0 && hash_domains > 0) {
+        lower_threshold_hashrate_pct = 1.0f - ((expected_hr / asic_count / hash_domains * 2.0f) / expected_hr);
+        ESP_LOGI(TAG, "Hashrate anomaly lower threshold: %.0f%% of expected", lower_threshold_hashrate_pct * 100.0f);
+    }
 
     HASHRATE_MONITOR_MODULE->total_measurement = heap_caps_malloc(asic_count * sizeof(measurement_t), MALLOC_CAP_SPIRAM);
     measurement_t* data = heap_caps_malloc(asic_count * hash_domains * sizeof(measurement_t), MALLOC_CAP_SPIRAM);
@@ -179,10 +245,19 @@ void hashrate_monitor_task(void *pvParameters)
             float current_hashrate = sum_hashrates(HASHRATE_MONITOR_MODULE->total_measurement, asic_count);
             float error_hashrate = sum_hashrates(HASHRATE_MONITOR_MODULE->error_measurement, asic_count);
 
+            // Track highest observed hashrate
+            if (current_hashrate > highest_hashrate) {
+                highest_hashrate = current_hashrate;
+                ESP_LOGI(TAG, "New highest hashrate: %.3f Gh/s", highest_hashrate);
+            }
+
             SYSTEM_MODULE->current_hashrate = current_hashrate;
             SYSTEM_MODULE->error_percentage = current_hashrate > 0 ? error_hashrate / current_hashrate * 100.f : 0;
 
             if (current_hashrate > 0.0f) update_hashrate_averages(SYSTEM_MODULE);
+
+            // Check for sustained hashrate anomalies and auto-recover if needed
+            check_hashrate_anomaly(pvParameters, current_hashrate);
         } else {
             SYSTEM_MODULE->current_hashrate = 0;
         }

--- a/main/tasks/hashrate_monitor_task.c
+++ b/main/tasks/hashrate_monitor_task.c
@@ -8,6 +8,7 @@
 #include "asic_common.h"
 #include "asic.h"
 #include "utils.h"
+#include "esp_system.h"
 #include "asic_init.h"
 #include "driver/uart.h"
 
@@ -22,10 +23,15 @@
 #define DIV_10M (HASHRATE_1M_SIZE)
 #define DIV_1H (HASHRATE_10M_SIZE * DIV_10M)
 
-// Number of consecutive anomalous readings before triggering ASIC recovery
+// Consecutive anomalous polls before triggering ASIC recovery
 #define ANOMALY_CONSECUTIVE_THRESHOLD 3
-// Stabilization delay after ASIC recovery to let tasks settle before frequency changes
+// Delay after ASIC recovery before resuming normal operation
 #define RECOVERY_STABILIZATION_DELAY_MS 2000
+// Max recovery attempts before forcing a full reboot
+#define MAX_RECOVERY_ATTEMPTS 3
+// Lower/upper hashrate thresholds relative to expected hashrate
+#define LOWER_HASHRATE_THRESHOLD 0.75f
+#define UPPER_HASHRATE_THRESHOLD 1.50f
 
 static unsigned long poll_count = 0;
 static float hashrate_1m[HASHRATE_1M_SIZE];
@@ -36,12 +42,9 @@ static float hashrate_1h[HASHRATE_1H_SIZE];
 
 static const char *TAG = "hashrate_monitor";
 
-// Hashrate anomaly detection state
-static float highest_hashrate = 0.0f;
 static uint8_t consecutive_anomaly_count = 0;
-static int reinitiate_count = 0;
-static float lower_threshold_hashrate_pct = 0.82f; // Fallback threshold; recomputed dynamically once expected hashrate is known
-static float upper_threshold_hashrate_pct = 1.50f; // 150% of expected hashrate
+static int recovery_count = 0;
+static bool warmup_complete = false;
 
 static float sum_hashrates(measurement_t * measurement, int asic_count)
 {
@@ -154,53 +157,60 @@ void check_hashrate_anomaly(void *pvParameters, float current_hashrate)
     GlobalState * GLOBAL_STATE = (GlobalState *)pvParameters;
     float expected_hashrate = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.expected_hashrate;
 
-    // Skip if expected hashrate is not set yet or mining is paused
     if (expected_hashrate <= 0.0f || GLOBAL_STATE->SYSTEM_MODULE.mining_paused) {
         return;
     }
 
-    // Detect two types of anomaly independently:
-    // - Low hashrate: only after we've previously achieved a good hashrate (prevents
-    //   false triggers during initial ramp-up), current drops below the lower threshold
-    // - High hashrate spike: always anomalous regardless of previous highest
-    bool is_low_anomaly = current_hashrate < highest_hashrate
-                          && current_hashrate < expected_hashrate * lower_threshold_hashrate_pct;
-    bool is_high_anomaly = current_hashrate > expected_hashrate * upper_threshold_hashrate_pct;
+    // Skip anomaly detection until hashrate has reached at least 50% of expected (warmup)
+    if (!warmup_complete) {
+        if (current_hashrate >= expected_hashrate * 0.5f) {
+            warmup_complete = true;
+            ESP_LOGI(TAG, "Warmup complete, enabling anomaly detection");
+        }
+        return;
+    }
 
-    if (is_low_anomaly || is_high_anomaly) {
+    bool is_low  = current_hashrate < expected_hashrate * LOWER_HASHRATE_THRESHOLD;
+    bool is_high = current_hashrate > expected_hashrate * UPPER_HASHRATE_THRESHOLD;
+
+    if (is_low || is_high) {
         consecutive_anomaly_count++;
-        ESP_LOGW(TAG, "Abnormal hashrate detected: %.3f Gh/s (expected: %.3f Gh/s). Count: %d",
+        ESP_LOGW(TAG, "Abnormal hashrate: %.3f Gh/s (expected: %.3f Gh/s), count: %d",
                  current_hashrate, expected_hashrate, consecutive_anomaly_count);
     } else {
         consecutive_anomaly_count = 0;
         return;
     }
 
-    if (consecutive_anomaly_count >= ANOMALY_CONSECUTIVE_THRESHOLD) {
-        reinitiate_count++;
-        ESP_LOGW(TAG, "Reinitiating ASICs due to sustained abnormal hashrate. Reinitiate count: %d", reinitiate_count);
+    if (consecutive_anomaly_count < ANOMALY_CONSECUTIVE_THRESHOLD) {
+        return;
+    }
 
-        // Mark ASIC as uninitialized to stop tasks from using UART
-        GLOBAL_STATE->ASIC_initalized = false;
-        // Give tasks time to complete any current UART operation
-        vTaskDelay(500 / portTICK_PERIOD_MS);
+    recovery_count++;
+    ESP_LOGW(TAG, "ASIC recovery #%d due to sustained abnormal hashrate", recovery_count);
 
-        // Flush UART buffers to clear stale data
-        uart_flush(UART_NUM_1);
-        vTaskDelay(100 / portTICK_PERIOD_MS);
+    // Stop tasks from using UART, then wait for current operations to finish
+    GLOBAL_STATE->ASIC_initalized = false;
+    vTaskDelay(500 / portTICK_PERIOD_MS);
 
-        // Perform live recovery with stabilization delay
-        uint8_t chip_count = asic_initialize(GLOBAL_STATE, ASIC_INIT_RECOVERY, RECOVERY_STABILIZATION_DELAY_MS);
+    uart_flush(UART_NUM_1);
+    vTaskDelay(100 / portTICK_PERIOD_MS);
 
-        if (chip_count > 0) {
-            ESP_LOGI(TAG, "ASIC recovery successful, resuming normal operation.");
-            // Reset measurements to avoid hashrate spike from stale counters
-            hashrate_monitor_reset_measurements(GLOBAL_STATE);
-        } else {
-            ESP_LOGE(TAG, "ASIC recovery failed - chip count 0");
-        }
+    uint8_t chip_count = asic_initialize(GLOBAL_STATE, ASIC_INIT_RECOVERY, RECOVERY_STABILIZATION_DELAY_MS);
 
-        consecutive_anomaly_count = 0;
+    if (chip_count > 0) {
+        ESP_LOGI(TAG, "ASIC recovery successful");
+        hashrate_monitor_reset_measurements(GLOBAL_STATE);
+        warmup_complete = false;
+    } else {
+        ESP_LOGE(TAG, "ASIC recovery failed (chip count 0)");
+    }
+
+    consecutive_anomaly_count = 0;
+
+    if (chip_count == 0 || recovery_count >= MAX_RECOVERY_ATTEMPTS) {
+        ESP_LOGE(TAG, "Rebooting after %d recovery attempts", recovery_count);
+        esp_restart();
     }
 }
 
@@ -212,18 +222,6 @@ void hashrate_monitor_task(void *pvParameters)
 
     int asic_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
     int hash_domains = GLOBAL_STATE->DEVICE_CONFIG.family.asic.hash_domains;
-
-    // Compute dynamic lower hashrate threshold based on hardware configuration.
-    // The formula detects when hashrate drops by more than twice the contribution
-    // of a single hash domain on a single ASIC. Multiplying by 2.0 provides a
-    // margin so that losing one domain triggers detection, while normal variance
-    // (which is less than one full domain) does not cause false positives.
-    float expected_hr = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.expected_hashrate;
-    if (expected_hr > 0.0f && asic_count > 0 && hash_domains > 0) {
-        float per_domain_contribution = expected_hr / asic_count / hash_domains;
-        lower_threshold_hashrate_pct = 1.0f - (per_domain_contribution * 2.0f / expected_hr);
-        ESP_LOGI(TAG, "Hashrate anomaly lower threshold: %.0f%% of expected", lower_threshold_hashrate_pct * 100.0f);
-    }
 
     HASHRATE_MONITOR_MODULE->total_measurement = heap_caps_malloc(asic_count * sizeof(measurement_t), MALLOC_CAP_SPIRAM);
     measurement_t* data = heap_caps_malloc(asic_count * hash_domains * sizeof(measurement_t), MALLOC_CAP_SPIRAM);
@@ -265,16 +263,7 @@ void hashrate_monitor_task(void *pvParameters)
 
             if (current_hashrate > 0.0f) update_hashrate_averages(SYSTEM_MODULE);
 
-            // Check for sustained hashrate anomalies and auto-recover if needed.
-            // Must run before updating highest_hashrate so the low-anomaly guard
-            // (current < highest) correctly ignores the initial ramp-up phase.
             check_hashrate_anomaly(pvParameters, current_hashrate);
-
-            // Track highest observed hashrate (after anomaly check)
-            if (current_hashrate > highest_hashrate) {
-                highest_hashrate = current_hashrate;
-                ESP_LOGI(TAG, "New highest hashrate: %.3f Gh/s", highest_hashrate);
-            }
         } else {
             SYSTEM_MODULE->current_hashrate = 0;
         }

--- a/main/tasks/hashrate_monitor_task.c
+++ b/main/tasks/hashrate_monitor_task.c
@@ -202,13 +202,15 @@ void check_hashrate_anomaly(void *pvParameters, float current_hashrate)
         ESP_LOGI(TAG, "ASIC recovery successful");
         hashrate_monitor_reset_measurements(GLOBAL_STATE);
         warmup_complete = false;
+        recovery_count = 0;
     } else {
-        ESP_LOGE(TAG, "ASIC recovery failed (chip count 0)");
+        ESP_LOGE(TAG, "ASIC recovery failed (chip count 0), rebooting");
+        esp_restart();
     }
 
     consecutive_anomaly_count = 0;
 
-    if (chip_count == 0 || recovery_count >= MAX_RECOVERY_ATTEMPTS) {
+    if (recovery_count >= MAX_RECOVERY_ATTEMPTS) {
         ESP_LOGE(TAG, "Rebooting after %d recovery attempts", recovery_count);
         esp_restart();
     }

--- a/main/tasks/hashrate_monitor_task.h
+++ b/main/tasks/hashrate_monitor_task.h
@@ -25,14 +25,11 @@ void update_hashrate(measurement_t * measurement, uint32_t value);
 void update_hash_counter(measurement_t * measurement, uint32_t value, uint64_t time_us);
 
 /**
- * Check for sustained hashrate anomalies and auto-recover ASICs if needed.
+ * Monitor hashrate for anomalies and trigger ASIC recovery or reboot.
  *
- * When the hashrate drops below a dynamic lower threshold or exceeds an upper
- * threshold for multiple consecutive polls, this function reinitializes the
- * ASICs using live recovery mode to restore normal operation without a full
- * system reboot.
- *
- * Inspired by TinyChipHub ESP-Miner-TCH stability improvements.
+ * After warmup, if hashrate stays below 75% or above 150% of expected
+ * for multiple consecutive polls, ASICs are reinitialized. A full reboot
+ * is triggered if recovery fails or after repeated attempts.
  */
 void check_hashrate_anomaly(void *pvParameters, float current_hashrate);
 

--- a/main/tasks/hashrate_monitor_task.h
+++ b/main/tasks/hashrate_monitor_task.h
@@ -23,4 +23,17 @@ void hashrate_monitor_reset_measurements(void *pvParameters);
 
 void update_hashrate(measurement_t * measurement, uint32_t value);
 void update_hash_counter(measurement_t * measurement, uint32_t value, uint64_t time_us);
+
+/**
+ * Check for sustained hashrate anomalies and auto-recover ASICs if needed.
+ *
+ * When the hashrate drops below a dynamic lower threshold or exceeds an upper
+ * threshold for multiple consecutive polls, this function reinitializes the
+ * ASICs using live recovery mode to restore normal operation without a full
+ * system reboot.
+ *
+ * Inspired by TinyChipHub ESP-Miner-TCH stability improvements.
+ */
+void check_hashrate_anomaly(void *pvParameters, float current_hashrate);
+
 #endif /* HASHRATE_MONITOR_TASK_H_ */


### PR DESCRIPTION
This pull request introduces an automatic hashrate anomaly detection and recovery mechanism to the `hashrate_monitor_task`. The main goal is to improve system robustness by monitoring for abnormal hashrate drops or spikes and automatically reinitializing the ASICs if anomalies persist, thus reducing the need for manual intervention or full system reboots. The detection thresholds are dynamically computed based on hardware configuration to minimize false positives.

**Hashrate anomaly detection and recovery:**

* Added a new `check_hashrate_anomaly` function that monitors for low or high hashrate anomalies and triggers ASIC live recovery if anomalies persist for a configurable number of consecutive polls. The function is documented in `hashrate_monitor_task.h` and called from the main monitoring loop before updating the highest observed hashrate. [[1]](diffhunk://#diff-f479b069b1d89257ff9436f39ee0d5c33a26e2a17983ea05e4538bbd43ce74c3R152-R206) [[2]](diffhunk://#diff-38d3bbe4d74e4b947af481760131957f2b2107ff4c6062b7d08f047e5b51cbf5R26-R38) [[3]](diffhunk://#diff-f479b069b1d89257ff9436f39ee0d5c33a26e2a17983ea05e4538bbd43ce74c3R267-R277)
* Introduced state variables and thresholds for anomaly detection, including dynamic calculation of the lower threshold based on ASIC and hash domain configuration. [[1]](diffhunk://#diff-f479b069b1d89257ff9436f39ee0d5c33a26e2a17983ea05e4538bbd43ce74c3R25-R29) [[2]](diffhunk://#diff-f479b069b1d89257ff9436f39ee0d5c33a26e2a17983ea05e4538bbd43ce74c3R39-R45) [[3]](diffhunk://#diff-f479b069b1d89257ff9436f39ee0d5c33a26e2a17983ea05e4538bbd43ce74c3R216-R227)

**Integration and robustness improvements:**

* Ensured that after ASIC recovery, measurements are reset to avoid reporting spikes from stale counters, and UART buffers are flushed to clear stale data.
* Added necessary includes for `asic_init.h` and `driver/uart.h` to support the new recovery logic.