### PR TITLE
Consolidate shared stratum socket, wifi and clean-queue helpers

### DIFF
--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -595,3 +595,9 @@ static const char *get_wifi_reason_string(int reason) {
     }
     return "Unknown error";
 }
+
+bool wifi_is_connected(void)
+{
+    wifi_ap_record_t ap_info;
+    return (esp_wifi_sta_get_ap_info(&ap_info) == ESP_OK);
+}

--- a/components/connect/include/connect.h
+++ b/components/connect/include/connect.h
@@ -4,6 +4,7 @@
 #include "lwip/sys.h"
 #include <arpa/inet.h>
 #include <lwip/netdb.h>
+#include <stdbool.h>
 
 #include "esp_err.h"
 #include "esp_wifi_types.h"
@@ -20,5 +21,6 @@ void wifi_init(void * GLOBAL_STATE);
 esp_err_t wifi_apply_hostname(const char *hostname);
 esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count);
 esp_err_t get_wifi_current_rssi(int8_t *rssi);
+bool wifi_is_connected(void);
 
 #endif /* CONNECT_H_ */

--- a/components/stratum/CMakeLists.txt
+++ b/components/stratum/CMakeLists.txt
@@ -3,10 +3,11 @@ SRCS
     "utils.c"
     "mining.c"
     "stratum_api.c"
+    "stratum_socket.c"
     "coinbase_decoder.c"
     "segwit_addr.c"
     "base58.c"
-                    
+
 INCLUDE_DIRS
     "include"
 
@@ -16,4 +17,5 @@ REQUIRES
     "app_update"
     "esp_timer"
     "tcp_transport"
+    "esp_netif"
 )

--- a/components/stratum/include/stratum_socket.h
+++ b/components/stratum/include/stratum_socket.h
@@ -1,0 +1,30 @@
+#ifndef STRATUM_SOCKET_H_
+#define STRATUM_SOCKET_H_
+
+#include <stdint.h>
+#include "esp_err.h"
+#include "esp_transport.h"
+#include <lwip/sockets.h>
+#include <lwip/netdb.h>
+
+// Resolved pool address, including the textual host_ip (with IPv6 zone id when
+// applicable) used for connecting and logging.
+typedef struct {
+    struct sockaddr_storage dest_addr;  // IPv4 or IPv6 address (with scope_id for IPv6)
+    socklen_t addrlen;
+    int addr_family;
+    int ip_protocol;
+    char host_ip[INET6_ADDRSTRLEN + 16];  // IPv6 address + zone identifier (e.g., "fe80::1%wlan0")
+} stratum_connection_info_t;
+
+// Resolve a pool hostname:port into conn_info, preferring IPv4 then IPv6 and
+// handling IPv6 link-local scope ids. Returns ESP_OK on success. Used by both
+// the SV1 and SV2 tasks so DNS resolution stays non-blocking (the resolved IP
+// is passed to esp_transport_connect instead of the hostname).
+esp_err_t stratum_socket_resolve(const char *hostname, uint16_t port, stratum_connection_info_t *conn_info);
+
+// Apply the common pool-socket options (timeouts, TCP_NODELAY, keepalive) used
+// by both the SV1 and SV2 stratum tasks.
+void stratum_socket_set_options(esp_transport_handle_t transport);
+
+#endif /* STRATUM_SOCKET_H_ */

