### PR TITLE
Use format specifiers for printf statements

### DIFF
--- a/main/bap/bap_handlers.c
+++ b/main/bap/bap_handlers.c
@@ -240,7 +240,7 @@ void BAP_send_request(bap_parameter_t param, GlobalState *state) {
         case BAP_PARAM_SHARES:
             {
                 char shares_ar_str[64];
-                snprintf(shares_ar_str, sizeof(shares_ar_str), "%llu/%llu", state->SYSTEM_MODULE.shares_accepted, state->SYSTEM_MODULE.shares_rejected);
+                snprintf(shares_ar_str, sizeof(shares_ar_str), "%" PRIu64 "/%" PRIu64, state->SYSTEM_MODULE.shares_accepted, state->SYSTEM_MODULE.shares_rejected);
                 BAP_send_message(BAP_CMD_RES, "shares", shares_ar_str);
             }
             break;

--- a/main/bap/bap_subscription.c
+++ b/main/bap/bap_subscription.c
@@ -285,7 +285,7 @@ void BAP_send_subscription_update(GlobalState *state) {
                     case BAP_PARAM_SHARES:
                         {
                             char shares_ar_str[64];
-                            snprintf(shares_ar_str, sizeof(shares_ar_str), "%llu/%llu", state->SYSTEM_MODULE.shares_accepted, state->SYSTEM_MODULE.shares_rejected);
+                            snprintf(shares_ar_str, sizeof(shares_ar_str), "%" PRIu64 "/%" PRIu64, state->SYSTEM_MODULE.shares_accepted, state->SYSTEM_MODULE.shares_rejected);
                             BAP_send_if_changed("shares", shares_ar_str, last_values.shares, sizeof(last_values.shares), &last_values_valid.shares);
                             
                         }

--- a/main/screen.c
+++ b/main/screen.c
@@ -672,13 +672,13 @@ static void uptime_update_cb(lv_timer_t * timer)
         uptime_seconds %= 60;
 
         if (days > 0) {
-            snprintf(uptime, sizeof(uptime), "Uptime: %lud %luh %lum %lus", days, hours, minutes, uptime_seconds);
+            snprintf(uptime, sizeof(uptime), "Uptime: %" PRIu32 "d %" PRIu32 "h %" PRIu32 "m %" PRIu32 "s", days, hours, minutes, uptime_seconds);
         } else if (hours > 0) {
-            snprintf(uptime, sizeof(uptime), "Uptime: %luh %lum %lus", hours, minutes, uptime_seconds);
+            snprintf(uptime, sizeof(uptime), "Uptime: %" PRIu32 "h %" PRIu32 "m %" PRIu32 "s", hours, minutes, uptime_seconds);
         } else if (minutes > 0) {
-            snprintf(uptime, sizeof(uptime), "Uptime: %lum %lus", minutes, uptime_seconds);
+            snprintf(uptime, sizeof(uptime), "Uptime: %" PRIu32 "m %" PRIu32 "s", minutes, uptime_seconds);
         } else {
-            snprintf(uptime, sizeof(uptime), "Uptime: %lus", uptime_seconds);
+            snprintf(uptime, sizeof(uptime), "Uptime: %" PRIu32 "s", uptime_seconds);
         }
 
         if (strcmp(lv_label_get_text(wifi_uptime_label), uptime) != 0) {

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -344,7 +344,7 @@ void self_test_task(void * pvParameters)
         }
 
         uint32_t remaining = (hashtest_ms - ((esp_timer_get_time() / 1000) - start_ms)) / 1000;
-        snprintf(logString, sizeof(logString), "%.0f Gh/s %.1f°C %lds", hashrate, asic_temp, remaining);
+        snprintf(logString, sizeof(logString), "%.0f Gh/s %.1f°C %" PRIu32 "s", hashrate, asic_temp, remaining);
         ESP_LOGI(TAG, "%s", logString);
 
         self_test_show_message(GLOBAL_STATE, logString);

--- a/main/task_monitor.c
+++ b/main/task_monitor.c
@@ -69,7 +69,7 @@ void task_monitor_task(void *pvParameters) {
             double delta_percentage = (task_delta * 100.0) / total_delta;
             uint64_t lifetime_runtime = task_array2[j].ulRunTimeCounter;
             double lifetime_percentage = (lifetime_runtime * 100.0) / total_runtime2;
-            printf("%-20s\t%llu\t\t\t%.2f%%\t\t%llu\t\t\t%.2f%%\n", task_array2[j].pcTaskName, task_delta, delta_percentage, lifetime_runtime, lifetime_percentage);
+            printf("%-20s\t%" PRIu64 "\t\t\t%.2f%%\t\t%" PRIu64 "\t\t\t%.2f%%\n", task_array2[j].pcTaskName, task_delta, delta_percentage, lifetime_runtime, lifetime_percentage);
         }
         printf("\n");
 

--- a/main/tasks/create_jobs_task.c
+++ b/main/tasks/create_jobs_task.c
@@ -288,7 +288,7 @@ static void generate_work_sv2(GlobalState *GLOBAL_STATE, sv2_job_t *sv2_job, dou
 
     // SV2 job metadata
     char jobid_str[16];
-    snprintf(jobid_str, sizeof(jobid_str), "%lu", sv2_job->job_id);
+    snprintf(jobid_str, sizeof(jobid_str), "%" PRIu32, sv2_job->job_id);
     next_job->jobid = strdup(jobid_str);
     next_job->extranonce2 = strdup(""); // unused in SV2 standard
     next_job->version_mask = version_mask;
@@ -390,7 +390,7 @@ static void generate_work_sv2_ext(GlobalState *GLOBAL_STATE, sv2_ext_job_t *ext_
 
     // Job metadata
     char jobid_str[16];
-    snprintf(jobid_str, sizeof(jobid_str), "%lu", ext_job->job_id);
+    snprintf(jobid_str, sizeof(jobid_str), "%" PRIu32, ext_job->job_id);
     next_job->jobid = strdup(jobid_str);
 
     // Store extranonce_2 as hex for share submission

--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -189,7 +189,7 @@ static esp_err_t resolve_stratum_address(const char *hostname, uint16_t port, st
         struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&conn_info->dest_addr;
         if (IN6_IS_ADDR_LINKLOCAL(&addr6->sin6_addr) && addr6->sin6_scope_id != 0) {
             char zone[16];
-            snprintf(zone, sizeof(zone), "%%%lu", (unsigned long)addr6->sin6_scope_id);
+            snprintf(zone, sizeof(zone), "%%%" PRIu32, addr6->sin6_scope_id);
             strncat(conn_info->host_ip, zone,
                     sizeof(conn_info->host_ip) - strlen(conn_info->host_ip) - 1);
             // Ensure null termination


### PR DESCRIPTION
Without these the vscode static analyser trips up on wrong formats:

`Format specifies type 'unsigned long' but the argument has type 'uint32_t' (aka 'unsigned int') (fix available)clang(-Wformat)`

By using the `PRIuN` specifier, it's correct for each platform, no matter how the static analyser is configured.

This should ideally also be done with ESP_LOG, but the static analyser is happy (for now). This might change in the future if the analyser is improved.