### PR TITLE
Clear firmware update screen after OTA failure (#764)

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -1292,12 +1292,17 @@ esp_err_t POST_WWW_update(httpd_req_t * req)
         } else if (recv_len <= 0) {
             snprintf(GLOBAL_STATE->SYSTEM_MODULE.firmware_update_status, 20, "Protocol Error");
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Protocol Error");
+            // Hold the error on screen long enough to read, then return to normal display.
+            vTaskDelay(5000 / portTICK_PERIOD_MS);
+            GLOBAL_STATE->SYSTEM_MODULE.is_firmware_update = false;
             return ESP_OK;
         }
 
         if (esp_partition_write(www_partition, www_partition->size - remaining, (const void *) buf, recv_len) != ESP_OK) {
             snprintf(GLOBAL_STATE->SYSTEM_MODULE.firmware_update_status, 20, "Write Error");
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Write Error");
+            vTaskDelay(5000 / portTICK_PERIOD_MS);
+            GLOBAL_STATE->SYSTEM_MODULE.is_firmware_update = false;
             return ESP_OK;
         }
 
@@ -1360,8 +1365,12 @@ esp_err_t POST_OTA_update(httpd_req_t * req)
 
             // Serious Error: Abort OTA
         } else if (recv_len <= 0) {
+            esp_ota_abort(ota_handle);
             snprintf(GLOBAL_STATE->SYSTEM_MODULE.firmware_update_status, 20, "Protocol Error");
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Protocol Error");
+            // Hold the error on screen long enough to read, then return to normal display.
+            vTaskDelay(5000 / portTICK_PERIOD_MS);
+            GLOBAL_STATE->SYSTEM_MODULE.is_firmware_update = false;
             return ESP_OK;
         }
 
@@ -1370,6 +1379,8 @@ esp_err_t POST_OTA_update(httpd_req_t * req)
             esp_ota_abort(ota_handle);
             snprintf(GLOBAL_STATE->SYSTEM_MODULE.firmware_update_status, 20, "Write Error");
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Write Error");
+            vTaskDelay(5000 / portTICK_PERIOD_MS);
+            GLOBAL_STATE->SYSTEM_MODULE.is_firmware_update = false;
             return ESP_OK;
         }
 
@@ -1389,6 +1400,8 @@ esp_err_t POST_OTA_update(httpd_req_t * req)
     if (esp_ota_end(ota_handle) != ESP_OK || esp_ota_set_boot_partition(ota_partition) != ESP_OK) {
         snprintf(GLOBAL_STATE->SYSTEM_MODULE.firmware_update_status, 20, "Validation Error");
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Validation / Activation Error");
+        vTaskDelay(5000 / portTICK_PERIOD_MS);
+        GLOBAL_STATE->SYSTEM_MODULE.is_firmware_update = false;
         return ESP_OK;
     }
 


### PR DESCRIPTION
Closes #764.

Every error path in `POST_OTA_update` and `POST_WWW_update` left `is_firmware_update = true`, so the display stayed stuck on the firmware screen showing the error until the device was reset. The chip was still hashing the whole time.

The reporter asked for the boot button to clear the screen. This PR auto-clears instead — the error stays on screen for 5 s (long enough to read), then `is_firmware_update` is cleared and the normal display returns. No new button wiring needed.

Also fixed a minor leak: the protocol-error path in `POST_OTA_update` was not calling `esp_ota_abort()` like the write-error path does.

## Test plan

- [ ] Reproduce per the issue: `curl --data \"@esp-miner.bin\" http://bitaxe/api/system/OTA` (no POST). Display should show "Write Error" briefly, then return to normal.
- [ ] Drop the connection mid-transfer. Display shows "Protocol Error" briefly, then returns to normal.
- [ ] Successful OTA still reboots cleanly.
- [ ] Successful WWW upload still completes and clears the screen.