### PR TITLE
Show Stratum auth failures in pool status

### DIFF
--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -604,6 +604,11 @@ void stratum_v1_task(void *pvParameters)
                     }
                 } else {
                     ESP_LOGE(TAG, "setup message rejected: %s", stratum_api_v1_message.error_str);
+                    if (stratum_api_v1_message.message_id == authorize_message_id) {
+                        snprintf(GLOBAL_STATE->SYSTEM_MODULE.pool_connection_info,
+                                 sizeof(GLOBAL_STATE->SYSTEM_MODULE.pool_connection_info),
+                                 "Pool auth failed: %.45s", stratum_api_v1_message.error_str);
+                    }
                 }
             }
             STRATUM_V1_reset_message(&stratum_api_v1_message);


### PR DESCRIPTION
## Summary
- surface failed `mining.authorize` setup responses in the existing pool connection status field
- keep the message short enough for the current `pool_connection_info` buffer

## Why
When a pool rejects `mining.authorize`, for example because the configured wallet address is invalid, AxeOS currently does not show the pool error to the user. The firmware logs the rejection, but the dashboard can still leave users guessing why mining never starts.

Fixes #1358.

## Testing
- git diff --check

Full firmware build was not run locally because idf.py is not installed in this shell and the Docker daemon is not running.