### PR TITLE
Add API and UI to reset best difficulty

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -174,6 +174,10 @@
 
         <button pButton [disabled]="!savedChanges" (click)="restart()">Restart</button>
 
+        <button pButton type="button" class="p-button-warning" (click)="resetBestDifficulty()">
+            Reset Best Difficulty
+        </button>
+
         <button *ngIf="settingsUnlocked" pButton pButton="p-button-danger" (click)="toggleOverclockMode(false)"
             class="p-button-danger" pTooltip="Return to safe preset values only">Disable Overclock Mode</button>
     </div>

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -346,4 +346,17 @@ export class EditComponent implements OnInit, OnDestroy, OnChanges {
     return !! Object.entries(this.form.controls)
       .filter(([field, control]) => control.dirty && !this.noRestartFields.includes(field)).length
   }
+
+  resetBestDifficulty() {
+    this.systemService.resetBestDifficulty(this.uri)
+      .pipe(this.loadingService.lockUIUntilComplete())
+      .subscribe({
+        next: () => {
+          this.toastr.success('Best difficulty has been reset.');
+        },
+        error: (err: HttpErrorResponse) => {
+          this.toastr.error('Failed to reset best difficulty: ' + err.message);
+        }
+      });
+  }
 }

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -29,6 +29,18 @@ export class SystemApiService {
     @Optional() private api: Api
   ) { }
 
+  public resetBestDifficulty(uri: string = ''): Observable<GenericResponse> {
+    if (environment.production && this.api && !uri) {
+      return from(this.api.invoke(functions.resetBestDifficulty, {}) as Promise<GenericResponse>);
+    }
+
+    if (environment.production && uri) {
+      return this.httpClient.post<GenericResponse>(`${uri}/api/system/resetBestDifficulty`, {});
+    }
+
+    return of({ message: 'Best difficulty reset (mock)' });
+  }
+
   public downloadLogs(uri: string = ''): Observable<Blob> {
     if (environment.production && this.api && !uri) {
       return from(this.api.invoke(functions.downloadSystemLogs, {}) as Promise<Blob>);

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -523,6 +523,36 @@ static esp_err_t handle_options_request(httpd_req_t * req)
     return ESP_OK;
 }
 
+// Handler to reset best difficulty
+static esp_err_t POST_reset_best_difficulty(httpd_req_t * req)
+{
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+
+    // Set CORS headers
+    if (set_cors_headers(req) != ESP_OK) {
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
+
+    // Reset best difficulty in global state
+    GLOBAL_STATE->SYSTEM_MODULE.best_nonce_diff = 0;
+    GLOBAL_STATE->SYSTEM_MODULE.best_diff_string[0] = '\0';
+    nvs_config_set_u64(NVS_CONFIG_BEST_DIFF, 0);
+
+    httpd_resp_set_type(req, "application/json");
+    cJSON * root = cJSON_CreateObject();
+    if (root == NULL) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Memory allocation failed");
+        return ESP_OK;
+    }
+    cJSON_AddStringToObject(root, "message", "Best difficulty has been reset.");
+    esp_err_t res = HTTP_send_json(req, root, &api_common_prebuffer_len);
+    cJSON_Delete(root);
+    return res;
+}
+
 bool check_settings_and_update(const cJSON * const root)
 {
     bool result = true;
@@ -1558,6 +1588,14 @@ esp_err_t start_rest_server(void * pvParameters)
         .user_ctx = rest_context
     };
     httpd_register_uri_handler(server, &update_system_settings_uri);
+
+        httpd_uri_t reset_best_diff_uri = {
+            .uri      = "/api/system/resetBestDifficulty",
+            .method   = HTTP_POST,
+            .handler  = POST_reset_best_difficulty,
+            .user_ctx = rest_context
+        };
+        httpd_register_uri_handler(server, &reset_best_diff_uri);
 
     httpd_uri_t update_post_ota_firmware = {
         .uri = "/api/system/OTA", 

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -1011,6 +1011,25 @@ paths:
         '500':
           description: Internal server error
 
+  /api/system/resetBestDifficulty:
+    post:
+      summary: Reset best difficulty
+      description: Resets the best difficulty value in persistent storage
+      operationId: resetBestDifficulty
+      tags:
+        - system
+      responses:
+        '200':
+          description: Best difficulty reset
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericResponse'
+        '401':
+          description: Unauthorized - Client not in allowed network range
+        '500':
+          description: Internal server error
+
   /api/system:
     patch:
       summary: Update system settings


### PR DESCRIPTION
- Added /api/system/resetBestDifficulty endpoint to backend (C, OpenAPI)
- Integrated reset button in web UI (Angular)
- Updated SystemApiService and EditComponent for new feature
- Ensures best difficulty can be reset from UI and API

This PR implements a secure, CORS-compliant API for resetting the best difficulty, updates the OpenAPI spec, and provides a user-facing button in the web interface. All changes are backward compatible.