### PR TITLE
Rename API key overheat_mode to overheatMode (#621)

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -46,7 +46,7 @@
             </ng-container>
         </div>
 
-        <div *ngIf="form.get('overheat_mode')?.value === 1" class="mt-4">
+        <div *ngIf="form.get('overheatMode')?.value === 1" class="mt-4">
             <button pButton type="button" label="Disable Overheat Mode"
                     class="p-button-danger w-full"
                     (click)="disableOverheatMode()">

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -164,7 +164,7 @@ export class EditComponent implements OnInit, OnDestroy, OnChanges {
           minfanspeed: [info.minFanSpeed, [Validators.required]],
           manualFanSpeed: [info.manualFanSpeed, [Validators.required]],
           temptarget: [info.temptarget, [Validators.required]],
-          overheat_mode: [info.overheat_mode, [Validators.required]],
+          overheatMode: [info.overheatMode ?? info.overheat_mode, [Validators.required]],
           statsFrequency: [info.statsFrequency, [
             Validators.required,
             Validators.min(0),
@@ -243,7 +243,7 @@ export class EditComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   disableOverheatMode() {
-    this.form.patchValue({ overheat_mode: 0 });
+    this.form.patchValue({ overheatMode: 0 });
     this.updateSystem();
   }
 
@@ -337,7 +337,7 @@ export class EditComponent implements OnInit, OnDestroy, OnChanges {
       'autofanspeed',
       'manualFanSpeed',
       'temptarget',
-      'overheat_mode',
+      'overheatMode',
       'statsFrequency'
     ];
   }

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -961,7 +961,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
     updateMessage(!!systemInfoError.duration, 'SYSTEM_INFO_ERROR', 'error', `Unable to reach the device for ${DateAgoPipe.transform(systemInfoError.duration, { strict: true })}`);
     updateMessage(!!(info as any).miningPaused, 'MINING_PAUSED', 'warn', 'Mining is paused');
-    updateMessage(info.overheat_mode === 1, 'DEVICE_OVERHEAT', 'error', 'Device has overheated - See settings');
+    updateMessage((info.overheatMode ?? info.overheat_mode) === 1, 'DEVICE_OVERHEAT', 'error', 'Device has overheated - See settings');
     updateMessage(!!info.power_fault, 'POWER_FAULT', 'error', `${info.power_fault} Check your Power Supply.`);
     updateMessage(!!info.hardware_fault, 'HARDWARE_FAULT', 'error', `${info.hardware_fault}`);
     updateMessage(!info.frequency || info.frequency < 400, 'FREQUENCY_LOW', 'warn', 'Device frequency is set low - See settings');

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -369,7 +369,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
       IP,
       ...existing,
       power_fault: null,
-      overheat_mode: null,
+      overheatMode: null,
       isUsingFallbackStratum: null,
       blockFound: null,
       ...info,
@@ -469,7 +469,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
     switch (true) {
       case !!axe.miningPaused:
         return { color: 'yellow', msg: 'Paused' };
-      case axe.overheat_mode === 1:
+      case (axe.overheatMode ?? axe.overheat_mode) === 1:
         return { color: 'red', msg: 'Overheated' };
       case !!axe.power_fault:
         return { color: 'red', msg: 'Power Fault' };

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -137,7 +137,7 @@ export class SystemApiService {
 
         boardtemp1: 30,
         boardtemp2: 40,
-        overheat_mode: 0,
+        overheatMode: 0,
 
         blockHeight: 811111,
         scriptsig: "..%..h..,H...ckpool.eu/solo.ckpool.org/",

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -523,6 +523,19 @@ static esp_err_t handle_options_request(httpd_req_t * req)
     return ESP_OK;
 }
 
+// Returns the JSON value for a setting, or NULL if absent.
+// Supports a legacy snake_case alias for keys we have renamed.
+static cJSON * get_setting_item(const cJSON * const root, NvsConfigKey key, const char * rest_name)
+{
+    cJSON * item = cJSON_GetObjectItem(root, rest_name);
+    if (item) return item;
+    if (key == NVS_CONFIG_OVERHEAT_MODE) {
+        // Deprecated: accept "overheat_mode" for legacy clients.
+        return cJSON_GetObjectItem(root, "overheat_mode");
+    }
+    return NULL;
+}
+
 bool check_settings_and_update(const cJSON * const root)
 {
     bool result = true;
@@ -531,7 +544,7 @@ bool check_settings_and_update(const cJSON * const root)
         Settings *setting = nvs_config_get_settings(key);
         if (!setting->rest_name) continue;
 
-        cJSON * item = cJSON_GetObjectItem(root, setting->rest_name);
+        cJSON * item = get_setting_item(root, key, setting->rest_name);
         if (!item) continue;
 
         switch (setting->type) {
@@ -607,7 +620,7 @@ bool check_settings_and_update(const cJSON * const root)
             Settings *setting = nvs_config_get_settings(key);
             if (!setting || !setting->rest_name) continue;
 
-            cJSON * item = cJSON_GetObjectItem(root, setting->rest_name);
+            cJSON * item = get_setting_item(root, key, setting->rest_name);
             if (!item) continue;
 
             switch(setting->type) {
@@ -990,7 +1003,10 @@ static esp_err_t GET_system_info(httpd_req_t * req)
     cJSON_AddStringToObject(root, "resetReason", esp_reset_reason_to_string(esp_reset_reason()));
     cJSON_AddStringToObject(root, "runningPartition", esp_ota_get_running_partition()->label);
 
-    cJSON_AddNumberToObject(root, "overheat_mode", nvs_config_get_bool(NVS_CONFIG_OVERHEAT_MODE));
+    bool overheat_mode_value = nvs_config_get_bool(NVS_CONFIG_OVERHEAT_MODE);
+    cJSON_AddNumberToObject(root, "overheatMode", overheat_mode_value);
+    // Deprecated: use "overheatMode" instead. Retained for backward compatibility.
+    cJSON_AddNumberToObject(root, "overheat_mode", overheat_mode_value);
     cJSON_AddBoolToObject(root, "miningPaused", GLOBAL_STATE->SYSTEM_MODULE.mining_paused);
     cJSON_AddNumberToObject(root, "overclockEnabled", nvs_config_get_bool(NVS_CONFIG_OVERCLOCK_ENABLED));
     cJSON_AddStringToObject(root, "display", display);

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -157,7 +157,7 @@ components:
         - maxPower
         - minFanSpeed
         - nominalVoltage
-        - overheat_mode
+        - overheatMode
         - overclockEnabled
         - poolConnectionInfo
         - poolDifficulty
@@ -340,9 +340,13 @@ components:
         nominalVoltage:
           type: integer
           description: Nominal board voltage
-        overheat_mode:
+        overheatMode:
           type: number
           description: Overheat protection mode
+        overheat_mode:
+          type: number
+          deprecated: true
+          description: Deprecated alias for overheatMode. Will be removed in a future release.
         overclockEnabled:
           type: integer
           description: Set custom voltage/frequency in AxeOS
@@ -713,9 +717,16 @@ components:
           enum: [0, 1]
           examples:
             - 0
-        overheat_mode:
+        overheatMode:
           type: integer
           description: Overheat protection mode (0=disabled)
+          enum: [0]
+          examples:
+            - 0
+        overheat_mode:
+          type: integer
+          deprecated: true
+          description: Deprecated alias for overheatMode. Will be removed in a future release.
           enum: [0]
           examples:
             - 0

--- a/main/nvs_config.c
+++ b/main/nvs_config.c
@@ -85,7 +85,7 @@ static Settings settings[NVS_CONFIG_COUNT] = {
     [NVS_CONFIG_MANUAL_FAN_SPEED]                      = {.nvs_key_name = "manualfanspeed",  .type = TYPE_U16,   .default_value = {.u16 = 100},                                         .rest_name = "manualFanSpeed",                     .min = 0,  .max = 100},
     [NVS_CONFIG_MIN_FAN_SPEED]                         = {.nvs_key_name = "minfanspeed",     .type = TYPE_U16,   .default_value = {.u16 = 25},                                          .rest_name = "minFanSpeed",                        .min = 0,  .max = 99},
     [NVS_CONFIG_TEMP_TARGET]                           = {.nvs_key_name = "temptarget",      .type = TYPE_U16,   .default_value = {.u16 = 60},                                          .rest_name = "temptarget",                         .min = 35, .max = 66},
-    [NVS_CONFIG_OVERHEAT_MODE]                         = {.nvs_key_name = "overheat_mode",   .type = TYPE_BOOL,                                                                         .rest_name = "overheat_mode",                      .min = 0,  .max = 0},
+    [NVS_CONFIG_OVERHEAT_MODE]                         = {.nvs_key_name = "overheat_mode",   .type = TYPE_BOOL,                                                                         .rest_name = "overheatMode",                       .min = 0,  .max = 0},
 
     [NVS_CONFIG_STATISTICS_FREQUENCY]                  = {.nvs_key_name = "statsFrequency",  .type = TYPE_U16,                                                                          .rest_name = "statsFrequency",                     .min = 0,  .max = UINT16_MAX},
 


### PR DESCRIPTION
Closes #621.

The `overheat_mode` JSON key in the system API is the only snake_case key in an otherwise camelCase REST surface. This renames it to `overheatMode`.

## Compatibility

The reporter asked about deprecation procedure, so this PR keeps the old spelling working alongside the new one:

- **GET `/api/system/info`** emits both `overheatMode` (canonical) and `overheat_mode` (deprecated alias).
- **PATCH `/api/system`** accepts either spelling. If both are present, `overheatMode` wins.
- **OpenAPI** marks `overheat_mode` with `deprecated: true` in both schemas.
- **Frontend** reads `info.overheatMode ?? info.overheat_mode` so AxeOS keeps working if it ever talks to older firmware (and vice-versa).

The NVS storage key (`nvs_key_name`) is unchanged so existing devices keep their stored setting on upgrade.

## Test plan

- [x] `npm run generate:api && ng build --configuration=production` passes.
- [ ] CI: ESP-IDF build (no local toolchain).
- [ ] Manual: PATCH with `overheat_mode: 0` still clears the overheat flag.
- [ ] Manual: PATCH with `overheatMode: 0` clears the overheat flag.
- [ ] Manual: GET response contains both keys with the same value.