### PR TITLE
Show actual resolved frequency

### DIFF
--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -147,7 +147,7 @@ void BM1366_set_version_mask(uint32_t version_mask)
     _send_BM1366(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1366_SERIALTX_DEBUG);
 }
 
-void BM1366_send_hash_frequency(float target_freq)
+float BM1366_send_hash_frequency(float target_freq)
 {
     uint8_t fb_divider, refdiv, postdiv1, postdiv2;
     float new_freq;
@@ -161,6 +161,8 @@ void BM1366_send_hash_frequency(float target_freq)
     _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_WRITE), freqbuf, 6, BM1366_SERIALTX_DEBUG);
 
     ESP_LOGI(TAG, "Setting Frequency to %g MHz (%g)", target_freq, new_freq);
+
+    return new_freq;
 }
 
 uint8_t BM1366_init(void * pvParameters)

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -124,7 +124,7 @@ void BM1368_set_version_mask(uint32_t version_mask)
     _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1368_SERIALTX_DEBUG);
 }
 
-void BM1368_send_hash_frequency(float target_freq) 
+float BM1368_send_hash_frequency(float target_freq)
 {
     uint8_t fb_divider, refdiv, postdiv1, postdiv2;
     float new_freq;
@@ -138,6 +138,8 @@ void BM1368_send_hash_frequency(float target_freq)
     _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, freqbuf, sizeof(freqbuf), BM1368_SERIALTX_DEBUG);
 
     ESP_LOGI(TAG, "Setting Frequency to %g MHz (%g)", target_freq, new_freq);
+
+    return new_freq;
 }
 
 uint8_t BM1368_init(void * pvParameters)

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -142,7 +142,7 @@ void BM1370_set_version_mask(uint32_t version_mask)
     _send_BM1370(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1370_SERIALTX_DEBUG);
 }
 
-void BM1370_send_hash_frequency(float target_freq) 
+float BM1370_send_hash_frequency(float target_freq)
 {
     uint8_t fb_divider, refdiv, postdiv1, postdiv2;
     float frequency;
@@ -156,6 +156,8 @@ void BM1370_send_hash_frequency(float target_freq)
     _send_BM1370(TYPE_CMD | GROUP_ALL | CMD_WRITE, freqbuf, 6, BM1370_SERIALTX_DEBUG);
 
     ESP_LOGI(TAG, "Setting Frequency to %g MHz (%g)", target_freq, frequency);
+
+    return frequency;
 }
 
 uint8_t BM1370_init(void * pvParameters)

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -149,7 +149,7 @@ void BM1397_set_version_mask(uint32_t version_mask) {
     // placeholder
 }
 
-void BM1397_send_hash_frequency(float target_freq)
+float BM1397_send_hash_frequency(float target_freq)
 {
     uint8_t fb_divider, refdiv, postdiv1, postdiv2;
     float frequency;
@@ -175,6 +175,8 @@ void BM1397_send_hash_frequency(float target_freq)
     vTaskDelay(10 / portTICK_PERIOD_MS);
 
     ESP_LOGI(TAG, "Setting Frequency to %g MHz (%g)", target_freq, frequency);
+
+    return frequency;
 }
 
 uint8_t BM1397_init(void * pvParameters)

