### PR TITLE
Clamp Stratum version rolling mask to ASIC capability

### DIFF
--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -10,6 +10,7 @@
 #include "asic.h"
 #include "device_config.h"
 #include "frequency_transition_bmXX.h"
+#include "utils.h"
 
 static const char *TAG = "asic";
 
@@ -101,6 +102,21 @@ void ASIC_set_version_mask(GlobalState * GLOBAL_STATE, uint32_t mask)
         default:
             ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set version mask", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
             break;
+    }
+}
+
+uint32_t ASIC_get_supported_version_mask(GlobalState * GLOBAL_STATE)
+{
+    switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
+        case BM1366:
+        case BM1368:
+        case BM1370:
+            return STRATUM_DEFAULT_VERSION_MASK;
+        case BM1397:
+            return 0;
+        default:
+            ESP_LOGE(TAG, "Unknown ASIC id %d — cannot get supported version mask", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
+            return 0;
     }
 }
 

--- a/components/asic/include/asic.h
+++ b/components/asic/include/asic.h
@@ -10,6 +10,7 @@ task_result * ASIC_process_work(GlobalState * GLOBAL_STATE);
 int ASIC_set_max_baud(GlobalState * GLOBAL_STATE);
 void ASIC_send_work(GlobalState * GLOBAL_STATE, void * next_job);
 void ASIC_set_version_mask(GlobalState * GLOBAL_STATE, uint32_t mask);
+uint32_t ASIC_get_supported_version_mask(GlobalState * GLOBAL_STATE);
 void ASIC_set_frequency(GlobalState * GLOBAL_STATE);
 void ASIC_set_nonce_space(GlobalState * GLOBAL_STATE);
 double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE);

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 #define TRANSPORT_TIMEOUT_MS 5000
 #define BUFFER_SIZE 1024
@@ -586,9 +587,12 @@ int STRATUM_V1_submit_share(esp_transport_handle_t transport, int send_uid, cons
 int STRATUM_V1_configure_version_rolling(esp_transport_handle_t transport, int send_uid, uint32_t * version_mask)
 {
     char configure_msg[BUFFER_SIZE];
+    uint32_t requested_mask = version_mask != NULL ? *version_mask : STRATUM_DEFAULT_VERSION_MASK;
+    requested_mask &= STRATUM_DEFAULT_VERSION_MASK;
+
     snprintf(configure_msg, sizeof(configure_msg),
-        "{\"id\":%d,\"method\":\"mining.configure\",\"params\":[[\"version-rolling\"],{\"version-rolling.mask\":\"ffffffff\"}]}\n",
-        send_uid);
+        "{\"id\":%d,\"method\":\"mining.configure\",\"params\":[[\"version-rolling\"],{\"version-rolling.mask\":\"%08" PRIx32 "\"}]}\n",
+        send_uid, requested_mask);
     debug_stratum_tx(configure_msg);
 
     return esp_transport_write(transport, configure_msg, strlen(configure_msg), TRANSPORT_TIMEOUT_MS);

--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -12,6 +12,7 @@
 #include "esp_timer.h"
 #include "esp_transport.h"
 #include "esp_transport_tcp.h"
+#include "asic.h"
 #include <sys/time.h>
 #include <stdbool.h>
 #include <string.h>
@@ -485,7 +486,8 @@ void stratum_v1_task(void *pvParameters)
 
         ///// Start Stratum Action
         // mining.configure - ID: 1
-        STRATUM_V1_configure_version_rolling(GLOBAL_STATE->transport, stratum_get_next_uid(GLOBAL_STATE), &GLOBAL_STATE->version_mask);
+        uint32_t supported_version_mask = ASIC_get_supported_version_mask(GLOBAL_STATE);
+        STRATUM_V1_configure_version_rolling(GLOBAL_STATE->transport, stratum_get_next_uid(GLOBAL_STATE), &supported_version_mask);
 
         // mining.subscribe - ID: 2
         STRATUM_V1_subscribe(GLOBAL_STATE->transport, stratum_get_next_uid(GLOBAL_STATE), GLOBAL_STATE->DEVICE_CONFIG.family.asic.name);
@@ -548,8 +550,10 @@ void stratum_v1_task(void *pvParameters)
                 GLOBAL_STATE->new_set_mining_difficulty_msg = true;
             } else if (stratum_api_v1_message.method == MINING_SET_VERSION_MASK ||
                     stratum_api_v1_message.method == STRATUM_RESULT_VERSION_MASK) {
-                ESP_LOGI(TAG, "Set version mask: %08lx", stratum_api_v1_message.version_mask);
-                GLOBAL_STATE->version_mask = stratum_api_v1_message.version_mask;
+                uint32_t supported_version_mask = stratum_api_v1_message.version_mask & ASIC_get_supported_version_mask(GLOBAL_STATE);
+                ESP_LOGI(TAG, "Set version mask: %08lx (pool: %08lx)",
+                         supported_version_mask, stratum_api_v1_message.version_mask);
+                GLOBAL_STATE->version_mask = supported_version_mask;
                 GLOBAL_STATE->new_stratum_version_rolling_msg = true;
             } else if (stratum_api_v1_message.method == MINING_SET_EXTRANONCE ||
                     stratum_api_v1_message.method == STRATUM_RESULT_SUBSCRIBE) {


### PR DESCRIPTION
## Summary
- advertise the ASIC-supported version rolling mask instead of the hardcoded `ffffffff` Stratum V1 mask
- add an ASIC helper for the supported version rolling mask
- clamp pool-provided `mining.set_version_mask` / `mining.configure` results before storing them globally

Fixes #1169

## Testing
- `git diff --check`

Firmware build was not run because `idf.py` is not installed in this environment.