--- a/components/stratum/stratum_socket.c
+++ b/components/stratum/stratum_socket.c
@@ -1,0 +1,184 @@
+#include "stratum_socket.h"
+
+#include "esp_log.h"
+#include "esp_netif.h"
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+static const char *TAG = "stratum_socket";
+
+esp_err_t stratum_socket_resolve(const char *hostname, uint16_t port, stratum_connection_info_t *conn_info)
+{
+    // Input validation
+    if (hostname == NULL || conn_info == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (port == 0) {
+        ESP_LOGE(TAG, "Invalid port: 0");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    char port_str[6];
+    snprintf(port_str, sizeof(port_str), "%u", port);
+
+    ESP_LOGD(TAG, "Resolving address for %s:%u", hostname, port);
+
+    struct addrinfo hints = {
+        .ai_family   = AF_UNSPEC,
+        .ai_socktype = SOCK_STREAM,
+        .ai_protocol = IPPROTO_TCP,
+        .ai_flags    = AI_NUMERICSERV
+    };
+
+    // getaddrinfo() maps to esp_getaddrinfo() when CONFIG_LWIP_USE_ESP_GETADDRINFO
+    // is enabled (as it is in the firmware), which resolves AF_UNSPEC into both
+    // IPv4 and IPv6. Using the standard name keeps this component buildable under
+    // the default lwip config too (e.g. the unit-test build).
+    struct addrinfo *res = NULL;
+    int gai_err = getaddrinfo(hostname, port_str, &hints, &res);
+    if (gai_err != 0 || res == NULL) {
+        ESP_LOGE(TAG, "DNS resolution failed for %s:%u (error: %d)", hostname, port, gai_err);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    // Initialize connection info
+    memset(conn_info, 0, sizeof(*conn_info));
+    conn_info->addr_family = AF_UNSPEC;
+
+    // Preferred order: IPv4 first, then IPv6
+    const int preferred_families[] = { AF_INET, AF_INET6 };
+    const size_t num_families = sizeof(preferred_families) / sizeof(preferred_families[0]);
+
+    const struct addrinfo *selected = NULL;
+
+    for (size_t i = 0; i < num_families && selected == NULL; i++) {
+        int family = preferred_families[i];
+
+        for (const struct addrinfo *p = res; p != NULL; p = p->ai_next) {
+            if (p->ai_family == family) {
+                selected = p;
+                break;
+            }
+        }
+    }
+
+    if (selected == NULL) {
+        ESP_LOGE(TAG, "No supported address family (IPv4 or IPv6) found for %s", hostname);
+        freeaddrinfo(res);
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    // Copy selected address
+    memcpy(&conn_info->dest_addr, selected->ai_addr, selected->ai_addrlen);
+    conn_info->addrlen     = selected->ai_addrlen;
+    conn_info->addr_family = selected->ai_family;
+    conn_info->ip_protocol = (selected->ai_family == AF_INET) ? IPPROTO_IP : IPPROTO_IPV6;
+
+    // Handle IPv6 link-local scope ID if needed
+    if (selected->ai_family == AF_INET6) {
+        struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&conn_info->dest_addr;
+
+        if (IN6_IS_ADDR_LINKLOCAL(&addr6->sin6_addr)) {
+            if (addr6->sin6_scope_id == 0) {
+                ESP_LOGW(TAG, "Link-local IPv6 address without scope ID - attempting to set from WiFi STA interface");
+
+                esp_netif_t *netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+                if (netif) {
+                    int index = esp_netif_get_netif_impl_index(netif);
+                    if (index >= 0) {
+                        addr6->sin6_scope_id = (uint32_t)index;
+                        ESP_LOGI(TAG, "Set IPv6 scope_id to interface index: %lu", (unsigned long)addr6->sin6_scope_id);
+                    } else {
+                        ESP_LOGW(TAG, "Failed to get valid interface index for WIFI_STA_DEF");
+                    }
+                } else {
+                    ESP_LOGW(TAG, "Could not get netif handle for WIFI_STA_DEF");
+                }
+            } else {
+                ESP_LOGI(TAG, "Link-local IPv6 address with existing scope_id: %lu", (unsigned long)addr6->sin6_scope_id);
+            }
+        }
+    }
+
+    const void *src_addr;
+    int af = conn_info->addr_family;
+
+    if (af == AF_INET) {
+        struct sockaddr_in *addr4 = (struct sockaddr_in *)&conn_info->dest_addr;
+        src_addr = &addr4->sin_addr;
+    } else {
+        struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&conn_info->dest_addr;
+        src_addr = &addr6->sin6_addr;
+    }
+
+    // Convert resolved address to string for logging and storage
+    if (inet_ntop(af, src_addr, conn_info->host_ip, sizeof(conn_info->host_ip)) == NULL) {
+        ESP_LOGW(TAG, "inet_ntop failed (errno: %d)", errno);
+        snprintf(conn_info->host_ip, sizeof(conn_info->host_ip), "[invalid %s addr]",
+                 (af == AF_INET) ? "IPv4" : "IPv6");
+    } else if (af == AF_INET6) {
+        struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&conn_info->dest_addr;
+        if (IN6_IS_ADDR_LINKLOCAL(&addr6->sin6_addr) && addr6->sin6_scope_id != 0) {
+            char zone[16];
+            snprintf(zone, sizeof(zone), "%%%" PRIu32, addr6->sin6_scope_id);
+            strncat(conn_info->host_ip, zone,
+                    sizeof(conn_info->host_ip) - strlen(conn_info->host_ip) - 1);
+            // Ensure null termination
+            conn_info->host_ip[sizeof(conn_info->host_ip) - 1] = '\0';
+        }
+    }
+
+    ESP_LOGI(TAG, "Resolved %s:%u → %s", hostname, port, conn_info->host_ip);
+
+    freeaddrinfo(res);
+    return ESP_OK;
+}
+
+void stratum_socket_set_options(esp_transport_handle_t transport)
+{
+    int sock = esp_transport_get_socket(transport);
+    if (sock < 0) {
+        ESP_LOGE(TAG, "Failed to get socket from transport");
+        return;
+    }
+
+    // Send and receive timeouts
+    struct timeval snd_timeout = { .tv_sec = 5, .tv_usec = 0 };
+    struct timeval rcv_timeout = { .tv_sec = 60 * 3, .tv_usec = 0 };
+    if (setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &snd_timeout, sizeof(snd_timeout)) < 0) {
+        ESP_LOGE(TAG, "Failed to set SO_SNDTIMEO");
+    }
+    if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout)) < 0) {
+        ESP_LOGE(TAG, "Failed to set SO_RCVTIMEO");
+    }
+
+    // Disable Nagle's algorithm so share submits are sent immediately. Stratum
+    // frames can be written in more than one segment; with Nagle on, later
+    // segments are held until earlier ones are ACKed, which collides with the
+    // pool's delayed-ACK and adds latency per submit.
+    int nodelay = 1;
+    if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) < 0) {
+        ESP_LOGE(TAG, "Failed to set TCP_NODELAY");
+    }
+
+    // Keepalive
+    int keepalive = 1;
+    if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive)) < 0) {
+        ESP_LOGE(TAG, "Failed to set SO_KEEPALIVE");
+    }
+    int keepidle = 60;  // seconds before sending keepalive probes
+    int keepintvl = 10; // seconds between keepalive probes
+    int keepcnt = 3;    // number of keepalive probes before dropping
+    if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle)) < 0) {
+        ESP_LOGE(TAG, "Failed to set TCP_KEEPIDLE");
+    }
+    if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl)) < 0) {
+        ESP_LOGE(TAG, "Failed to set TCP_KEEPINTVL");
+    }
+    if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt)) < 0) {
+        ESP_LOGE(TAG, "Failed to set TCP_KEEPCNT");
+    }
+}

