### PR TITLE
Measure SV2 share response time per-share

### DIFF
--- a/components/stratum_v2/include/sv2_protocol.h
+++ b/components/stratum_v2/include/sv2_protocol.h
@@ -160,7 +160,8 @@ int sv2_parse_set_target(const uint8_t *payload, uint32_t len,
                          uint32_t *channel_id, uint8_t max_target[32]);
 
 int sv2_parse_submit_shares_success(const uint8_t *payload, uint32_t len,
-                                    uint32_t *channel_id, uint32_t *accepted_count);
+                                    uint32_t *channel_id, uint32_t *last_sequence_number,
+                                    uint32_t *accepted_count);
 
 int sv2_parse_submit_shares_error(const uint8_t *payload, uint32_t len,
                                   uint32_t *channel_id, uint32_t *seq_num,

--- a/components/stratum_v2/sv2_protocol.c
+++ b/components/stratum_v2/sv2_protocol.c
@@ -310,11 +310,13 @@ int sv2_parse_set_target(const uint8_t *payload, uint32_t len,
 }
 
 int sv2_parse_submit_shares_success(const uint8_t *payload, uint32_t len,
-                                    uint32_t *channel_id, uint32_t *accepted_count)
+                                    uint32_t *channel_id, uint32_t *last_sequence_number,
+                                    uint32_t *accepted_count)
 {
     // channel_id(4) + last_seq(4) + accepted_count(4) + shares_sum(8) = 20 bytes
     if (len < 20) return -1;
     *channel_id = read_u32_le(payload);
+    *last_sequence_number = read_u32_le(payload + 4);
     *accepted_count = read_u32_le(payload + 8);
     return 0;
 }

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -85,6 +85,7 @@ typedef struct
     bool pool_decode_coinbase_tx;
     bool fallback_pool_decode_coinbase_tx;
     float response_time;
+    uint16_t response_share_batch; // shares acked in the batch that produced response_time (SV2: 1 = single, >1 = batched)
     float process_time;
     float cpu_usage;
     bool use_fallback_stratum;

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -85,7 +85,7 @@ typedef struct
     bool pool_decode_coinbase_tx;
     bool fallback_pool_decode_coinbase_tx;
     float response_time;
-    uint16_t response_share_batch; // shares acked in the batch that produced response_time (SV2: 1 = single, >1 = batched)
+    uint16_t response_share_batch;
     float process_time;
     float cpu_usage;
     bool use_fallback_stratum;

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -440,7 +440,7 @@
                                 />
                             </div>
                             <ng-container *ngIf="info.responseTime > 0; else noValue">
