### PR TITLE
Add camelCase overheat mode API field

### DIFF
--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -140,6 +140,7 @@ export class SystemApiService {
 
         boardtemp1: 30,
         boardtemp2: 40,
+        overheatMode: 0,
         overheat_mode: 0,
         statsLimit: 720,
 

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -157,6 +157,7 @@ components:
         - maxPower
         - minFanSpeed
         - nominalVoltage
+        - overheatMode
         - overheat_mode
         - overclockEnabled
         - poolConnectionInfo
@@ -354,9 +355,13 @@ components:
         nominalVoltage:
           type: integer
           description: Nominal board voltage
-        overheat_mode:
+        overheatMode:
           type: number
           description: Overheat protection mode
+        overheat_mode:
+          type: number
+          deprecated: true
+          description: Deprecated alias for overheatMode
         overclockEnabled:
           type: integer
           description: Set custom voltage/frequency in AxeOS

--- a/main/http_server/system_api_json.c
+++ b/main/http_server/system_api_json.c
@@ -95,6 +95,7 @@ static void system_api_add_telemetry(cJSON *root, GlobalState *g) {
     cJSON_AddNumberToObject(root, "uptimeSeconds", (uint32_t)((esp_timer_get_time() - g->SYSTEM_MODULE.start_time) / 1000000));
     cJSON_AddFloatToObject(root, "cpuUsage", g->SYSTEM_MODULE.cpu_usage);
     cJSON_AddBoolToObject(root, "miningPaused", g->SYSTEM_MODULE.mining_paused);
+    cJSON_AddNumberToObject(root, "overheatMode", g->SYSTEM_MODULE.overheat_mode ? 1 : 0);
     cJSON_AddNumberToObject(root, "overheat_mode", g->SYSTEM_MODULE.overheat_mode ? 1 : 0);
     cJSON_AddStringToObject(root, "wifiStatus", g->SYSTEM_MODULE.wifi_status);
 


### PR DESCRIPTION
## Summary
- add `overheatMode` to the system info response
- keep `overheat_mode` as a deprecated compatibility alias
- update OpenAPI and the frontend mock data so generated API types continue to build

Fixes #621

## Testing
- `git diff --check`
- `npm run build`

Note: the frontend build still reports the existing initial bundle budget warning.