--- a/main/system.c
+++ b/main/system.c
@@ -32,6 +32,8 @@
 #include "utils.h"
 #include "self_test.h"
 #include "filesystem.h"
+#include "work_queue.h"
+#include "hashrate_monitor_task.h"
 
 static const char * TAG = "system";
 
@@ -250,6 +252,21 @@ esp_err_t SYSTEM_init_peripherals(GlobalState * GLOBAL_STATE) {
     }
 
     return ESP_OK;
+}
+
+void SYSTEM_clean_jobs_queue(GlobalState * GLOBAL_STATE)
+{
+    ESP_LOGI(TAG, "Clean Jobs: clearing queue");
+    queue_clear(&GLOBAL_STATE->stratum_queue);
+
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
+    for (int i = 0; i < 128; i = i + 4) {
+        GLOBAL_STATE->valid_jobs[i] = 0;
+    }
+    pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
+
+    // Reset hashrate measurements to prevent a spike on reconnection
+    hashrate_monitor_reset_measurements(GLOBAL_STATE);
 }
 
 void SYSTEM_notify_accepted_share(GlobalState * GLOBAL_STATE)

--- a/main/system.h
+++ b/main/system.h
@@ -8,6 +8,11 @@ void SYSTEM_init_system(GlobalState * GLOBAL_STATE);
 void SYSTEM_init_versions(GlobalState * GLOBAL_STATE);
 esp_err_t SYSTEM_init_peripherals(GlobalState * GLOBAL_STATE);
 
+// Clear the stratum job queue and valid-job tracking on a clean-jobs event,
+// and reset hashrate measurements so reconnects don't spike the average.
+// Shared by the SV1 and SV2 tasks.
+void SYSTEM_clean_jobs_queue(GlobalState * GLOBAL_STATE);
+
 void SYSTEM_notify_accepted_share(GlobalState * GLOBAL_STATE);
 void SYSTEM_notify_rejected_share(GlobalState * GLOBAL_STATE, char * error_msg);
 void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint8_t job_id);

--- a/main/tasks/protocol_coordinator.c
+++ b/main/tasks/protocol_coordinator.c
@@ -2,13 +2,13 @@
 #include "esp_timer.h"
 #include "esp_transport.h"
 #include "esp_transport_tcp.h"
-#include "esp_wifi.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 
 #include "protocol_coordinator.h"
 #include "stratum_v1_task.h"
 #include "stratum_v2_task.h"
