### PR TITLE
Fix url decoding of the statistics endpoint path parameters

### DIFF
--- a/components/stratum/include/utils.h
+++ b/components/stratum/include/utils.h
@@ -29,6 +29,8 @@ void suffixString(uint64_t val, char * buf, size_t bufsiz, int sigdigits);
 
 float hashCounterToGhs(uint64_t duration_us, uint32_t counter);
 
+void url_decode(char *dst, const char *src);
+
 #define STRATUM_DEFAULT_VERSION_MASK 0x1fffe000
 
 #endif // STRATUM_UTILS_H

--- a/components/stratum/utils.c
+++ b/components/stratum/utils.c
@@ -237,3 +237,18 @@ float hashCounterToGhs(uint64_t duration_us, uint32_t counter)
     float hashrate = counter / seconds * (float)HASH_CNT_LSB; // Make sure it stays in float
     return hashrate / 1e9f; // Convert to Gh/s
 }
+
+void url_decode(char *dst, const char *src) {
+    while (*src) {
+        if ((*src == '%') && src[1] && src[2]) {
+            *dst++ = (hex_val_table[(unsigned char)src[1]] << 4) | hex_val_table[(unsigned char)src[2]];
+            src += 3;
+        } else if (*src == '+') {
+            *dst++ = ' ';
+            src++;
+        } else {
+            *dst++ = *src++;
+        }
+    }
+    *dst = '\0';
+}

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -220,12 +220,17 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.loadingService.loading$.next(true);
 
     let dataSources = this.storageService.getItem(HOME_CHART_DATA_SOURCES);