-                                {{ info.responseTime | number:'1.1-1' }} ms
+                                {{ info.responseTime | number:'1.1-1' }} ms<span *ngIf="(info.responseShareBatch ?? 0) > 1" class="text-500" pTooltip="The pool acknowledged {{ info.responseShareBatch }} shares in one batch; the time reflects the most recent share, so it may include the pool's batching window" tooltipPosition="top">&nbsp;(batched ×{{ info.responseShareBatch }})</span>
                             </ng-container>
                         </div>
                         <div class="flex flex-nowrap" *ngIf="(info.coinbaseOutputs?.length ?? 0) > 0">

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -113,6 +113,7 @@ export class SystemApiService {
         fallbackStratumDecodeCoinbase: true,
         poolDifficulty: 1000,
         responseTime: 10,
+        responseShareBatch: 1,
         isUsingFallbackStratum: 0,
         poolConnectionInfo: "IPv4 (TLS)",
         frequency: 485,

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -285,6 +285,9 @@ components:
         responseTime:
           type: number
           description: Pool response time in ms
+        responseShareBatch:
+          type: number
+          description: Number of shares acknowledged in the batch that produced responseTime (SV2; 1 = single share, >1 = batched ack)
         rotation:
           type: number
           description: Screen rotation setting (0, 90, 180, 270)

--- a/main/http_server/system_api_json.c
+++ b/main/http_server/system_api_json.c
@@ -75,6 +75,7 @@ static void system_api_add_telemetry(cJSON *root, GlobalState *g) {
     cJSON_AddNumberToObject(root, "bestSessionDiff", g->SYSTEM_MODULE.best_session_nonce_diff);
     cJSON_AddNumberToObject(root, "poolDifficulty", g->pool_difficulty);
     cJSON_AddFloatToObject(root, "responseTime", g->SYSTEM_MODULE.response_time);
+    cJSON_AddNumberToObject(root, "responseShareBatch", g->SYSTEM_MODULE.response_share_batch);
     cJSON_AddFloatToObject(root, "processTime", g->SYSTEM_MODULE.process_time);
 
     // Dynamic Block Info

--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -150,8 +150,18 @@ void stratum_v2_close_connection(GlobalState *GLOBAL_STATE)
     vTaskDelay(1000 / portTICK_PERIOD_MS);
 }
 
-// Track last share submit time for response time measurement
-static int64_t stratum_v2_last_submit_time_us = 0;
+// Track per-share submit timestamps for response time measurement.
+// SubmitShares.Success can batch-acknowledge multiple shares via its
+// last_sequence_number field, so we key the submit time by sequence number
+// (ring buffer) and measure against the specific share being acknowledged
+// rather than just the most recent submit.
+#define SV2_SUBMIT_TIMING_SLOTS 32
+static int64_t stratum_v2_submit_time_us[SV2_SUBMIT_TIMING_SLOTS] = {0};
+
+static inline void stratum_v2_record_submit_time(uint32_t sequence_number)
+{
+    stratum_v2_submit_time_us[sequence_number % SV2_SUBMIT_TIMING_SLOTS] = esp_timer_get_time();
+}
 
 int stratum_v2_submit_share(GlobalState *GLOBAL_STATE, uint32_t job_id, uint32_t nonce,
                             uint32_t ntime, uint32_t version)
@@ -163,13 +173,14 @@ int stratum_v2_submit_share(GlobalState *GLOBAL_STATE, uint32_t job_id, uint32_t
     sv2_conn_t *conn = GLOBAL_STATE->sv2_conn;
     uint8_t buf[SV2_FRAME_HEADER_SIZE + 24];
 
+    uint32_t sequence_number = conn->sequence_number++;
     int len = sv2_build_submit_shares_standard(buf, sizeof(buf),
                                                 conn->channel_id,
-                                                conn->sequence_number++,
+                                                sequence_number,
                                                 job_id, nonce, ntime, version);
     if (len < 0) return -1;
 
-    stratum_v2_last_submit_time_us = esp_timer_get_time();
+    stratum_v2_record_submit_time(sequence_number);
     return sv2_noise_send(GLOBAL_STATE->sv2_noise_ctx, GLOBAL_STATE->transport, buf, len);
 }
 
@@ -184,14 +195,15 @@ int stratum_v2_submit_share_extended(GlobalState *GLOBAL_STATE, uint32_t job_id,
     sv2_conn_t *conn = GLOBAL_STATE->sv2_conn;
     uint8_t buf[SV2_FRAME_HEADER_SIZE + 24 + 1 + 32];
 
+    uint32_t sequence_number = conn->sequence_number++;
     int len = sv2_build_submit_shares_extended(buf, sizeof(buf),
                                                 conn->channel_id,
-                                                conn->sequence_number++,
+                                                sequence_number,
                                                 job_id, nonce, ntime, version,
                                                 extranonce, extranonce_len);
     if (len < 0) return -1;
 
-    stratum_v2_last_submit_time_us = esp_timer_get_time();
+    stratum_v2_record_submit_time(sequence_number);
     return sv2_noise_send(GLOBAL_STATE->sv2_noise_ctx, GLOBAL_STATE->transport, buf, len);
 }
 
@@ -951,12 +963,20 @@ void stratum_v2_task(void *pvParameters)
                     break;
 
                 case SV2_MSG_SUBMIT_SHARES_SUCCESS: {
-                    uint32_t channel_id, accepted_count;
-                    if (sv2_parse_submit_shares_success(recv_buf, hdr.msg_length, &channel_id, &accepted_count) == 0) {
-                        if (stratum_v2_last_submit_time_us > 0) {
-                            float response_time_ms = (float)(esp_timer_get_time() - stratum_v2_last_submit_time_us) / 1000.0f;
+                    uint32_t channel_id, last_sequence_number, accepted_count;
+                    if (sv2_parse_submit_shares_success(recv_buf, hdr.msg_length, &channel_id, &last_sequence_number, &accepted_count) == 0) {
+                        // Measure against the share acknowledged by last_sequence_number — the
+                        // most recent share in the ack, giving the cleanest available round trip.
+                        // accepted_count is surfaced separately so the UI can flag batch acks,
+                        // where the elapsed time also includes the pool's batching window.
+                        int slot = last_sequence_number % SV2_SUBMIT_TIMING_SLOTS;
+                        int64_t submit_time_us = stratum_v2_submit_time_us[slot];
+                        if (submit_time_us > 0) {
+                            float response_time_ms = (float)(esp_timer_get_time() - submit_time_us) / 1000.0f;
                             ESP_LOGI(TAG, "Shares accepted: %lu (%.1f ms)", accepted_count, response_time_ms);
                             GLOBAL_STATE->SYSTEM_MODULE.response_time = response_time_ms;
+                            GLOBAL_STATE->SYSTEM_MODULE.response_share_batch = (uint16_t)accepted_count;
+                            stratum_v2_submit_time_us[slot] = 0;
                         } else {
                             ESP_LOGI(TAG, "Shares accepted: %lu", accepted_count);
                         }


### PR DESCRIPTION
The SV2 task measured share response time against a single timestamp (the last submit). If more than one share is in flight, the pool can ack several at once via `SubmitShares.Success` (`last_sequence_number` + `new_submits_accepted_count`), so measuring against the last submit gives a wrong round trip.

Now submit timestamps are stored per sequence number (small ring buffer) and the response time is measured against the `last_sequence_number` the pool acked. `sv2_parse_submit_shares_success` now also reads `last_sequence_number`, which was already in the payload but unused.

For pools that batch-ack, the elapsed time also includes the pool's batching window, not just the network round trip. So `new_submits_accepted_count` is exposed as `responseShareBatch` and the dashboard shows a small `(batched ×N)` next to the Time when it's >1.

SV1 unaffected, it already does 1:1 request/response timing.