+#include "connect.h"
 #include "system.h"
 #include "nvs_config.h"
 
@@ -116,12 +116,6 @@ void protocol_coordinator_v2_exited(void)
     if (s_event_queue) {
         xQueueSend(s_event_queue, &evt, 0);
     }
-}
-
-static bool is_wifi_connected(void)
-{
-    wifi_ap_record_t ap_info;
-    return (esp_wifi_sta_get_ap_info(&ap_info) == ESP_OK);
 }
 
 static void reset_share_stats(GlobalState *gs)
@@ -343,7 +337,7 @@ static void do_heartbeat_probe(GlobalState *gs)
         return;
     }
 
-    if (!is_wifi_connected()) {
+    if (!wifi_is_connected()) {
         return;
     }
 
@@ -406,7 +400,7 @@ static void resume_on_pool(GlobalState *gs, bool use_fallback)
 // Resumes mining as soon as one is reachable.
 static void try_resume_from_paused(GlobalState *gs)
 {
-    if (!is_wifi_connected()) {
+    if (!wifi_is_connected()) {
         return;
     }
 

--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -3,22 +3,20 @@
 #include "system.h"
 #include "global_state.h"
 #include <lwip/tcpip.h>
-#include <lwip/netdb.h>
 #include "stratum_v1_task.h"
+#include "stratum_socket.h"
 #include "protocol_coordinator.h"
+#include "connect.h"
 #include "work_queue.h"
-#include "esp_wifi.h"
 #include <esp_sntp.h>
 #include "esp_timer.h"
 #include "esp_transport.h"
 #include "esp_transport_tcp.h"
-#include <sys/time.h>
 #include <stdbool.h>
 #include <string.h>
 #include "utils.h"
 #include "coinbase_decoder.h"
 #include <esp_heap_caps.h>
-#include "hashrate_monitor_task.h"
 #include "esp_transport_ssl.h"
 #include "freertos/task.h"
 
@@ -56,212 +54,6 @@ static int stratum_get_next_uid(GlobalState * GLOBAL_STATE)
     return uid;
 }
 
-struct timeval tcp_snd_timeout = {
-    .tv_sec = 5,
-    .tv_usec = 0
-};
-
-struct timeval tcp_rcv_timeout = {
-    .tv_sec = 60 * 3,
-    .tv_usec = 0
-};
-
-
-typedef struct {
-    struct sockaddr_storage dest_addr;  // Stores IPv4 or IPv6 address with scope_id for IPv6
-    socklen_t addrlen;
-    int addr_family;
-    int ip_protocol;
-    char host_ip[INET6_ADDRSTRLEN + 16];  // IPv6 address + zone identifier (e.g., "fe80::1%wlan0")
-} stratum_connection_info_t;
-
-static esp_err_t resolve_stratum_address(const char *hostname, uint16_t port, stratum_connection_info_t *conn_info)
-{
-    // Input validation
-    if (hostname == NULL || conn_info == NULL) {
-        return ESP_ERR_INVALID_ARG;
-    }
-    if (port == 0) {
-        ESP_LOGE(TAG, "Invalid port: 0");
-        return ESP_ERR_INVALID_ARG;
-    }
-
-    char port_str[6];
-    snprintf(port_str, sizeof(port_str), "%u", port);
-
-    ESP_LOGD(TAG, "Resolving address for %s:%u", hostname, port);
-
-    struct addrinfo hints = {
-        .ai_family   = AF_UNSPEC,
-        .ai_socktype = SOCK_STREAM,
-        .ai_protocol = IPPROTO_TCP,
-        .ai_flags    = AI_NUMERICSERV
-    };
-
-    struct addrinfo *res = NULL;
-    int gai_err = esp_getaddrinfo(hostname, port_str, &hints, &res);
-    if (gai_err != 0 || res == NULL) {
-        ESP_LOGE(TAG, "DNS resolution failed for %s:%u (error: %d)", hostname, port, gai_err);
-        return ESP_ERR_NOT_FOUND;
-    }
-
-    // Initialize connection info
-    memset(conn_info, 0, sizeof(*conn_info));
-    conn_info->addr_family = AF_UNSPEC;
-
-    // Preferred order: IPv4 first, then IPv6
-    const int preferred_families[] = { AF_INET, AF_INET6 };
-    const size_t num_families = sizeof(preferred_families) / sizeof(preferred_families[0]);
-
-    const struct addrinfo *selected = NULL;
-
-    for (size_t i = 0; i < num_families && selected == NULL; i++) {
-        int family = preferred_families[i];
-
-        for (const struct addrinfo *p = res; p != NULL; p = p->ai_next) {
-            if (p->ai_family == family) {
-                selected = p;
-                break;
-            }
-        }
-    }
-
-    if (selected == NULL) {
-        ESP_LOGE(TAG, "No supported address family (IPv4 or IPv6) found for %s", hostname);
-        freeaddrinfo(res);
-        return ESP_ERR_NOT_SUPPORTED;
-    }
-
-    // Copy selected address
-    memcpy(&conn_info->dest_addr, selected->ai_addr, selected->ai_addrlen);
-    conn_info->addrlen     = selected->ai_addrlen;
-    conn_info->addr_family = selected->ai_family;
-    conn_info->ip_protocol = (selected->ai_family == AF_INET) ? IPPROTO_IP : IPPROTO_IPV6;
-
-    // Handle IPv6 link-local scope ID if needed
-    if (selected->ai_family == AF_INET6) {
-        struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&conn_info->dest_addr;
-
-        if (IN6_IS_ADDR_LINKLOCAL(&addr6->sin6_addr)) {
-            if (addr6->sin6_scope_id == 0) {
-                ESP_LOGW(TAG, "Link-local IPv6 address without scope ID - attempting to set from WiFi STA interface");
-
-                esp_netif_t *netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-                if (netif) {
-                    int index = esp_netif_get_netif_impl_index(netif);
-                    if (index >= 0) {
-                        addr6->sin6_scope_id = (uint32_t)index;
-                        ESP_LOGI(TAG, "Set IPv6 scope_id to interface index: %lu", (unsigned long)addr6->sin6_scope_id);
-                    } else {
-                        ESP_LOGW(TAG, "Failed to get valid interface index for WIFI_STA_DEF");
-                    }
-                } else {
-                    ESP_LOGW(TAG, "Could not get netif handle for WIFI_STA_DEF");
-                }
-            } else {
-                ESP_LOGI(TAG, "Link-local IPv6 address with existing scope_id: %lu", (unsigned long)addr6->sin6_scope_id);
-            }
-        }
-    }
-
-    const void *src_addr;
-    int af = conn_info->addr_family;
-
-    if (af == AF_INET) {
-        struct sockaddr_in *addr4 = (struct sockaddr_in *)&conn_info->dest_addr;
-        src_addr = &addr4->sin_addr;
-    } else {
-        struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&conn_info->dest_addr;
-        src_addr = &addr6->sin6_addr;
-    }
-
-    // Convert resolved address to string for logging and storage
-    if (inet_ntop(af, src_addr, conn_info->host_ip, sizeof(conn_info->host_ip)) == NULL) {
-        ESP_LOGW(TAG, "inet_ntop failed (errno: %d)", errno);
-        snprintf(conn_info->host_ip, sizeof(conn_info->host_ip), "[invalid %s addr]",
-                 (af == AF_INET) ? "IPv4" : "IPv6");
-    } else if (af == AF_INET6) {
-        struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&conn_info->dest_addr;
-        if (IN6_IS_ADDR_LINKLOCAL(&addr6->sin6_addr) && addr6->sin6_scope_id != 0) {
-            char zone[16];
-            snprintf(zone, sizeof(zone), "%%%" PRIu32, addr6->sin6_scope_id);
-            strncat(conn_info->host_ip, zone,
-                    sizeof(conn_info->host_ip) - strlen(conn_info->host_ip) - 1);
-            // Ensure null termination
-            conn_info->host_ip[sizeof(conn_info->host_ip) - 1] = '\0';
-        }
-    }
-
-    ESP_LOGI(TAG, "Resolved %s:%u → %s", hostname, port, conn_info->host_ip);
-
-    freeaddrinfo(res);
-    return ESP_OK;
-}
-
-static void set_socket_options(esp_transport_handle_t transport)
-{
-    int sock = esp_transport_get_socket(transport);
-    if (sock >= 0) {
-        // Set send and receive timeouts
-        if (setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tcp_snd_timeout, sizeof(tcp_snd_timeout)) < 0) {
-            ESP_LOGE(TAG, "Failed to set SO_SNDTIMEO");
-        }
-        if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tcp_rcv_timeout, sizeof(tcp_rcv_timeout)) < 0) {
-            ESP_LOGE(TAG, "Failed to set SO_RCVTIMEO");
-        }
-
-        // Disable Nagle's algorithm so share submits are sent immediately instead
-        // of being held back to coalesce with later data, which interacts badly
-        // with the pool's delayed-ACK and adds latency per submit.
-        int nodelay = 1;
-        if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) < 0) {
-            ESP_LOGE(TAG, "Failed to set TCP_NODELAY");
-        }
-
-        // Enable keepalive
-        int keepalive = 1;
-        if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive)) < 0) {
-            ESP_LOGE(TAG, "Failed to set SO_KEEPALIVE");
-        }
-
-        // Set keepalive parameters (adjust values as needed)
-        int keepidle = 60;  // TCP_KEEPIDLE: seconds before sending keepalive
-        int keepintvl = 10; // TCP_KEEPINTVL: seconds between keepalive probes
-        int keepcnt = 3;    // TCP_KEEPCNT: number of keepalive probes
-        if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle)) < 0) {
-            ESP_LOGE(TAG, "Failed to set TCP_KEEPIDLE");
-        }
-        if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl)) < 0) {
-            ESP_LOGE(TAG, "Failed to set TCP_KEEPINTVL");
-        }
-        if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt)) < 0) {
-            ESP_LOGE(TAG, "Failed to set TCP_KEEPCNT");
-        }
-    } else {
-        ESP_LOGE(TAG, "Failed to get socket from transport");
-    }
-}
-
-static bool is_wifi_connected(void)
-{
-    wifi_ap_record_t ap_info;
-    return (esp_wifi_sta_get_ap_info(&ap_info) == ESP_OK);
-}
-
-static void cleanQueue(GlobalState *GLOBAL_STATE)
-{
-    ESP_LOGI(TAG, "Clean Jobs: clearing queue");
-    queue_clear(&GLOBAL_STATE->stratum_queue);
-
-    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
-    for (int i = 0; i < 128; i = i + 4) {
-        GLOBAL_STATE->valid_jobs[i] = 0;
-    }
-    pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
-    
-    // Reset hashrate measurements to prevent spike on reconnection
-    hashrate_monitor_reset_measurements(GLOBAL_STATE);
-}
 
 static void stratum_v1_reset_uid(GlobalState *GLOBAL_STATE)
 {
@@ -282,7 +74,7 @@ void stratum_v1_close_connection(GlobalState *GLOBAL_STATE)
     if (transport != NULL) {
         esp_transport_close(transport);
     }
-    cleanQueue(GLOBAL_STATE);
+    SYSTEM_clean_jobs_queue(GLOBAL_STATE);
     vTaskDelay(1000 / portTICK_PERIOD_MS);
 }
 
