### PR TITLE
Change hostname without reboot

### DIFF
--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include "esp_event.h"
 #include "esp_log.h"
+#include "esp_netif.h"
 #include "esp_wifi.h"
 #include "freertos/task.h"
 #include "freertos/timers.h"
@@ -58,6 +59,43 @@ static int clients_connected_to_ap = 0;
 static const char *get_wifi_reason_string(int reason);
 static void wifi_softap_on(void);
 static void wifi_softap_off(void);
+
+esp_err_t wifi_apply_hostname(const char *hostname)
+{
+    if (hostname == NULL || hostname[0] == '\0') {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    esp_netif_t *esp_netif_sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+    if (esp_netif_sta == NULL) {
+        ESP_LOGW(TAG, "STA netif not ready; hostname will apply on next Wi-Fi start");
+        return ESP_ERR_ESP_NETIF_IF_NOT_READY;
+    }
+
+    esp_err_t err = esp_netif_set_hostname(esp_netif_sta, hostname);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "esp_netif_set_hostname failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    ESP_LOGI(TAG, "Set Wi-Fi hostname to: %s", hostname);
+
+    // Bounce the DHCP client so the new hostname is sent in option 12 on the
+    // next DISCOVER/REQUEST. This keeps the Wi-Fi link up — no AP flap.
+    err = esp_netif_dhcpc_stop(esp_netif_sta);
+    if (err != ESP_OK && err != ESP_ERR_ESP_NETIF_DHCP_ALREADY_STOPPED) {
+        ESP_LOGW(TAG, "esp_netif_dhcpc_stop failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    err = esp_netif_dhcpc_start(esp_netif_sta);
+    if (err != ESP_OK && err != ESP_ERR_ESP_NETIF_DHCP_ALREADY_STARTED) {
+        ESP_LOGW(TAG, "esp_netif_dhcpc_start failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    return ESP_OK;
+}
 
 esp_err_t get_wifi_current_rssi(int8_t *rssi)
 {

--- a/components/connect/include/connect.h
+++ b/components/connect/include/connect.h
@@ -5,6 +5,7 @@
 #include <arpa/inet.h>
 #include <lwip/netdb.h>
 
+#include "esp_err.h"
 #include "esp_wifi_types.h"
 
 // Structure to hold WiFi scan results
@@ -16,6 +17,7 @@ typedef struct {
 
 void toggle_wifi_softap(void);
 void wifi_init(void * GLOBAL_STATE);
+esp_err_t wifi_apply_hostname(const char *hostname);
 esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count);
 esp_err_t get_wifi_current_rssi(int8_t *rssi);
 

--- a/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/network-edit/network.edit.component.ts
@@ -53,6 +53,8 @@ export class NetworkEditComponent implements OnInit {
 
   public updateSystem() {
 
+    const restartAlreadyPending = this.savedChanges;
+    const restartRequired = this.isRestartRequired;
     const form = this.form.getRawValue();
 
     // Allow an empty Wi-Fi password
@@ -71,13 +73,16 @@ export class NetworkEditComponent implements OnInit {
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe({
         next: () => {
-          this.toastr.warning('You must restart this device after saving for changes to take effect.');
+          if (restartRequired) {
+            this.toastr.warning('You must restart this device after saving for changes to take effect.');
+          }
           this.toastr.success('Saved network settings');
-          this.savedChanges = true;
+          this.savedChanges = restartAlreadyPending || restartRequired;
+          this.form.markAsPristine();
         },
         error: (err: HttpErrorResponse) => {
           this.toastr.error(`Could not save. ${err.message}`);
-          this.savedChanges = false;
+          this.savedChanges = restartAlreadyPending;
         }
       });
   }
@@ -140,10 +145,22 @@ export class NetworkEditComponent implements OnInit {
       .subscribe({
         next: () => {
           this.toastr.success('Device restarted');
+          this.savedChanges = false;
         },
         error: (err: HttpErrorResponse) => {
           this.toastr.error(`Could not restart. ${err.message}`);
         }
       });
+  }
+
+  get noRestartFields(): string[] {
+    return [
+      'hostname'
+    ];
+  }
+
+  get isRestartRequired(): boolean {
+    return Object.entries(this.form.controls)
+      .some(([field, control]) => control.dirty && !this.noRestartFields.includes(field));
   }
 }

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -11,6 +11,7 @@
 #include "freertos/task.h"
 #include "esp_http_server.h"
 #include "esp_log.h"
+#include "esp_netif.h"
 #include "esp_system.h"
 #include "esp_timer.h"
 #include "esp_wifi.h"
@@ -719,10 +720,23 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
         return ESP_OK;
     }
 
+    cJSON *hostname_item = cJSON_GetObjectItem(root, "hostname");
+    char *current_hostname = cJSON_IsString(hostname_item) ? nvs_config_get_string(NVS_CONFIG_HOSTNAME) : NULL;
+    bool hostname_changed = cJSON_IsString(hostname_item) &&
+                            (current_hostname == NULL || strcmp(current_hostname, hostname_item->valuestring) != 0);
+    free(current_hostname);
+
     if (!check_settings_and_update(root)) {
         cJSON_Delete(root);
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Wrong API input");
         return ESP_OK;
+    }
+
+    if (hostname_changed) {
+        esp_err_t err = wifi_apply_hostname(hostname_item->valuestring);
+        if (err != ESP_OK && err != ESP_ERR_ESP_NETIF_IF_NOT_READY) {
+            ESP_LOGW(TAG, "Failed to apply hostname live: %s", esp_err_to_name(err));
+        }
     }
 
     cJSON_Delete(root);


### PR DESCRIPTION
This fixes #581 

The Wi-Fi link stays up throughout — no `WIFI_EVENT_STA_DISCONNECTED`, so the AP doesn't flap on and the 5s retry delay doesn't fire. The router will see a new DHCP exchange (usually re-issues the same IP) and will trigger an `IP_EVENT_STA_GOT_IP` event, which your existing handler treats idempotently.

Some routers cache hostnames per-MAC and won't update their DNS/lease table from a mid-session DHCP refresh — you may need to wait for the existing lease to expire. If you ever see a router that ignores the refresh, the fallback would be a full disconnect/reconnect — but most consumer routers honor the new option-12 immediately.
