### PR TITLE
fix: disable browser autocomplete for pool password fields

### DIFF
--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -39,7 +39,7 @@
                         [ngClass]="{'pi-eye': !showPassword[pool], 'pi-eye-slash': showPassword[pool]}"
                         (click)="showPassword[pool] = !showPassword[pool]"></i>
                         <input pInputText [id]="pool + 'Password'" [formControlName]="pool + 'Password'"
-                            [type]="showPassword[pool] ? 'text' : 'password'" />
+                            [type]="showPassword[pool] ? 'text' : 'password'" autocomplete="off" />
                     </div>
                 </div>
 


### PR DESCRIPTION
- Added `autocomplete="off"` to pool password inputs in `pool.component.html`

fixes #1727 