### PR TITLE
Ignore duplicate stratum jobId

### DIFF
--- a/components/stratum_v2/include/sv2_protocol.h
+++ b/components/stratum_v2/include/sv2_protocol.h
@@ -88,6 +88,8 @@ typedef struct {
 
 #define SV2_PENDING_JOBS_SIZE 8
 
+#define SV2_MAX_ACTIVE_JOB_IDS 16
+
 // SV2 connection state
 typedef struct sv2_conn {
     uint32_t channel_id;
@@ -110,6 +112,10 @@ typedef struct sv2_conn {
     uint8_t  extranonce_prefix_len;
     uint8_t  extranonce_size;              // total extranonce bytes assigned by pool
     sv2_ext_job_t *ext_pending_jobs[SV2_PENDING_JOBS_SIZE];
+
+    // Active job IDs tracking for duplicate detection
+    uint32_t active_job_ids[SV2_MAX_ACTIVE_JOB_IDS];
+    int active_job_ids_count;
 } sv2_conn_t;
 
 // --- Frame encode/decode ---

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -169,6 +169,7 @@ typedef struct
     bool new_set_mining_difficulty_msg;
     uint32_t version_mask;
     bool new_stratum_version_rolling_msg;
+    bool reset_extranonce2;
 
     esp_transport_handle_t transport;
     portMUX_TYPE stratum_mux;

--- a/main/tasks/create_jobs_task.c
+++ b/main/tasks/create_jobs_task.c
@@ -63,6 +63,12 @@ void create_jobs_task(void *pvParameters)
     ESP_LOGI(TAG, "ASIC Ready!");
 
     while (1) {
+        if (GLOBAL_STATE->reset_extranonce2) {
+            ESP_LOGI(TAG, "Resetting extranonce2 to 0 due to set_extranonce request");
+            extranonce_2 = 0;
+            GLOBAL_STATE->reset_extranonce2 = false;
+        }
+
         // Read protocol dynamically each iteration (coordinator may have switched it)
         stratum_protocol_t active_protocol = GLOBAL_STATE->stratum_protocol;
 

--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -41,8 +41,40 @@
 #define TRANSPORT_TIMEOUT_MS 5000
 
 #define BUFFER_SIZE 1024
+#define MAX_ACTIVE_JOB_IDS 16
 
 static const char *TAG = "stratum_v1_task";
+
+static bool add_active_job_id(char **active_job_ids, int *count, const char *job_id)
+{
+    for (int i = 0; i < *count; i++) {
+        if (active_job_ids[i] && strcmp(active_job_ids[i], job_id) == 0) {
+            return false;
+        }
+    }
+    if (*count < MAX_ACTIVE_JOB_IDS) {
+        active_job_ids[*count] = strdup(job_id);
+        if (active_job_ids[*count]) {
+            (*count)++;
+        }
+    } else {
+        free(active_job_ids[0]);
+        for (int i = 1; i < MAX_ACTIVE_JOB_IDS; i++) {
+            active_job_ids[i - 1] = active_job_ids[i];
+        }
+        active_job_ids[MAX_ACTIVE_JOB_IDS - 1] = strdup(job_id);
+    }
+    return true;
+}
+
+static void clear_active_job_ids(char **active_job_ids, int *count)
+{
+    for (int i = 0; i < *count; i++) {
+        free(active_job_ids[i]);
+        active_job_ids[i] = NULL;
+    }
+    *count = 0;
+}
 
 static StratumApiV1Message stratum_api_v1_message = {};
 
@@ -182,11 +214,15 @@ void stratum_v1_task(void *pvParameters)
     int retry_attempts = 0;
     int retry_critical_attempts = 0;
 
+    char *active_job_ids[MAX_ACTIVE_JOB_IDS] = {0};
+    int active_job_ids_count = 0;
+
     ESP_LOGI(TAG, "Opening connection to pool: %s:%d", stratum_url, port);
     while (1) {
         // Check if coordinator wants us to shut down
         if (protocol_coordinator_v1_should_shutdown()) {
             ESP_LOGI(TAG, "Coordinator requested shutdown, exiting");
+            clear_active_job_ids(active_job_ids, &active_job_ids_count);
             protocol_coordinator_v1_exited();
             vTaskDelete(NULL);
         }
@@ -209,6 +245,7 @@ void stratum_v1_task(void *pvParameters)
             // recovery — see protocol_coordinator.c.
             ESP_LOGW(TAG, "Max V1 retry attempts reached (%d), notifying coordinator", retry_attempts);
             stratum_v1_close_connection(GLOBAL_STATE);
+            clear_active_job_ids(active_job_ids, &active_job_ids_count);
             protocol_coordinator_notify_failure();
             vTaskDelete(NULL);
             return;
@@ -216,6 +253,8 @@ void stratum_v1_task(void *pvParameters)
 
         stratum_url = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_url : GLOBAL_STATE->SYSTEM_MODULE.pool_url;
         port = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_port : GLOBAL_STATE->SYSTEM_MODULE.pool_port;
+
+        clear_active_job_ids(active_job_ids, &active_job_ids_count);
 
         stratum_connection_info_t conn_info;
         if (stratum_socket_resolve(stratum_url, port, &conn_info) != ESP_OK) {
@@ -303,6 +342,7 @@ void stratum_v1_task(void *pvParameters)
             if (protocol_coordinator_v1_should_shutdown()) {
                 ESP_LOGI(TAG, "Coordinator requested shutdown during recv loop, exiting");
                 stratum_v1_close_connection(GLOBAL_STATE);
+                clear_active_job_ids(active_job_ids, &active_job_ids_count);
                 protocol_coordinator_v1_exited();
                 vTaskDelete(NULL);
             }
@@ -340,19 +380,34 @@ void stratum_v1_task(void *pvParameters)
                     break;
 
                 case MINING_NOTIFY:
-                    GLOBAL_STATE->SYSTEM_MODULE.work_received++;
-                    SYSTEM_notify_new_ntime(GLOBAL_STATE, stratum_api_v1_message.mining_notification->ntime);
-                    if (stratum_api_v1_message.mining_notification->clean_jobs &&
-                        (GLOBAL_STATE->stratum_queue.count > 0)) {
-                        SYSTEM_clean_jobs_queue(GLOBAL_STATE);
+                    {
+                        mining_notify *notify = stratum_api_v1_message.mining_notification;
+                        bool is_duplicate = false;
+                        if (notify && notify->job_id) {
+                            if (notify->clean_jobs) {
+                                clear_active_job_ids(active_job_ids, &active_job_ids_count);
+                            }
+                            is_duplicate = !add_active_job_id(active_job_ids, &active_job_ids_count, notify->job_id);
+                        }
+
+                        if (is_duplicate) {
+                            ESP_LOGW(TAG, "Ignoring duplicate notify for job %s", notify ? notify->job_id : "unknown");
+                        } else {
+                            GLOBAL_STATE->SYSTEM_MODULE.work_received++;
+                            SYSTEM_notify_new_ntime(GLOBAL_STATE, stratum_api_v1_message.mining_notification->ntime);
+                            if (stratum_api_v1_message.mining_notification->clean_jobs &&
+                                (GLOBAL_STATE->stratum_queue.count > 0)) {
+                                SYSTEM_clean_jobs_queue(GLOBAL_STATE);
+                            }
+                            if (GLOBAL_STATE->stratum_queue.count == QUEUE_SIZE) {
+                                mining_notify *next_notify_json_str = (mining_notify *) queue_dequeue(&GLOBAL_STATE->stratum_queue);
+                                STRATUM_V1_free_mining_notify(next_notify_json_str);
+                            }
+                            queue_enqueue(&GLOBAL_STATE->stratum_queue, stratum_api_v1_message.mining_notification);
+                            decode_mining_notification(GLOBAL_STATE, stratum_api_v1_message.mining_notification);
+                            stratum_api_v1_message.mining_notification = NULL;
+                        }
                     }
-                    if (GLOBAL_STATE->stratum_queue.count == QUEUE_SIZE) {
-                        mining_notify *next_notify_json_str = (mining_notify *) queue_dequeue(&GLOBAL_STATE->stratum_queue);
-                        STRATUM_V1_free_mining_notify(next_notify_json_str);
-                    }
-                    queue_enqueue(&GLOBAL_STATE->stratum_queue, stratum_api_v1_message.mining_notification);
-                    decode_mining_notification(GLOBAL_STATE, stratum_api_v1_message.mining_notification);
-                    stratum_api_v1_message.mining_notification = NULL;
                     break;
 
                 case MINING_SET_DIFFICULTY:
@@ -393,6 +448,7 @@ void stratum_v1_task(void *pvParameters)
                         stratum_api_v1_message.extranonce_str = NULL;
                         GLOBAL_STATE->extranonce_2_len = stratum_api_v1_message.extranonce_2_len;
                         free(old_extranonce_str);
+                        GLOBAL_STATE->reset_extranonce2 = true;
                     }
                     break;
 
@@ -411,7 +467,8 @@ void stratum_v1_task(void *pvParameters)
 
                 case CLIENT_GET_VERSION:
                     STRATUM_V1_send_version(GLOBAL_STATE->transport, stratum_api_v1_message.message_id);
-                    break;                case STRATUM_RESULT:
+                    break;
+                case STRATUM_RESULT:
                     {
                         float response_time_ms = STRATUM_V1_get_response_time_ms(stratum_api_v1_message.message_id, receive_time_us);
                         if (response_time_ms >= 0) {
@@ -455,5 +512,6 @@ void stratum_v1_task(void *pvParameters)
             }
         }
     }
+    clear_active_job_ids(active_job_ids, &active_job_ids_count);
     vTaskDelete(NULL);
 }

--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -93,6 +93,31 @@ static sv2_channel_type_t sv2_select_channel_type(GlobalState *GLOBAL_STATE, boo
     return type;
 }
 
+static bool add_active_job_id(uint32_t *active_job_ids, int *count, uint32_t job_id)
+{
+    for (int i = 0; i < *count; i++) {
+        if (active_job_ids[i] == job_id) {
+            return false;
+        }
+    }
+    if (*count < SV2_MAX_ACTIVE_JOB_IDS) {
+        active_job_ids[*count] = job_id;
+        (*count)++;
+    } else {
+        for (int i = 1; i < SV2_MAX_ACTIVE_JOB_IDS; i++) {
+            active_job_ids[i - 1] = active_job_ids[i];
+        }
+        active_job_ids[SV2_MAX_ACTIVE_JOB_IDS - 1] = job_id;
+    }
+    return true;
+}
+
+static void clear_active_job_ids(uint32_t *active_job_ids, int *count)
+{
+    memset(active_job_ids, 0, sizeof(uint32_t) * SV2_MAX_ACTIVE_JOB_IDS);
+    *count = 0;
+}
+
 void stratum_v2_close_connection(GlobalState *GLOBAL_STATE)
 {
     ESP_LOGE(TAG, "Shutting down SV2 connection and restarting...");
@@ -172,12 +197,20 @@ bool stratum_v2_is_extended_channel(GlobalState *GLOBAL_STATE)
            GLOBAL_STATE->sv2_conn->channel_type == SV2_CHANNEL_EXTENDED;
 }
 
-// Enqueue an sv2_job_t onto the stratum queue
 static void stratum_v2_enqueue_job(GlobalState *GLOBAL_STATE, sv2_conn_t *conn,
                                    uint32_t job_id, uint32_t version,
                                    const uint8_t merkle_root[32], const uint8_t prev_hash[32],
                                    uint32_t ntime, uint32_t nbits, bool clean_jobs)
 {
+    if (clean_jobs) {
+        clear_active_job_ids(conn->active_job_ids, &conn->active_job_ids_count);
+    }
+
+    if (!add_active_job_id(conn->active_job_ids, &conn->active_job_ids_count, job_id)) {
+        ESP_LOGW(TAG, "Ignoring duplicate V2 standard job %lu", job_id);
+        return;
+    }
+
     sv2_job_t *job = malloc(sizeof(sv2_job_t));
     if (!job) {
         ESP_LOGE(TAG, "Failed to allocate sv2_job_t");
@@ -212,6 +245,16 @@ static void stratum_v2_enqueue_job(GlobalState *GLOBAL_STATE, sv2_conn_t *conn,
 static void stratum_v2_enqueue_ext_job(GlobalState *GLOBAL_STATE, sv2_conn_t *conn,
                                         sv2_ext_job_t *job)
 {
+    if (job->clean_jobs) {
+        clear_active_job_ids(conn->active_job_ids, &conn->active_job_ids_count);
+    }
+
+    if (!add_active_job_id(conn->active_job_ids, &conn->active_job_ids_count, job->job_id)) {
+        ESP_LOGW(TAG, "Ignoring duplicate V2 extended job %lu", job->job_id);
+        sv2_ext_job_free(job);
+        return;
+    }
+
     GLOBAL_STATE->SYSTEM_MODULE.work_received++;
 
     SYSTEM_notify_new_ntime(GLOBAL_STATE, job->ntime);
@@ -863,6 +906,7 @@ void stratum_v2_task(void *pvParameters)
                 conn->extranonce_size = (uint8_t)extranonce_size;
                 conn->extranonce_prefix_len = extranonce_prefix_len;
                 memcpy(conn->extranonce_prefix, extranonce_prefix, extranonce_prefix_len);
+                GLOBAL_STATE->reset_extranonce2 = true;
 
                 ESP_LOGI(TAG, "Extended channel: extranonce_size=%d, prefix_len=%d",
                          extranonce_size, extranonce_prefix_len);


### PR DESCRIPTION
In some cases, a pool can send work that's already on the ASIC. These messages should be ignored.

Also reset `extranonce_2` on `mining.set_extranonce`

Fixes #1587
Replaces #1694