### PR TITLE
Warn when ASIC hash domains stop incrementing

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -583,9 +583,11 @@
                                     <td *ngIf="asicAmount > 1" class="text-500 text-left">
                                         {{ i + 1 }}
                                     </td>
-                                <td *ngFor="let domain of asic?.domains; trackBy: trackByIndex"
-                                    [style.backgroundColor]="getHeatmapColor(info, domain)"
+                                <td *ngFor="let domain of asic?.domains; let domainIndex = index; trackBy: trackByIndex"
+                                    [style.backgroundColor]="isHashDomainStalled(asic, domainIndex) ? 'var(--red-700)' : getHeatmapColor(info, domain)"
                                         [style.height]="(asicAmount <= 2 ? '2rem' : null)"
+                                        [pTooltip]="isHashDomainStalled(asic, domainIndex) ? 'Hash domain counter stopped incrementing' : undefined"
+                                        tooltipPosition="bottom"
                                         class="text-center">
                                         <span class="text-xs">{{ domain | hashSuffix }}</span>
                                     </td>

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -36,6 +36,7 @@ type MessageType =
   | 'VERSION_MISMATCH'
   | 'NOT_SOLO_MINING'
   | 'NO_MINING_REWARD'
+  | 'HASH_DOMAIN_STALLED'
   | 'HARDWARE_FAULT';
 
 interface ISystemMessage {
@@ -1005,6 +1006,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     updateMessage(!!info.overheat_mode, 'DEVICE_OVERHEAT', 'error', 'Device has overheated - See settings');
     updateMessage(!!info.power_fault, 'POWER_FAULT', 'error', `${info.power_fault} Check your Power Supply.`);
     updateMessage(!!info.hardware_fault, 'HARDWARE_FAULT', 'error', `${info.hardware_fault}`);
+    updateMessage(this.hasStalledHashDomains(info), 'HASH_DOMAIN_STALLED', 'warn', 'One or more ASIC hash domains stopped incrementing. Check power supply, voltage and frequency settings.');
     updateMessage(!info.frequency || info.frequency < 400, 'FREQUENCY_LOW', 'warn', 'Device frequency is set low - See settings');
     updateMessage(!!info.isUsingFallbackStratum, 'FALLBACK_STRATUM', 'warn', 'Using fallback pool - Share stats reset. Check Pool Settings and / or reboot Device.');
     updateMessage(info.version !== info.axeOSVersion, 'VERSION_MISMATCH', 'warn', `Firmware (${info.version}) and AxeOS (${info.axeOSVersion}) versions do not match. Please make sure to update both www.bin and esp-miner.bin.`);
@@ -1070,6 +1072,14 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   public getAsicDomainsAmount(info: ISystemInfo): number {
     return info.hashrateMonitor?.asics?.[0]?.domains?.length ?? 0;
+  }
+
+  public hasStalledHashDomains(info: ISystemInfo): boolean {
+    return info.hashrateMonitor?.asics?.some(asic => asic.stalledDomains?.some(Boolean)) ?? false;
+  }
+
+  public isHashDomainStalled(asic: { stalledDomains?: boolean[] }, domainIndex: number): boolean {
+    return asic.stalledDomains?.[domainIndex] ?? false;
   }
 
   public getHeatmapColor(info: ISystemInfo, domainHashrate: number): string {

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -151,6 +151,7 @@ export class SystemApiService {
           asics: [{
             total: 441.2579,
             domains: [114.9901, 98.6658, 103.8136, 122.7133],
+            stalledDomains: [false, false, false, false],
             errorCount: 4,
           }],
           hashrate: 441.2579,

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -95,6 +95,7 @@ components:
       required:
         - total
         - domains
+        - stalledDomains
         - errorCount
       properties:
         total:
@@ -105,6 +106,11 @@ components:
           description: Hashrate per domain
           items:
             type: number
+        stalledDomains:
+          type: array
+          description: Whether each hash domain counter has stopped changing
+          items:
+            type: boolean
         errorCount:
           description: Number of errors
           type: number

--- a/main/http_server/system_api_json.c
+++ b/main/http_server/system_api_json.c
@@ -250,8 +250,11 @@ static void system_api_add_hashrate_monitor(cJSON *root, GlobalState *g) {
         
         cJSON *domains = cJSON_CreateArray();
         cJSON_AddItemToObject(asic, "domains", domains);
+        cJSON *stalled_domains = cJSON_CreateArray();
+        cJSON_AddItemToObject(asic, "stalledDomains", stalled_domains);
         for (int j = 0; j < hash_domains; j++) {
             cJSON_AddItemToArray(domains, cJSON_CreateNumber(g->HASHRATE_MONITOR_MODULE.domain_measurements[i][j].hashrate));
+            cJSON_AddItemToArray(stalled_domains, cJSON_CreateBool(g->HASHRATE_MONITOR_MODULE.domain_stalled[i][j]));
         }
     }
 }

--- a/main/tasks/hashrate_monitor_task.c
+++ b/main/tasks/hashrate_monitor_task.c
@@ -19,6 +19,7 @@
 #define HASHRATE_1H_SIZE 6
 #define DIV_10M (HASHRATE_1M_SIZE)
 #define DIV_1H (HASHRATE_10M_SIZE * DIV_10M)
+#define DOMAIN_STALL_POLLS 30
 
 static unsigned long poll_count = 0;
 static float hashrate_1m[HASHRATE_1M_SIZE];
@@ -55,6 +56,8 @@ void hashrate_monitor_reset_measurements(void *pvParameters)
     pthread_mutex_lock(&HASHRATE_MONITOR_MODULE->lock);
     memset(HASHRATE_MONITOR_MODULE->total_measurement, 0, asic_count * sizeof(measurement_t));
     memset(HASHRATE_MONITOR_MODULE->domain_measurements[0], 0, asic_count * hash_domains * sizeof(measurement_t));
+    memset(HASHRATE_MONITOR_MODULE->domain_stall_counts[0], 0, asic_count * hash_domains * sizeof(uint8_t));
+    memset(HASHRATE_MONITOR_MODULE->domain_stalled[0], 0, asic_count * hash_domains * sizeof(bool));
     memset(HASHRATE_MONITOR_MODULE->error_measurement, 0, asic_count * sizeof(measurement_t));
     pthread_mutex_unlock(&HASHRATE_MONITOR_MODULE->lock);
 }
@@ -85,6 +88,33 @@ void update_hash_counter(measurement_t * measurement, uint32_t value, uint64_t t
 
     measurement->value = value;
     measurement->time_us = time_us;
+}
+
+static void update_domain_hash_counter(HashrateMonitorModule *module, uint8_t asic_nr, uint8_t domain_nr, uint32_t value, uint64_t time_us)
+{
+    measurement_t *measurement = &module->domain_measurements[asic_nr][domain_nr];
+    uint32_t previous_value = measurement->value;
+    uint64_t previous_time_us = measurement->time_us;
+
+    update_hash_counter(measurement, value, time_us);
+
+    if (previous_time_us == 0 || measurement->time_us == previous_time_us) {
+        return;
+    }
+
+    if (value == previous_value) {
+        if (module->domain_stall_counts[asic_nr][domain_nr] < DOMAIN_STALL_POLLS) {
+            module->domain_stall_counts[asic_nr][domain_nr]++;
+        }
+    } else {
+        module->domain_stall_counts[asic_nr][domain_nr] = 0;
+        module->domain_stalled[asic_nr][domain_nr] = false;
+    }
+
+    if (module->domain_stall_counts[asic_nr][domain_nr] >= DOMAIN_STALL_POLLS && !module->domain_stalled[asic_nr][domain_nr]) {
+        ESP_LOGW(TAG, "ASIC %d domain %d hash counter stalled", asic_nr, domain_nr);
+        module->domain_stalled[asic_nr][domain_nr] = true;
+    }
 }
 
 static void init_averages()
@@ -153,8 +183,14 @@ void hashrate_monitor_task(void *pvParameters)
     HASHRATE_MONITOR_MODULE->total_measurement = heap_caps_malloc(asic_count * sizeof(measurement_t), MALLOC_CAP_SPIRAM);
     measurement_t* data = heap_caps_malloc(asic_count * hash_domains * sizeof(measurement_t), MALLOC_CAP_SPIRAM);
     HASHRATE_MONITOR_MODULE->domain_measurements = heap_caps_malloc(asic_count * sizeof(measurement_t*), MALLOC_CAP_SPIRAM);
+    uint8_t* stall_count_data = heap_caps_malloc(asic_count * hash_domains * sizeof(uint8_t), MALLOC_CAP_SPIRAM);
+    HASHRATE_MONITOR_MODULE->domain_stall_counts = heap_caps_malloc(asic_count * sizeof(uint8_t*), MALLOC_CAP_SPIRAM);
+    bool* stalled_data = heap_caps_malloc(asic_count * hash_domains * sizeof(bool), MALLOC_CAP_SPIRAM);
+    HASHRATE_MONITOR_MODULE->domain_stalled = heap_caps_malloc(asic_count * sizeof(bool*), MALLOC_CAP_SPIRAM);
     for (size_t asic_nr = 0; asic_nr < asic_count; asic_nr++) {
         HASHRATE_MONITOR_MODULE->domain_measurements[asic_nr] = data + (asic_nr * hash_domains);
+        HASHRATE_MONITOR_MODULE->domain_stall_counts[asic_nr] = stall_count_data + (asic_nr * hash_domains);
+        HASHRATE_MONITOR_MODULE->domain_stalled[asic_nr] = stalled_data + (asic_nr * hash_domains);
     }
     HASHRATE_MONITOR_MODULE->error_measurement = heap_caps_malloc(asic_count * sizeof(measurement_t), MALLOC_CAP_SPIRAM);
 
@@ -223,16 +259,16 @@ void hashrate_monitor_register_read(void *pvParameters, register_type_t register
             update_hash_counter(&HASHRATE_MONITOR_MODULE->total_measurement[asic_nr], value, timestamp_us);
             break;
         case REGISTER_DOMAIN_0_COUNT:
-            update_hash_counter(&HASHRATE_MONITOR_MODULE->domain_measurements[asic_nr][0], value, timestamp_us);
+            update_domain_hash_counter(HASHRATE_MONITOR_MODULE, asic_nr, 0, value, timestamp_us);
             break;
         case REGISTER_DOMAIN_1_COUNT:
-            update_hash_counter(&HASHRATE_MONITOR_MODULE->domain_measurements[asic_nr][1], value, timestamp_us);
+            update_domain_hash_counter(HASHRATE_MONITOR_MODULE, asic_nr, 1, value, timestamp_us);
             break;
         case REGISTER_DOMAIN_2_COUNT:
-            update_hash_counter(&HASHRATE_MONITOR_MODULE->domain_measurements[asic_nr][2], value, timestamp_us);
+            update_domain_hash_counter(HASHRATE_MONITOR_MODULE, asic_nr, 2, value, timestamp_us);
             break;
         case REGISTER_DOMAIN_3_COUNT:
-            update_hash_counter(&HASHRATE_MONITOR_MODULE->domain_measurements[asic_nr][3], value, timestamp_us);
+            update_domain_hash_counter(HASHRATE_MONITOR_MODULE, asic_nr, 3, value, timestamp_us);
             break;
         case REGISTER_ERROR_COUNT:
             update_hash_counter(&HASHRATE_MONITOR_MODULE->error_measurement[asic_nr], value, timestamp_us);

--- a/main/tasks/hashrate_monitor_task.h
+++ b/main/tasks/hashrate_monitor_task.h
@@ -3,6 +3,7 @@
 
 #include "asic_common.h"
 #include <pthread.h>
+#include <stdbool.h>
 
 typedef struct {
     uint32_t value;
@@ -13,6 +14,8 @@ typedef struct {
 typedef struct {
     measurement_t* total_measurement;
     measurement_t** domain_measurements;
+    uint8_t** domain_stall_counts;
+    bool** domain_stalled;
     measurement_t* error_measurement;
 
     pthread_mutex_t lock;


### PR DESCRIPTION
## Summary
- detect stalled ASIC hash domains from the existing per-domain hash counter registers
- expose stalled domain flags through the system info API and OpenAPI schema
- show an AxeOS warning and highlight stalled domains in the hashrate register card

## Why
Issue #1053 reports devices that continue receiving pool work while one or more ASIC domains stop producing useful work. A previous recovery-only approach was rejected because it hid likely power/voltage/frequency problems behind automatic restarts. This PR adds direct observability first: the firmware reports the stalled domain so users can diagnose power supply, voltage, and frequency settings instead of only seeing a flatline.

Fixes #1053.

## Testing
- npm run build
- git diff --check

Full firmware build was not run locally because idf.py is not installed in this shell and the Docker daemon is not running.