### PR TITLE
Chart ASIC temp as hottest chip (#1476)

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -1153,7 +1153,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       case eChartLabel.hashrate_10m:       return info.hashRate_10m;
       case eChartLabel.hashrate_1h:        return info.hashRate_1h;
       case eChartLabel.errorPercentage:    return info.errorPercentage;
-      case eChartLabel.asicTemp:           return info.temp;
+      case eChartLabel.asicTemp:           return Math.max(info.temp, info.temp2);
       case eChartLabel.vrTemp:             return info.vrTemp;
       case eChartLabel.asicVoltage:        return info.coreVoltageActual;
       case eChartLabel.voltage:            return info.voltage;


### PR DESCRIPTION
## Summary
- The ASIC Temp chart on multi-chip units was plotting only ASIC #1's temperature (`info.temp`), hiding hotter chips. Issue reporter on a GammaTurbo (two-chip 800 GT) saw ASIC #2 running hotter than charted.
- Use `Math.max(info.temp, info.temp2)` so the chart reflects the hottest chip.
- On single-chip boards `Thermal_get_chip_temp2` returns -1, so `Math.max` degenerates to `info.temp` — no change in behavior.

## Test plan
- [x] `ng build --configuration development` — clean build, no TS errors
- [ ] On a multi-chip unit (GammaTurbo / GammaDuo / Hex / SupraHex), verify chart tracks the hotter of the two reported chip temps
- [ ] On a single-chip unit (Ultra / Supra / Gamma), verify chart still shows ASIC temp as before