@@ -404,7 +196,7 @@ void stratum_v1_task(void *pvParameters)
             continue;
         }
 
-        if (!is_wifi_connected()) {
+        if (!wifi_is_connected()) {
             ESP_LOGI(TAG, "WiFi disconnected, attempting to reconnect...");
             vTaskDelay(10000 / portTICK_PERIOD_MS);
             continue;
@@ -426,7 +218,7 @@ void stratum_v1_task(void *pvParameters)
         port = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_port : GLOBAL_STATE->SYSTEM_MODULE.pool_port;
 
         stratum_connection_info_t conn_info;
-        if (resolve_stratum_address(stratum_url, port, &conn_info) != ESP_OK) {
+        if (stratum_socket_resolve(stratum_url, port, &conn_info) != ESP_OK) {
             ESP_LOGE(TAG, "Address resolution failed for %s", stratum_url);
             retry_attempts++;
             vTaskDelay(1000 / portTICK_PERIOD_MS);
@@ -472,7 +264,7 @@ void stratum_v1_task(void *pvParameters)
             continue;
         }
 
-        set_socket_options(GLOBAL_STATE->transport);
+        stratum_socket_set_options(GLOBAL_STATE->transport);
 
         const char *protocol = (conn_info.addr_family == AF_INET6) ? "IPv6" : "IPv4";
         const char *tls_status;
@@ -489,7 +281,7 @@ void stratum_v1_task(void *pvParameters)
                  "%s%s", protocol, tls_status);
 
         stratum_v1_reset_uid(GLOBAL_STATE);
-        cleanQueue(GLOBAL_STATE);
+        SYSTEM_clean_jobs_queue(GLOBAL_STATE);
 
         ///// Start Stratum Action
         // mining.configure - ID: 1
@@ -541,7 +333,7 @@ void stratum_v1_task(void *pvParameters)
                 SYSTEM_notify_new_ntime(GLOBAL_STATE, stratum_api_v1_message.mining_notification->ntime);
                 if (stratum_api_v1_message.mining_notification->clean_jobs &&
                     (GLOBAL_STATE->stratum_queue.count > 0)) {
-                    cleanQueue(GLOBAL_STATE);
+                    SYSTEM_clean_jobs_queue(GLOBAL_STATE);
                 }
                 if (GLOBAL_STATE->stratum_queue.count == QUEUE_SIZE) {
                     mining_notify *next_notify_json_str = (mining_notify *) queue_dequeue(&GLOBAL_STATE->stratum_queue);

--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -3,11 +3,12 @@
 #include "esp_transport_tcp.h"
 #include <lwip/sockets.h>
 #include "esp_timer.h"
-#include "esp_wifi.h"
 #include "system.h"
 #include "global_state.h"
 #include "stratum_v2_task.h"
+#include "stratum_socket.h"
 #include "protocol_coordinator.h"
+#include "connect.h"
 #include "sv2_protocol.h"
 #include "sv2_noise.h"
 #include "nvs_config.h"
@@ -18,7 +19,6 @@
 #include "coinbase_decoder.h"
 #include "esp_heap_caps.h"
 
-#include <lwip/netdb.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -27,44 +27,6 @@
 #define SV2_MAX_FRAME_SIZE 2048
 
 static const char *TAG = "stratum_v2_task";
-
-static bool is_wifi_connected(void)
-{
-    wifi_ap_record_t ap_info;
-    return (esp_wifi_sta_get_ap_info(&ap_info) == ESP_OK);
-}
-
-static void stratum_v2_set_socket_options(esp_transport_handle_t transport)
-{
-    int sock = esp_transport_get_socket(transport);
-    if (sock < 0) {
-        ESP_LOGE(TAG, "Failed to get socket from transport");
-        return;
-    }
-
-    struct timeval snd_timeout = { .tv_sec = 5, .tv_usec = 0 };
-    struct timeval rcv_timeout = { .tv_sec = 60 * 3, .tv_usec = 0 };
-
-    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &snd_timeout, sizeof(snd_timeout));
-    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout));
-
-    // Disable Nagle's algorithm. SV2 frames are written as two segments (encrypted
-    // header then payload); with Nagle on, the second segment is held until the
-    // first is ACKed, which collides with the pool's delayed-ACK and adds ~40 ms
-    // of latency per share submit.
-    int nodelay = 1;
-    setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
-
-    int keepalive = 1;
-    setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
-
-    int keepidle = 60;
-    int keepintvl = 10;
-    int keepcnt = 3;
-    setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle));
-    setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl));
-    setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt));
-}
 
 // Load authority pubkey from NVS (base58-encoded) into 32-byte buffer.
 // SV2 format: base58check(0x0001_LE + 32_byte_xonly_pubkey)
