### PR TITLE
Set TCP_NODELAY on pool sockets to fix SV2 submit latency

### DIFF
--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -210,6 +210,14 @@ static void set_socket_options(esp_transport_handle_t transport)
             ESP_LOGE(TAG, "Failed to set SO_RCVTIMEO");
         }
 
+        // Disable Nagle's algorithm so share submits are sent immediately instead
+        // of being held back to coalesce with later data, which interacts badly
+        // with the pool's delayed-ACK and adds latency per submit.
+        int nodelay = 1;
+        if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) < 0) {
+            ESP_LOGE(TAG, "Failed to set TCP_NODELAY");
+        }
+
         // Enable keepalive
         int keepalive = 1;
         if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive)) < 0) {

--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -48,6 +48,13 @@ static void stratum_v2_set_socket_options(esp_transport_handle_t transport)
     setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &snd_timeout, sizeof(snd_timeout));
     setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout));
 
+    // Disable Nagle's algorithm. SV2 frames are written as two segments (encrypted
+    // header then payload); with Nagle on, the second segment is held until the
+    // first is ACKed, which collides with the pool's delayed-ACK and adds ~40 ms
+    // of latency per share submit.
+    int nodelay = 1;
+    setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+
     int keepalive = 1;
     setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
 


### PR DESCRIPTION
SV2 share submits were taking ~40-60ms on hardware where SV1 submits take ~5-10ms. Traced it with tcpdump at the pool:

- The firmware writes each `SubmitSharesExtended` as two TCP segments (encrypted header, then payload), and the pool socket had Nagle's algorithm active (TCP_NODELAY was never set).
- With Nagle on, the stack sends segment 1 and holds segment 2 until segment 1 is ACKed. The pool only has a partial message so it can't respond, and sends a standalone delayed-ACK after ~40ms. Only then does segment 2 go out, after which the pool responds in <0.1ms.
- SV1 sends its message in a single write/segment, which is why it was already fast.

Fix: set `TCP_NODELAY` on the pool socket right after connect, for both SV1 and SV2. Measured SV2 submit latency drops from 40-60ms to ~8ms, in line with SV1.

Verified with tcpdump at the pool: the submit now arrives without the ~40ms delayed-ACK gap and the pool responds in <1ms.

Before:
<img width="714" height="395" alt="Bildschirmfoto_20260526_133902" src="https://github.com/user-attachments/assets/d636327b-ccfb-4a46-9cfe-65207a5d2844" />


After:

<img width="711" height="394" alt="Bildschirmfoto_20260526_133808" src="https://github.com/user-attachments/assets/79964873-ef55-4f69-95dc-0f6322b83e89" />
