### PR TITLE
Confirm before restart from topbar (#1633)

### DIFF
--- a/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
@@ -72,6 +72,9 @@ export class AppTopBarComponent implements OnInit, OnDestroy {
   }
 
   public restart() {
+    if (!window.confirm('Restart the device? Current mining work will be lost.')) {
+      return;
+    }
     this.systemService.restart().subscribe({
       next: () => this.toastr.success('Device restarted'),
       error: () => this.toastr.error('Restart failed')


### PR DESCRIPTION
## Summary
- Prompt the user via `window.confirm()` before calling `systemService.restart()` from the topbar icon.
- Addresses #1633: on tablets the restart icon sits close to the mining controls and is easy to hit by accident, rebooting the device and losing in-flight work with no warning.

## Test plan
- [x] `ng build --configuration development` — clean build, no TS errors
- [x] `ng serve` started, confirm-dialog string present in bundled `main.js`
- [ ] Click restart icon → prompt appears; Cancel aborts, OK still reboots
- [ ] No regression on the adjacent Pause/Resume icon (untouched)