@@ -111,18 +73,6 @@ static bool stratum_v2_load_authority_pubkey(uint8_t out[32], bool use_fallback)
     return true;
 }
 
-static void stratum_v2_clean_queue(GlobalState *GLOBAL_STATE)
-{
-    ESP_LOGI(TAG, "Clean Jobs: clearing queue");
-    queue_clear(&GLOBAL_STATE->stratum_queue);
-
-    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
-    for (int i = 0; i < 128; i = i + 4) {
-        GLOBAL_STATE->valid_jobs[i] = 0;
-    }
-    pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
-}
-
 static sv2_channel_type_t sv2_select_channel_type(GlobalState *GLOBAL_STATE, bool use_fallback)
 {
     NvsConfigKey key = use_fallback ? NVS_CONFIG_FALLBACK_SV2_CHANNEL_TYPE
@@ -146,7 +96,7 @@ void stratum_v2_close_connection(GlobalState *GLOBAL_STATE)
         esp_transport_destroy(GLOBAL_STATE->transport);
         GLOBAL_STATE->transport = NULL;
     }
-    stratum_v2_clean_queue(GLOBAL_STATE);
+    SYSTEM_clean_jobs_queue(GLOBAL_STATE);
     vTaskDelay(1000 / portTICK_PERIOD_MS);
 }
 
