### PR TITLE
Avoid restart warning for hostname-only network changes

### DIFF
--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
@@ -71,9 +71,11 @@ export class NetworkEditComponent implements OnInit {
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe({
         next: () => {
-          this.toastr.warning('You must restart this device after saving for changes to take effect.');
+          if (this.isRestartRequired) {
+            this.toastr.warning('You must restart this device after saving for changes to take effect.');
+          }
           this.toastr.success('Saved network settings');
-          this.savedChanges = true;
+          this.savedChanges = this.isRestartRequired;
         },
         error: (err: HttpErrorResponse) => {
           this.toastr.error(`Could not save. ${err.message}`);
@@ -145,5 +147,10 @@ export class NetworkEditComponent implements OnInit {
           this.toastr.error(`Could not restart. ${err.message}`);
         }
       });
+  }
+
+  get isRestartRequired(): boolean {
+    return !!Object.entries(this.form.controls)
+      .filter(([field, control]) => control.dirty && field !== 'hostname').length;
   }
 }


### PR DESCRIPTION
## Summary
- only show the network restart warning when Wi-Fi settings changed
- keep hostname-only saves quiet because the hostname is reflected without a restart
- only enable the Restart button after saves that actually need a restart

Fixes #581

## Testing
- `git diff --check`
- `npm run build`

Note: the frontend build still reports the existing initial bundle budget warning.