### PR TITLE
Fix ckpool quick link host generation

### DIFF
--- a/main/http_server/axe-os/src/app/services/quicklink.service.ts
+++ b/main/http_server/axe-os/src/app/services/quicklink.service.ts
@@ -32,7 +32,7 @@ export class QuicklinkService {
       { search: 'solohash.co.uk', url: `https://solohash.co.uk/user/${user}` },
       { search: 'solo.stratum.braiins.com', url: `https://solo.braiins.com/stats/${user}` },
       { search: 'parasite.wtf', url: `https://parasite.space/user/${user}` },
-      { regex: /^(eu|au)?solo[46]?.ckpool\.org/, url: `https://$1solostats.ckpool.org/users/${user}` },
+      { regex: /^((?:eu|au)?solo[46]?)\.ckpool\.org/, url: `https://$1.ckpool.org/users/${user}` },
       { search: 'atlaspool.io', url: `https://atlaspool.io/dashboard.html?wallet=${user}` },
       { regex: /^(eu\.|tinyminer\.)?m45core\.com$/, url: `https://$1m45core.com/user/${user}` },
     ];


### PR DESCRIPTION
## Summary
- generate ckpool quick links from the matched pool host instead of adding the `solostats` subdomain
- fixes links such as `eusolo.ckpool.org` so they point to `/users/<address>` on the same ckpool host
- keeps support for `solo`, `solo4`, `solo6`, `eusolo`, and `ausolo` variants

Fixes #596

## Testing
- `git diff --check`
- `npm run build`

Note: the frontend build still reports the existing initial bundle budget warning.