### PR TITLE
Reset ASIC error count after frequency changes

### DIFF
--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -109,18 +109,45 @@ void ASIC_set_frequency(GlobalState * GLOBAL_STATE)
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
         case BM1397:
             do_frequency_transition(GLOBAL_STATE, BM1397_send_hash_frequency);
-            return;
+            break;
         case BM1366:
             do_frequency_transition(GLOBAL_STATE, BM1366_send_hash_frequency);
-            return;
+            break;
         case BM1368:
             do_frequency_transition(GLOBAL_STATE, BM1368_send_hash_frequency);
-            return;
+            break;
         case BM1370:
             do_frequency_transition(GLOBAL_STATE, BM1370_send_hash_frequency);
+            break;
+        default:
+            ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set frequency", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
             return;
     }
-    ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set frequency", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
+
+    ASIC_reset_error_count(GLOBAL_STATE);
+}
+
+void ASIC_reset_error_count(GlobalState * GLOBAL_STATE)
+{
+    switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
+        case BM1397:
+            BM1397_reset_error_count();
+            break;
+        case BM1366:
+            BM1366_reset_error_count();
+            break;
+        case BM1368:
+            BM1368_reset_error_count();
+            break;
+        case BM1370:
+            BM1370_reset_error_count();
+            break;
+        default:
+            ESP_LOGE(TAG, "Unknown ASIC id %d — cannot reset error count", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
+            return;
+    }
+
+    hashrate_monitor_reset_error_measurements(GLOBAL_STATE);
 }
 
 void ASIC_set_nonce_space(GlobalState * GLOBAL_STATE)

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -147,6 +147,12 @@ void BM1366_set_version_mask(uint32_t version_mask)
     _send_BM1366(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1366_SERIALTX_DEBUG);
 }
 
+void BM1366_reset_error_count(void)
+{
+    uint8_t reset_error_count[] = {0x00, 0x4C, 0x00, 0x00, 0x00, 0x00};
+    _send_BM1366(TYPE_CMD | GROUP_ALL | CMD_WRITE, reset_error_count, 6, BM1366_SERIALTX_DEBUG);
+}
+
 void BM1366_set_hash_counting_number(uint32_t hcn) {
     uint8_t set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x00, 0x00};
     set_10_hash_counting[2] = (hcn >> 24) & 0xFF;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -124,6 +124,12 @@ void BM1368_set_version_mask(uint32_t version_mask)
     _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1368_SERIALTX_DEBUG);
 }
 
+void BM1368_reset_error_count(void)
+{
+    uint8_t reset_error_count[] = {0x00, 0x4C, 0x00, 0x00, 0x00, 0x00};
+    _send_BM1368(TYPE_CMD | GROUP_ALL | CMD_WRITE, reset_error_count, 6, BM1368_SERIALTX_DEBUG);
+}
+
 void BM1368_set_hash_counting_number(uint32_t hcn) {
     uint8_t set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x00, 0x00};
     set_10_hash_counting[2] = (hcn >> 24) & 0xFF;

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -139,6 +139,12 @@ void BM1370_set_version_mask(uint32_t version_mask)
     _send_BM1370(TYPE_CMD | GROUP_ALL | CMD_WRITE, version_cmd, 6, BM1370_SERIALTX_DEBUG);
 }
 
+void BM1370_reset_error_count(void)
+{
+    uint8_t reset_error_count[] = {0x00, 0x4C, 0x00, 0x00, 0x00, 0x00};
+    _send_BM1370(TYPE_CMD | GROUP_ALL | CMD_WRITE, reset_error_count, 6, BM1370_SERIALTX_DEBUG);
+}
+
 void BM1370_set_hash_counting_number(uint32_t hcn) {
     uint8_t set_10_hash_counting[6] = {0x00, 0x10, 0x00, 0x00, 0x00, 0x00};
     set_10_hash_counting[2] = (hcn >> 24) & 0xFF;

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -148,6 +148,12 @@ void BM1397_set_version_mask(uint32_t version_mask)
     // placeholder
 }
 
