### PR TITLE
Report found blocks only after accepted shares

### DIFF
--- a/main/global_state.h
+++ b/main/global_state.h
@@ -61,6 +61,7 @@ typedef struct
     uint64_t best_session_nonce_diff;
     char best_session_diff_string[DIFF_STRING_SIZE];
     int block_found;
+    uint8_t pending_block_candidates;
     bool show_new_block;
     char * ssid;
     char wifi_status[256];

--- a/main/system.c
+++ b/main/system.c
@@ -257,6 +257,13 @@ void SYSTEM_notify_accepted_share(GlobalState * GLOBAL_STATE)
     SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
 
     module->shares_accepted++;
+
+    if (module->pending_block_candidates > 0) {
+        module->pending_block_candidates--;
+        module->block_found++;
+        module->show_new_block = true;
+        ESP_LOGI(TAG, "FOUND BLOCK accepted by pool (count: %d)", module->block_found);
+    }
 }
 
 static int compare_rejected_reason_stats(const void *a, const void *b) {
@@ -270,6 +277,10 @@ void SYSTEM_notify_rejected_share(GlobalState * GLOBAL_STATE, char * error_msg)
     SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
 
     module->shares_rejected++;
+    if (module->pending_block_candidates > 0) {
+        module->pending_block_candidates--;
+        ESP_LOGW(TAG, "Block candidate rejected by pool: %s", error_msg);
+    }
 
     for (int i = 0; i < module->rejected_reason_stats_count; i++) {
         if (strncmp(module->rejected_reason_stats[i].message, error_msg, sizeof(module->rejected_reason_stats[i].message) - 1) == 0) {
@@ -309,20 +320,13 @@ void SYSTEM_notify_new_ntime(GlobalState * GLOBAL_STATE, uint32_t ntime)
     settimeofday(&tv, NULL);
 }
 
-void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint8_t job_id)
+void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff)
 {
     SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
 
     if ((uint64_t) diff > module->best_session_nonce_diff) {
         module->best_session_nonce_diff = (uint64_t) diff;
         suffixString((uint64_t) diff, module->best_session_diff_string, DIFF_STRING_SIZE, 0);
-    }
-
-    double network_diff = networkDifficulty(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->target);
-    if (diff >= network_diff) {
-        module->block_found++;
-        module->show_new_block = true;
-        ESP_LOGI(TAG, "FOUND BLOCK!!!!!!!!!!!!!!!!!!!!!! %f >= %f (count: %d)", diff, network_diff, module->block_found);
     }
 
     if ((uint64_t) diff <= module->best_nonce_diff) {
@@ -336,6 +340,16 @@ void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint8_t 
     suffixString((uint64_t) diff, module->best_diff_string, DIFF_STRING_SIZE, 0);
 
     ESP_LOGI(TAG, "New best difficulty: %s", module->best_diff_string);
+}
+
+void SYSTEM_notify_submitted_block_candidate(GlobalState * GLOBAL_STATE, double diff)
+{
+    SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
+
+    if (module->pending_block_candidates < UINT8_MAX) {
+        module->pending_block_candidates++;
+    }
+    ESP_LOGI(TAG, "Submitted block candidate, waiting for pool acceptance: %f", diff);
 }
 
 static esp_err_t ensure_overheat_mode_config() {

--- a/main/system.h
+++ b/main/system.h
@@ -10,7 +10,8 @@ esp_err_t SYSTEM_init_peripherals(GlobalState * GLOBAL_STATE);
 
 void SYSTEM_notify_accepted_share(GlobalState * GLOBAL_STATE);
 void SYSTEM_notify_rejected_share(GlobalState * GLOBAL_STATE, char * error_msg);
-void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint8_t job_id);
+void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff);
+void SYSTEM_notify_submitted_block_candidate(GlobalState * GLOBAL_STATE, double diff);
 void SYSTEM_notify_new_ntime(GlobalState * GLOBAL_STATE, uint32_t ntime);
 
 #endif /* SYSTEM_H_ */

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -58,6 +58,7 @@ void ASIC_result_task(void *pvParameters)
         if (GLOBAL_STATE->SELF_TEST_MODULE.is_active) continue;
 
         uint32_t version_bits = asic_result->rolled_version ^ active_job->version;
+        bool block_candidate = nonce_diff >= networkDifficulty(active_job->target);
         if (nonce_diff >= active_job->pool_diff)
         {
             if (GLOBAL_STATE->stratum_protocol == STRATUM_V2) {
@@ -87,6 +88,8 @@ void ASIC_result_task(void *pvParameters)
                 if (ret < 0) {
                     ESP_LOGW(TAG, "Failed to submit SV2 share (ret=%d, errno=%d: %s)",
                              ret, errno, strerror(errno));
+                } else if (block_candidate) {
+                    SYSTEM_notify_submitted_block_candidate(GLOBAL_STATE, nonce_diff);
                 }
             } else {
                 // V1: submit with JSON-RPC
@@ -115,6 +118,8 @@ void ASIC_result_task(void *pvParameters)
                     if (ret < 0) {
                         ESP_LOGW(TAG, "Unable to write share to socket (ret: %d, errno %d: %s)", ret, errno, strerror(errno));
                         // stratum_task recv loop will detect a broken connection on its next read and handle reconnection
+                    } else if (block_candidate) {
+                        SYSTEM_notify_submitted_block_candidate(GLOBAL_STATE, nonce_diff);
                     }
 
                     float process_time = (sent_time_us - asic_result->timestamp_us) / 1000.0f;
@@ -127,7 +132,7 @@ void ASIC_result_task(void *pvParameters)
         //log the ASIC response
         ESP_LOGI(TAG, "ID: %s, ASIC nr: %d, Core: %d/%d, ver: %08" PRIX32 " Nonce %08" PRIX32 " diff %.1f of %g.", active_job->jobid, asic_result->asic_nr, asic_result->core_id, asic_result->small_core_id, asic_result->rolled_version, asic_result->nonce, nonce_diff, active_job->pool_diff);
 
-        SYSTEM_notify_found_nonce(GLOBAL_STATE, nonce_diff, job_id);
+        SYSTEM_notify_found_nonce(GLOBAL_STATE, nonce_diff);
 
         scoreboard_add(&GLOBAL_STATE->SYSTEM_MODULE.scoreboard, nonce_diff, active_job->jobid, active_job->extranonce2, active_job->ntime, asic_result->nonce, version_bits);
     }


### PR DESCRIPTION
## Summary
- keep updating best/session difficulty as soon as a nonce is found
- mark block candidates as pending only after the share is successfully submitted
- increment blockFound and show the block banner only when the pool accepts a pending block candidate
- clear pending block candidates when the pool rejects the matching pending share path

## Why
A nonce can meet network difficulty but still fail to become a valid pool-accepted block candidate if it is never submitted or is rejected. The dashboard should not report a found block until the pool has accepted the submitted share.

Fixes #1552.

## Testing
- git diff --check

Full firmware build was not run locally because idf.py is not installed in this shell and the Docker daemon is not running.