### PR TITLE
Chart the maximum ASIC temperature by default

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -783,7 +783,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
         this.maxPower = Math.max(info.maxPower || 0, info.power || 0);
         this.nominalVoltage = info.nominalVoltage || 5;
-        this.maxTemp = Math.max(75, info.temp || 0);
+        this.maxTemp = Math.max(75, info.temp || 0, info.temp2 || 0);
         this.maxRpm = Math.max(7000, info.fanrpm || 0, info.fan2rpm || 0);
         this.maxFrequency = Math.max(800, info.actualFrequency || info.frequency || 0);
         this.statsLimit = info.statsLimit || 720;
@@ -1242,7 +1242,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       case eChartLabel.hashrate_10m:       return info.hashRate_10m;
       case eChartLabel.hashrate_1h:        return info.hashRate_1h;
       case eChartLabel.errorPercentage:    return info.errorPercentage;
-      case eChartLabel.asicTemp:           return info.temp;
+      case eChartLabel.asicTemp:           return Math.max(info.temp || 0, info.temp2 || 0);
       case eChartLabel.asicTemp2:          return info.temp2;
       case eChartLabel.vrTemp:             return info.vrTemp;
       case eChartLabel.asicVoltage:        return info.coreVoltageActual;

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -182,6 +182,7 @@ export class SystemApiService {
     const hashrateData = [0,413.4903744405481,410.7764830376959,440.100549473198,430.5816012914026,452.5464981767163,414.9564271189586,498.7294609150379,411.1671601439723,491.327834852684];
     const powerData = [14.45068359375,14.86083984375,15.03173828125,15.1171875,15.1171875,15.1513671875,15.185546875,15.27099609375,15.30517578125,15.33935546875];
     const asicTempData = [-1,58.5,59.625,60.125,60.75,61.5,61.875,62.125,62.5,63];
+    const asicTemp2Data = [-1,59.1,60.2,60.6,61.2,62.1,62.4,62.9,63.1,64];
     const vrTempData = [45,45,45,44,45,44,44,45,45,45];
     const asicVoltageData = [1221,1223,1219,1223,1217,1222,1221,1219,1221,1221];
     const voltageData = [5196.875,5204.6875,5196.875,5196.875,5196.875,5196.875,5196.875,5196.875,5196.875,5204.6875];
@@ -206,7 +207,8 @@ export class SystemApiService {
           case eChartLabel.hashrate_10m: statisticsList[i][j] = hashrateData[i];     break;
           case eChartLabel.hashrate_1h:  statisticsList[i][j] = hashrateData[i];     break;
           case eChartLabel.power:        statisticsList[i][j] = powerData[i];        break;
-          case eChartLabel.asicTemp:     statisticsList[i][j] = asicTempData[i];     break;
+          case eChartLabel.asicTemp:     statisticsList[i][j] = Math.max(asicTempData[i], asicTemp2Data[i]); break;
+          case eChartLabel.asicTemp2:    statisticsList[i][j] = asicTemp2Data[i];    break;
           case eChartLabel.vrTemp:       statisticsList[i][j] = vrTempData[i];       break;
           case eChartLabel.asicVoltage:  statisticsList[i][j] = asicVoltageData[i];  break;
           case eChartLabel.voltage:      statisticsList[i][j] = voltageData[i];      break;

--- a/main/http_server/axe-os/src/models/enum/eChartLabel.ts
+++ b/main/http_server/axe-os/src/models/enum/eChartLabel.ts
@@ -3,7 +3,7 @@ export enum eChartLabel {
     hashrate_1m = 'Hashrate 1m',
     hashrate_10m = 'Hashrate 10m',
     hashrate_1h = 'Hashrate 1h',
-    asicTemp = 'ASIC Temp',
+    asicTemp = 'Max ASIC Temp',
     asicTemp2 = 'ASIC Temp 2',
     errorPercentage = 'Error %',
     vrTemp = 'VR Temp',

--- a/main/tasks/statistics_task.c
+++ b/main/tasks/statistics_task.c
@@ -175,7 +175,9 @@ void statistics_task(void * pvParameters)
                 statsData.hashrate_10m = sys_module->hashrate_10m;
                 statsData.hashrate_1h = sys_module->hashrate_1h;
                 statsData.errorPercentage = sys_module->error_percentage;
-                statsData.chipTemperature = power_management->chip_temp_avg;
+                statsData.chipTemperature = power_management->chip_temp2_avg > power_management->chip_temp_avg
+                                            ? power_management->chip_temp2_avg
+                                            : power_management->chip_temp_avg;
                 statsData.chipTemperature2 = power_management->chip_temp2_avg;
                 statsData.vrTemperature = power_management->vr_temp;
                 statsData.power = power_management->power;


### PR DESCRIPTION
## Summary
- make the default `asicTemp` chart source use the hottest ASIC temperature when a second sensor is present
- store historical `asicTemp` samples as the max of ASIC temp 1 and 2
- rename the chart label to `Max ASIC Temp` while keeping the existing `asicTemp` key compatible

Fixes #1476

## Testing
- `git diff --check`
- `npm run build`

Note: the frontend build still reports the existing initial bundle budget warning.