+void BM1397_reset_error_count(void)
+{
+    uint8_t reset_error_count[] = {0x00, 0x4C, 0x00, 0x00, 0x00, 0x00};
+    _send_BM1397((TYPE_CMD | GROUP_ALL | CMD_WRITE), reset_error_count, 6, BM1397_SERIALTX_DEBUG);
+}
+
 float BM1397_send_hash_frequency(float target_freq)
 {
     uint8_t fb_divider, refdiv, postdiv1, postdiv2;

--- a/components/asic/include/asic.h
+++ b/components/asic/include/asic.h
@@ -11,6 +11,7 @@ int ASIC_set_max_baud(GlobalState * GLOBAL_STATE);
 void ASIC_send_work(GlobalState * GLOBAL_STATE, void * next_job);
 void ASIC_set_version_mask(GlobalState * GLOBAL_STATE, uint32_t mask);
 void ASIC_set_frequency(GlobalState * GLOBAL_STATE);
+void ASIC_reset_error_count(GlobalState * GLOBAL_STATE);
 void ASIC_set_nonce_space(GlobalState * GLOBAL_STATE);
 double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE);
 void ASIC_read_registers(GlobalState * GLOBAL_STATE);

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -24,6 +24,7 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1366_init(void * GLOBAL_STATE);
 void BM1366_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1366_set_version_mask(uint32_t version_mask);
+void BM1366_reset_error_count(void);
 int BM1366_set_max_baud(void);
 int BM1366_set_default_baud(void);
 float BM1366_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -24,6 +24,7 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1368_init(void * GLOBAL_STATE);
 void BM1368_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1368_set_version_mask(uint32_t version_mask);
+void BM1368_reset_error_count(void);
 int BM1368_set_max_baud(void);
 int BM1368_set_default_baud(void);
 float BM1368_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -24,6 +24,7 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1370_init(void * GLOBAL_STATE);
 void BM1370_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1370_set_version_mask(uint32_t version_mask);
+void BM1370_reset_error_count(void);
 int BM1370_set_max_baud(void);
 int BM1370_set_default_baud(void);
 float BM1370_send_hash_frequency(float frequency);

--- a/components/asic/include/bm1397.h
+++ b/components/asic/include/bm1397.h
@@ -26,6 +26,7 @@ typedef struct __attribute__((__packed__))
 uint8_t BM1397_init(void * GLOBAL_STATE);
 void BM1397_send_work(void * GLOBAL_STATE, bm_job * next_bm_job);
 void BM1397_set_version_mask(uint32_t version_mask);
+void BM1397_reset_error_count(void);
 int BM1397_set_max_baud(void);
 int BM1397_set_default_baud(void);
 float BM1397_send_hash_frequency(float frequency);

--- a/main/tasks/hashrate_monitor_task.c
+++ b/main/tasks/hashrate_monitor_task.c
@@ -59,6 +59,22 @@ void hashrate_monitor_reset_measurements(void *pvParameters)
     pthread_mutex_unlock(&HASHRATE_MONITOR_MODULE->lock);
 }
 
+void hashrate_monitor_reset_error_measurements(void *pvParameters)
+{
+    GlobalState * GLOBAL_STATE = (GlobalState *)pvParameters;
+    HashrateMonitorModule * HASHRATE_MONITOR_MODULE = &GLOBAL_STATE->HASHRATE_MONITOR_MODULE;
+
+    if (!HASHRATE_MONITOR_MODULE->is_initialized) {
+        return;
+    }
+
+    int asic_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
+
+    pthread_mutex_lock(&HASHRATE_MONITOR_MODULE->lock);
+    memset(HASHRATE_MONITOR_MODULE->error_measurement, 0, asic_count * sizeof(measurement_t));
+    pthread_mutex_unlock(&HASHRATE_MONITOR_MODULE->lock);
+}
+
 void update_hashrate(measurement_t * measurement, uint32_t value)
 {
     uint8_t flag_long = (value & 0x80000000) >> 31;

--- a/main/tasks/hashrate_monitor_task.h
+++ b/main/tasks/hashrate_monitor_task.h
@@ -22,6 +22,7 @@ typedef struct {
 void hashrate_monitor_task(void *pvParameters);
 void hashrate_monitor_register_read(void *pvParameters, register_type_t register_type, uint8_t asic_nr, uint32_t value, uint64_t timestamp_us);
 void hashrate_monitor_reset_measurements(void *pvParameters);
+void hashrate_monitor_reset_error_measurements(void *pvParameters);
 
 void update_hashrate(measurement_t * measurement, uint32_t value);
 void update_hash_counter(measurement_t * measurement, uint32_t value, uint64_t time_us);


### PR DESCRIPTION
## Summary
- reset each supported ASIC error-count register after a frequency transition completes
- clear the in-memory error measurement at the same time to avoid a stale baseline or wraparound spike
- route the reset through the common ASIC facade so UI, BAP, startup ramps, and safety-mode frequency changes get the same behavior

Fixes #1328

## Testing
- `git diff --check`

Firmware build was not run because `idf.py` is not installed in this environment.