@@ -238,7 +188,7 @@ static void stratum_v2_enqueue_job(GlobalState *GLOBAL_STATE, sv2_conn_t *conn,
     SYSTEM_notify_new_ntime(GLOBAL_STATE, ntime);
 
     if (clean_jobs && (GLOBAL_STATE->stratum_queue.count > 0)) {
-        stratum_v2_clean_queue(GLOBAL_STATE);
+        SYSTEM_clean_jobs_queue(GLOBAL_STATE);
     }
 
     if (GLOBAL_STATE->stratum_queue.count == QUEUE_SIZE) {
@@ -258,7 +208,7 @@ static void stratum_v2_enqueue_ext_job(GlobalState *GLOBAL_STATE, sv2_conn_t *co
     SYSTEM_notify_new_ntime(GLOBAL_STATE, job->ntime);
 
     if (job->clean_jobs && (GLOBAL_STATE->stratum_queue.count > 0)) {
-        stratum_v2_clean_queue(GLOBAL_STATE);
+        SYSTEM_clean_jobs_queue(GLOBAL_STATE);
     }
 
     if (GLOBAL_STATE->stratum_queue.count == QUEUE_SIZE) {
@@ -646,7 +596,7 @@ void stratum_v2_task(void *pvParameters)
             return;
         }
 
-        if (!is_wifi_connected()) {
+        if (!wifi_is_connected()) {
             ESP_LOGI(TAG, "WiFi disconnected, waiting...");
             vTaskDelay(10000 / portTICK_PERIOD_MS);
             continue;
@@ -678,11 +628,11 @@ void stratum_v2_task(void *pvParameters)
             continue;
         }
 
-        int64_t connect_start_us = esp_timer_get_time();
-
-        esp_err_t ret = esp_transport_connect(transport, stratum_url, port, TRANSPORT_TIMEOUT_MS);
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "TCP connect failed to %s:%d (err %d)", stratum_url, port, ret);
+        // Resolve up front and connect by IP so DNS stays non-blocking (a long
+        // DNS timeout otherwise stalls the lwIP stack and starves the HTTP server).
+        stratum_connection_info_t conn_info;
+        if (stratum_socket_resolve(stratum_url, port, &conn_info) != ESP_OK) {
+            ESP_LOGE(TAG, "Address resolution failed for %s", stratum_url);
             snprintf(GLOBAL_STATE->SYSTEM_MODULE.pool_connection_info,
                      sizeof(GLOBAL_STATE->SYSTEM_MODULE.pool_connection_info), "SV2: Pool unreachable");
             esp_transport_close(transport);
@@ -692,10 +642,24 @@ void stratum_v2_task(void *pvParameters)
             continue;
         }
 
-        ESP_LOGI(TAG, "TCP connected to %s:%d", stratum_url, port);
+        int64_t connect_start_us = esp_timer_get_time();
+
+        esp_err_t ret = esp_transport_connect(transport, conn_info.host_ip, port, TRANSPORT_TIMEOUT_MS);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "TCP connect failed to %s:%d (%s) (err %d)", stratum_url, port, conn_info.host_ip, ret);
+            snprintf(GLOBAL_STATE->SYSTEM_MODULE.pool_connection_info,
+                     sizeof(GLOBAL_STATE->SYSTEM_MODULE.pool_connection_info), "SV2: Pool unreachable");
+            esp_transport_close(transport);
+            esp_transport_destroy(transport);
+            retry_attempts++;
+            vTaskDelay(5000 / portTICK_PERIOD_MS);
+            continue;
+        }
+
+        ESP_LOGI(TAG, "TCP connected to %s:%d (%s)", stratum_url, port, conn_info.host_ip);
 
         GLOBAL_STATE->transport = transport;
-        stratum_v2_set_socket_options(transport);
+        stratum_socket_set_options(transport);
 
         // Reset connection state
         memset(conn, 0, sizeof(*conn));


### PR DESCRIPTION
Follow-up to #1722 — mutatrum suggested doing the socket/code consolidation in a separate PR instead of overloading the TCP_NODELAY change, so here it is.

The SV1 and SV2 tasks had grown several copies of the same code. This pulls them together:

- New `components/stratum/stratum_socket.{c,h}` holds the socket setup (`stratum_socket_set_options`) and the non-blocking DNS resolver (`stratum_socket_resolve`), both moved out of the SV1 task. SV2 now uses the resolver as well and connects by the resolved IP, so its DNS lookups no longer block the lwIP stack — SV1 already did this.
- `is_wifi_connected` existed three times (SV1, SV2 and protocol_coordinator). Moved into the connect component as `wifi_is_connected`.
- `cleanQueue` / `stratum_v2_clean_queue` merged into `SYSTEM_clean_jobs_queue` in system.c.

One behaviour change worth pointing out: the two clean-queue functions weren't identical. The SV1 one also reset the hashrate measurements (to avoid a spike on reconnect), the SV2 one didn't. The merged version keeps the reset, so SV2 now behaves like SV1 there.

Otherwise no functional change — same timeouts, same keepalive and TCP_NODELAY settings. Builds clean for esp32s3.