-    if (dataSources === null) {
-      dataSources = `{"chartY1Data":"${chartLabelKey(eChartLabel.hashrate)}",`;
-      dataSources += `"chartY2Data":"${chartLabelKey(eChartLabel.asicTemp)}"}`;
+    let parsedConfig: any = { chartY1Data: chartLabelKey(eChartLabel.hashrate), chartY2Data: chartLabelKey(eChartLabel.asicTemp) };
+    
+    if (dataSources !== null) {
+      try {
+        const stored = JSON.parse(dataSources);
+        if (stored.chartY1Data) parsedConfig.chartY1Data = stored.chartY1Data;
+        if (stored.chartY2Data) parsedConfig.chartY2Data = stored.chartY2Data;
+      } catch (e) { }
     }
 
-    this.form = this.fb.group(JSON.parse(dataSources));
+    this.form = this.fb.group(parsedConfig);
 
     this.form.valueChanges.subscribe(() => {
       this.storageService.setItem(HOME_CHART_DATA_SOURCES, JSON.stringify(this.form.getRawValue()));
@@ -1132,7 +1137,8 @@ export class HomeComponent implements OnInit, OnDestroy {
       case eChartLabel.hashrate_10m:
       case eChartLabel.hashrate_1h:      return info.expectedHashrate;
       case eChartLabel.errorPercentage:  return 1;
-      case eChartLabel.asicTemp:         return this.maxTemp;
+      case eChartLabel.asicTemp:
+      case eChartLabel.asicTemp2:        return this.maxTemp;
       case eChartLabel.vrTemp:           return this.maxTemp + 25;
       case eChartLabel.asicVoltage:      return info.coreVoltage;
       case eChartLabel.voltage:          return info.nominalVoltage + .5;
@@ -1154,6 +1160,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       case eChartLabel.hashrate_1h:        return info.hashRate_1h;
       case eChartLabel.errorPercentage:    return info.errorPercentage;
       case eChartLabel.asicTemp:           return info.temp;
+      case eChartLabel.asicTemp2:          return info.temp2;
       case eChartLabel.vrTemp:             return info.vrTemp;
       case eChartLabel.asicVoltage:        return info.coreVoltageActual;
       case eChartLabel.voltage:            return info.voltage;
@@ -1173,6 +1180,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     switch (label) {
       case eChartLabel.errorPercentage:  return {suffix: ' %', precision: 2};
       case eChartLabel.asicTemp:
+      case eChartLabel.asicTemp2:
       case eChartLabel.vrTemp:           return {suffix: ' °C', precision: 1};
       case eChartLabel.asicVoltage:
       case eChartLabel.voltage:          return {suffix: ' V', precision: 1};
@@ -1216,6 +1224,9 @@ export class HomeComponent implements OnInit, OnDestroy {
   dataSourceLabels(info: ISystemInfo) {
     return Object.entries(eChartLabel)
       .filter(([key, ]) => key !== 'vrTemp' || info.vrTemp)
+      .filter(([key, ]) => key !== 'asicTemp2' || (info.temp2 && info.temp2 !== -1))
+      .filter(([key, ]) => key !== 'fanRpm' || info.fanrpm)
+      .filter(([key, ]) => key !== 'fan2Rpm' || info.fan2rpm)
       .map(([key, value]) => ({name: value, value: key}));
   }
 }

--- a/main/http_server/axe-os/src/models/enum/eChartLabel.ts
+++ b/main/http_server/axe-os/src/models/enum/eChartLabel.ts
@@ -4,6 +4,7 @@ export enum eChartLabel {
     hashrate_10m = 'Hashrate 10m',
     hashrate_1h = 'Hashrate 1h',
     asicTemp = 'ASIC Temp',
+    asicTemp2 = 'ASIC Temp 2',
     errorPercentage = 'Error %',
     vrTemp = 'VR Temp',
     asicVoltage = 'ASIC Voltage',

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -47,6 +47,7 @@
 #include "system.h"
 #include "websocket.h"
 #include "log_buffer.h"
+#include "utils.h"
 
 static const char * TAG = "http_server";
 static const char * CORS_TAG = "CORS";
@@ -57,6 +58,7 @@ static const char * STATS_LABEL_HASHRATE_10m = "hashrate_10m";
 static const char * STATS_LABEL_HASHRATE_1h = "hashrate_1h";
 static const char * STATS_LABEL_ERROR_PERCENTAGE = "errorPercentage";
 static const char * STATS_LABEL_ASIC_TEMP = "asicTemp";
+static const char * STATS_LABEL_ASIC_TEMP2 = "asicTemp2";
 static const char * STATS_LABEL_VR_TEMP = "vrTemp";
 static const char * STATS_LABEL_ASIC_VOLTAGE = "asicVoltage";
 static const char * STATS_LABEL_VOLTAGE = "voltage";
@@ -84,6 +86,7 @@ typedef enum
     SRC_HASHRATE_1h,
     SRC_ERROR_PERCENTAGE,
     SRC_ASIC_TEMP,
+    SRC_ASIC_TEMP2,
     SRC_VR_TEMP,
     SRC_ASIC_VOLTAGE,
     SRC_VOLTAGE,
@@ -110,6 +113,7 @@ DataSource strToDataSource(const char * sourceStr)
         if (strcmp(sourceStr, STATS_LABEL_POWER) == 0)        return SRC_POWER;
         if (strcmp(sourceStr, STATS_LABEL_CURRENT) == 0)      return SRC_CURRENT;
         if (strcmp(sourceStr, STATS_LABEL_ASIC_TEMP) == 0)    return SRC_ASIC_TEMP;
+        if (strcmp(sourceStr, STATS_LABEL_ASIC_TEMP2) == 0)   return SRC_ASIC_TEMP2;
         if (strcmp(sourceStr, STATS_LABEL_VR_TEMP) == 0)      return SRC_VR_TEMP;
         if (strcmp(sourceStr, STATS_LABEL_ASIC_VOLTAGE) == 0) return SRC_ASIC_VOLTAGE;
         if (strcmp(sourceStr, STATS_LABEL_FAN_SPEED) == 0)    return SRC_FAN_SPEED;
@@ -1106,8 +1110,10 @@ static esp_err_t GET_system_statistics(httpd_req_t * req)
     if (1 < bufLen) {
         char buf[bufLen];
         if (httpd_req_get_url_query_str(req, buf, bufLen) == ESP_OK) {
-            char columns[bufLen];
-            if (httpd_query_key_value(buf, "columns", columns, bufLen) == ESP_OK) {
+            char columns_enc[bufLen];
+            if (httpd_query_key_value(buf, "columns", columns_enc, bufLen) == ESP_OK) {
+                char columns[bufLen];
+                url_decode(columns, columns_enc);
                 char * param = strtok(columns, ",");
                 while (NULL != param) {
                     DataSource sourceParam = strToDataSource(param);
@@ -1139,6 +1145,7 @@ static esp_err_t GET_system_statistics(httpd_req_t * req)
     if (dataSelection[SRC_HASHRATE_1h]) { cJSON_AddItemToArray(labelArray, cJSON_CreateString(STATS_LABEL_HASHRATE_1h)); }
     if (dataSelection[SRC_ERROR_PERCENTAGE]) { cJSON_AddItemToArray(labelArray, cJSON_CreateString(STATS_LABEL_ERROR_PERCENTAGE)); }
     if (dataSelection[SRC_ASIC_TEMP]) { cJSON_AddItemToArray(labelArray, cJSON_CreateString(STATS_LABEL_ASIC_TEMP)); }
+    if (dataSelection[SRC_ASIC_TEMP2]) { cJSON_AddItemToArray(labelArray, cJSON_CreateString(STATS_LABEL_ASIC_TEMP2)); }
     if (dataSelection[SRC_VR_TEMP]) { cJSON_AddItemToArray(labelArray, cJSON_CreateString(STATS_LABEL_VR_TEMP)); }
     if (dataSelection[SRC_ASIC_VOLTAGE]) { cJSON_AddItemToArray(labelArray, cJSON_CreateString(STATS_LABEL_ASIC_VOLTAGE)); }
     if (dataSelection[SRC_VOLTAGE]) { cJSON_AddItemToArray(labelArray, cJSON_CreateString(STATS_LABEL_VOLTAGE)); }
@@ -1166,6 +1173,7 @@ static esp_err_t GET_system_statistics(httpd_req_t * req)
         if (dataSelection[SRC_HASHRATE_1h]) { cJSON_AddItemToArray(valueArray, cJSON_CreateFloat(statsData.hashrate_1h)); }
         if (dataSelection[SRC_ERROR_PERCENTAGE]) { cJSON_AddItemToArray(valueArray, cJSON_CreateFloat(statsData.errorPercentage)); }
         if (dataSelection[SRC_ASIC_TEMP]) { cJSON_AddItemToArray(valueArray, cJSON_CreateFloat(statsData.chipTemperature)); }
+        if (dataSelection[SRC_ASIC_TEMP2]) { cJSON_AddItemToArray(valueArray, cJSON_CreateFloat(statsData.chipTemperature2)); }
         if (dataSelection[SRC_VR_TEMP]) { cJSON_AddItemToArray(valueArray, cJSON_CreateFloat(statsData.vrTemperature)); }
         if (dataSelection[SRC_ASIC_VOLTAGE]) { cJSON_AddItemToArray(valueArray, cJSON_CreateNumber(statsData.coreVoltageActual)); }
         if (dataSelection[SRC_VOLTAGE]) { cJSON_AddItemToArray(valueArray, cJSON_CreateFloat(statsData.voltage)); }

--- a/main/tasks/statistics_task.c
+++ b/main/tasks/statistics_task.c
@@ -137,6 +137,7 @@ void statistics_task(void * pvParameters)
                 statsData.hashrate_1h = sys_module->hashrate_1h;
                 statsData.errorPercentage = sys_module->error_percentage;
                 statsData.chipTemperature = power_management->chip_temp_avg;
+                statsData.chipTemperature2 = power_management->chip_temp2_avg;
                 statsData.vrTemperature = power_management->vr_temp;
                 statsData.power = power_management->power;
                 statsData.voltage = power_management->voltage;

--- a/main/tasks/statistics_task.h
+++ b/main/tasks/statistics_task.h
@@ -14,6 +14,7 @@ struct StatisticsData
     float hashrate_1h;
     float errorPercentage;
     float chipTemperature;
+    float chipTemperature2;
     float vrTemperature;
     float power;
     float voltage;


### PR DESCRIPTION
The statistics endpoint didn't properly decode the url parameters, and reverted to fallback of just sending all columns. Added `url_decode` to tailer to response to whatever the dashboard needs.

Also:
 * Adds Asic 2 temp on the column selector
 * Filters out asic2temp, fanRpm and/or fan2rpm from the column selector of the chart if these are not available
 * Made parsing of `HOME_CHART_DATA_SOURCES` more robust