--- a/components/asic/frequency_transition_bmXX.c
+++ b/components/asic/frequency_transition_bmXX.c
@@ -22,8 +22,7 @@ void do_frequency_transition(void * pvParameters, set_hash_frequency_fn set_freq
 
     if (fabs(target_frequency - current_frequency) < STEP_SIZE) {
         current_frequency = target_frequency;
-        GLOBAL_STATE->POWER_MANAGEMENT_MODULE.actual_frequency = current_frequency;
-        set_frequency_fn(current_frequency);
+        GLOBAL_STATE->POWER_MANAGEMENT_MODULE.actual_frequency = set_frequency_fn(current_frequency);
         return;
     }
 
@@ -40,8 +39,7 @@ void do_frequency_transition(void * pvParameters, set_hash_frequency_fn set_freq
             current_step += signum;
 
             current_frequency = current_step * STEP_SIZE;
-            GLOBAL_STATE->POWER_MANAGEMENT_MODULE.actual_frequency = current_frequency;
-            set_frequency_fn(current_frequency);
+            GLOBAL_STATE->POWER_MANAGEMENT_MODULE.actual_frequency = set_frequency_fn(current_frequency);
             
             vTaskDelay(100 / portTICK_PERIOD_MS);
         }
@@ -49,8 +47,7 @@ void do_frequency_transition(void * pvParameters, set_hash_frequency_fn set_freq
     
     if (fabs(current_frequency - target_frequency) > EPSILON) {
         current_frequency = target_frequency;
-        GLOBAL_STATE->POWER_MANAGEMENT_MODULE.actual_frequency = current_frequency;
-        set_frequency_fn(current_frequency);
+        GLOBAL_STATE->POWER_MANAGEMENT_MODULE.actual_frequency = set_frequency_fn(current_frequency);
     }
     
     ESP_LOGI(TAG, "Successfully transitioned to %g MHz", target_frequency);

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -26,7 +26,7 @@ void BM1366_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1366_set_version_mask(uint32_t version_mask);
 int BM1366_set_max_baud(void);
 int BM1366_set_default_baud(void);
-void BM1366_send_hash_frequency(float frequency);
+float BM1366_send_hash_frequency(float frequency);
 task_result * BM1366_process_work(void * GLOBAL_STATE);
 void BM1366_read_registers(void);
 

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -26,7 +26,7 @@ void BM1368_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1368_set_version_mask(uint32_t version_mask);
 int BM1368_set_max_baud(void);
 int BM1368_set_default_baud(void);
-void BM1368_send_hash_frequency(float frequency);
+float BM1368_send_hash_frequency(float frequency);
 task_result * BM1368_process_work(void * GLOBAL_STATE);
 void BM1368_read_registers(void);
 

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -26,7 +26,7 @@ void BM1370_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1370_set_version_mask(uint32_t version_mask);
 int BM1370_set_max_baud(void);
 int BM1370_set_default_baud(void);
-void BM1370_send_hash_frequency(float frequency);
+float BM1370_send_hash_frequency(float frequency);
 task_result * BM1370_process_work(void * GLOBAL_STATE);
 void BM1370_read_registers(void);
 

--- a/components/asic/include/bm1397.h
+++ b/components/asic/include/bm1397.h
@@ -28,7 +28,7 @@ void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1397_set_version_mask(uint32_t version_mask);
 int BM1397_set_max_baud(void);
 int BM1397_set_default_baud(void);
-void BM1397_send_hash_frequency(float frequency);
+float BM1397_send_hash_frequency(float frequency);
 task_result * BM1397_process_work(void * GLOBAL_STATE);
 void BM1397_read_registers(void);
 

--- a/components/asic/include/frequency_transition_bmXX.h
+++ b/components/asic/include/frequency_transition_bmXX.h
@@ -13,7 +13,7 @@ extern const char *FREQUENCY_TRANSITION_TAG;
  * 
  * @param frequency The frequency to set in MHz
  */
-typedef void (*set_hash_frequency_fn)(float frequency);
+typedef float (*set_hash_frequency_fn)(float frequency);
 
 /**
  * @brief Transition the ASIC frequency to a target value

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -269,7 +269,7 @@
 
                 <div class="mb-3">
                     <h6 class="flex justify-content-between mb-1">
-                        ASIC Frequency<span>{{info.actualFrequency}} MHz</span>
+                        ASIC Frequency<span>{{info.actualFrequency | number: '1.0-4'}} MHz</span>
                     </h6>
                     <p-progressBar [value]="(info.actualFrequency / maxFrequency) * 100" [styleClass]="'p-progressbar--thin'">
                         <ng-template pTemplate="content" let-value></ng-template>


### PR DESCRIPTION
Expose frequency as resolved by the PLL solver.

Example, when setting 528 Mhz:

<img width="1026" height="372" alt="image" src="https://github.com/user-attachments/assets/a0ed7f80-abe7-4299-949b-c42379ddcbca" />

The PLL cannot perfectly resolve this, so it lands to the closest frequency:

```
I (992164) power_management: New ASIC frequency requested: 528 MHz (current: 525 MHz)
I (992165) pll: Frequency: 528.125 MHz (fb_divider: 169, refdiv: 2, postdiv1: 4, postdiv2: 1)
```

Which will then be shown:

<img width="571" height="338" alt="image" src="https://github.com/user-attachments/assets/662b53b7-6999-4c60-a28c-5a39d7e57730" />