### PR TITLE
Clarify partial mining reward dashboard message

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -1010,7 +1010,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     updateMessage(info.version !== info.axeOSVersion, 'VERSION_MISMATCH', 'warn', `Firmware (${info.version}) and AxeOS (${info.axeOSVersion}) versions do not match. Please make sure to update both www.bin and esp-miner.bin.`);
     if (info.coinbaseOutputs && info.coinbaseOutputs.length > 0) {
       let percentage = this.getPayoutPercentage(info);
-      updateMessage(percentage > 0 && percentage < 95, 'NOT_SOLO_MINING', 'warn', `Your share of the mining reward is only ${percentage.toFixed(1)}%`);
+      updateMessage(percentage > 0 && percentage < 95, 'NOT_SOLO_MINING', 'info', `Mining reward is split; your decoded share is ${percentage.toFixed(1)}%`);
       updateMessage(percentage === 0, 'NO_MINING_REWARD', 'warn', `You don't have a share in the mining reward`);
     }
   }


### PR DESCRIPTION
## Summary

Fixes the most visible part of #1703 by changing the dashboard message for decoded partial mining rewards from an alarming warning to a neutral informational message.

Before:

- Severity: warn
- Text: `Your share of the mining reward is only X%`

After:

- Severity: info
- Text: `Mining reward is split; your decoded share is X%`

The existing zero-share warning is unchanged:

- `You don't have a share in the mining reward`

## Why

For Sv2 Extended Channel setups such as the SRI pool donation mode described in #1703, a partial decoded payout can be intentional and valid. The previous wording made expected reward splitting sound suspicious even when AxeOS successfully decoded that the user has a non-zero share.

This keeps the useful visibility while avoiding an accusatory warning for legitimate split-reward configurations.

## Scope

This is intentionally small and UI-only:

- No firmware/backend changes.
- No new settings.
- No pool-specific allowlist.
- No change to the zero-share warning.

There is also a broader existing PR (#1678) that adds a toggle and larger coinbase-output handling. This PR is meant as a minimal alternative/foundation that can be reviewed independently.

## Testing

- Ran `npm ci` in `main/http_server/axe-os`.
- Ran `npm run build` successfully.

Build completed with the existing Angular initial bundle budget warning, but exited successfully.