### PR TITLE
Only show restart warning when Wi-Fi changes (#581)

### DIFF
--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
@@ -64,11 +64,16 @@ export class NetworkEditComponent implements OnInit {
       form.ssid = form.ssid.trim();
     }
 
+    // Hostname is applied live; only Wi-Fi changes require a restart.
+    const restartRequired = this.form.controls['ssid'].dirty || this.form.controls['wifiPass'].dirty;
+
     this.systemService.updateSystem(this.uri, form)
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe({
         next: () => {
-          this.toastr.warning('You must restart this device after saving for changes to take effect.');
+          if (restartRequired) {
+            this.toastr.warning('You must restart this device after saving for changes to take effect.');
+          }
           this.toastr.success('Saved network settings');
           this.savedChanges = true;
         },


### PR DESCRIPTION
Closes #581.

The network settings page warned "you must restart" after any save, but the device applies hostname changes live (visible immediately in the swarm view, as the issue reporter noted). Limit the warning to dirty `ssid`/`wifiPass` so it only appears when a Wi-Fi reconnection is actually needed.

## Test plan

- [x] Frontend builds (`ng build --configuration=production`).
- [ ] Manual: change only hostname → no restart warning, hostname updates immediately.
- [ ] Manual: change SSID → restart warning appears.
- [ ] Manual: change Wi-Fi password → restart warning appears.
- [ ] Manual: change hostname + SSID together → restart warning appears.