### PR TITLE
Improve factory self-test validation and thermal control

### DIFF
--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -12,6 +12,7 @@
 #define PREAMBLE 0xAA55
 
 static const char * TAG = "common";
+static char asic_chain_error[96];
 
 static void format_asic_indices(char *buffer, size_t buffer_size, int first_index, int end_index)
 {
@@ -26,6 +27,16 @@ static void format_asic_indices(char *buffer, size_t buffer_size, int first_inde
 
         offset += written;
     }
+}
+
+void clear_asic_chain_error(void)
+{
+    asic_chain_error[0] = '\0';
+}
+
+const char *get_asic_chain_error(void)
+{
+    return asic_chain_error[0] == '\0' ? NULL : asic_chain_error;
 }
 
 unsigned char _reverse_bits(unsigned char num)
@@ -71,6 +82,8 @@ int _next_power_of_two(int num)
 int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response_length)
 {
     uint8_t buffer[11] = {0};
+
+    clear_asic_chain_error();
 
     int chip_counter = 0;
     while (true) {
@@ -119,11 +132,12 @@ int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response
         char asic_indices[64];
         if (chip_counter < asic_count) {
             format_asic_indices(asic_indices, sizeof(asic_indices), chip_counter, asic_count);
-            ESP_LOGE(TAG, "ASIC %s not found", asic_indices);
+            snprintf(asic_chain_error, sizeof(asic_chain_error), "ASIC %s not found", asic_indices);
         } else {
             format_asic_indices(asic_indices, sizeof(asic_indices), asic_count, chip_counter);
-            ESP_LOGE(TAG, "Unexpected ASIC %s detected", asic_indices);
+            snprintf(asic_chain_error, sizeof(asic_chain_error), "Unexpected ASIC %s detected", asic_indices);
         }
+        ESP_LOGE(TAG, "%s", asic_chain_error);
 
         return 0;
     }

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -98,7 +98,8 @@ int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response
     }    
     
     if (chip_counter != asic_count) {
-        ESP_LOGW(TAG, "%i chip(s) detected on the chain, expected %i", chip_counter, asic_count);
+        ESP_LOGE(TAG, "%i chip(s) detected on the chain, expected %i", chip_counter, asic_count);
+        return 0;
     }
 
     return chip_counter;

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <math.h>
+#include <stdio.h>
 
 #include "asic_common.h"
 #include "serial.h"
@@ -11,6 +12,21 @@
 #define PREAMBLE 0xAA55
 
 static const char * TAG = "common";
+
+static void format_asic_indices(char *buffer, size_t buffer_size, int first_index, int end_index)
+{
+    size_t offset = 0;
+
+    for (int index = first_index; index < end_index; index++) {
+        int written = snprintf(buffer + offset, buffer_size - offset, "%s%d", index == first_index ? "" : ",", index);
+        if (written < 0 || (size_t) written >= buffer_size - offset) {
+            snprintf(buffer, buffer_size, "%d-%d", first_index, end_index - 1);
+            return;
+        }
+
+        offset += written;
+    }
+}
 
 unsigned char _reverse_bits(unsigned char num)
 {
@@ -99,6 +115,16 @@ int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response
     
     if (chip_counter != asic_count) {
         ESP_LOGE(TAG, "%i chip(s) detected on the chain, expected %i", chip_counter, asic_count);
+
+        char asic_indices[64];
+        if (chip_counter < asic_count) {
+            format_asic_indices(asic_indices, sizeof(asic_indices), chip_counter, asic_count);
+            ESP_LOGE(TAG, "ASIC %s not found", asic_indices);
+        } else {
+            format_asic_indices(asic_indices, sizeof(asic_indices), asic_count, chip_counter);
+            ESP_LOGE(TAG, "Unexpected ASIC %s detected", asic_indices);
+        }
+
         return 0;
     }
 

--- a/components/asic/include/asic_common.h
+++ b/components/asic/include/asic_common.h
@@ -39,6 +39,8 @@ typedef struct
 unsigned char _reverse_bits(unsigned char num);
 int _largest_power_of_two(int num);
 int _next_power_of_two(int num);
+void clear_asic_chain_error(void);
+const char *get_asic_chain_error(void);
 int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response_length);
 esp_err_t receive_work(uint8_t * buffer, int buffer_size, uint64_t *out_timestamp_us);
 void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask);

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -109,7 +109,7 @@ typedef struct
     char firmware_update_status[20];
     bool hardware_fault;
     char hardware_fault_msg[64];
-    char * asic_status;
+    const char * asic_status;
     char * version;
     char * axeOSVersion;
     Scoreboard scoreboard;
@@ -129,7 +129,7 @@ typedef struct
     bool is_active;
     bool is_finished;
     SelfTestNonceMeasurement nonce_measurement;
-    char *message;
+    const char *message;
     char *result;
     char *finished;
     esp_err_t system_init_ret;

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -118,7 +118,17 @@ typedef struct
 typedef struct
 {
     bool is_active;
+    uint64_t accepted_count;
+    uint64_t rejected_count;
+    double hashes;
+    pthread_mutex_t lock;
+} SelfTestNonceMeasurement;
+
+typedef struct
+{
+    bool is_active;
     bool is_finished;
+    SelfTestNonceMeasurement nonce_measurement;
     char *message;
     char *result;
     char *finished;

--- a/main/main.c
+++ b/main/main.c
@@ -144,7 +144,7 @@ void app_main(void)
                 return;
             }
 
-            self_test_show_message(&GLOBAL_STATE, "ASIC COUNT:FAIL");
+            self_test_show_message(&GLOBAL_STATE, GLOBAL_STATE.SYSTEM_MODULE.asic_status);
             system_init_ret = ESP_FAIL;
         } else {
             if (xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 20, NULL) != pdPASS) {

--- a/main/main.c
+++ b/main/main.c
@@ -140,21 +140,26 @@ void app_main(void)
 
     if (system_init_ret == ESP_OK) {
         if (asic_initialize(&GLOBAL_STATE, ASIC_INIT_COLD_BOOT, 0) == 0) {
-            return;
-        }
+            if (!GLOBAL_STATE.SELF_TEST_MODULE.is_active) {
+                return;
+            }
 
-        if (xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 20, NULL) != pdPASS) {
-            ESP_LOGE(TAG, "Error creating stratum miner task");
-        }
-        if (xTaskCreate(ASIC_result_task, "asic result", 8192, (void *) &GLOBAL_STATE, 15, NULL) != pdPASS) {
-            ESP_LOGE(TAG, "Error creating asic result task");
-        }
+            self_test_show_message(&GLOBAL_STATE, "ASIC COUNT:FAIL");
+            system_init_ret = ESP_FAIL;
+        } else {
+            if (xTaskCreate(create_jobs_task, "stratum miner", 8192, (void *) &GLOBAL_STATE, 20, NULL) != pdPASS) {
+                ESP_LOGE(TAG, "Error creating stratum miner task");
+            }
+            if (xTaskCreate(ASIC_result_task, "asic result", 8192, (void *) &GLOBAL_STATE, 15, NULL) != pdPASS) {
+                ESP_LOGE(TAG, "Error creating asic result task");
+            }
 
-        if (xTaskCreateWithCaps(hashrate_monitor_task, "hashrate monitor", 8192, (void *) &GLOBAL_STATE, 5, NULL, MALLOC_CAP_SPIRAM) != pdPASS) {
-            ESP_LOGE(TAG, "Error creating hashrate monitor task");
-        }
-        if (xTaskCreateWithCaps(statistics_task, "statistics", 8192, (void *) &GLOBAL_STATE, 3, NULL, MALLOC_CAP_SPIRAM) != pdPASS) {
-            ESP_LOGE(TAG, "Error creating statistics task");
+            if (xTaskCreateWithCaps(hashrate_monitor_task, "hashrate monitor", 8192, (void *) &GLOBAL_STATE, 5, NULL, MALLOC_CAP_SPIRAM) != pdPASS) {
+                ESP_LOGE(TAG, "Error creating hashrate monitor task");
+            }
+            if (xTaskCreateWithCaps(statistics_task, "statistics", 8192, (void *) &GLOBAL_STATE, 3, NULL, MALLOC_CAP_SPIRAM) != pdPASS) {
+                ESP_LOGE(TAG, "Error creating statistics task");
+            }
         }
     }
 

--- a/main/power/asic_init.c
+++ b/main/power/asic_init.c
@@ -46,8 +46,8 @@ uint8_t asic_initialize(GlobalState *GLOBAL_STATE, asic_init_mode_t mode, uint32
     uint8_t chip_count = ASIC_init(GLOBAL_STATE);
     
     if (chip_count == 0) {
-        ESP_LOGE(TAG, "ASIC initialization failed - chip count 0");
-        GLOBAL_STATE->SYSTEM_MODULE.asic_status = "Chip count 0";
+        ESP_LOGE(TAG, "ASIC initialization failed - chip chain detection failed");
+        GLOBAL_STATE->SYSTEM_MODULE.asic_status = "ASIC chain detection failed";
         return 0;
     }
 

--- a/main/power/asic_init.c
+++ b/main/power/asic_init.c
@@ -3,6 +3,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "asic.h"
+#include "asic_common.h"
 #include "serial.h"
 #include "asic_reset.h"
 
@@ -43,11 +44,13 @@ uint8_t asic_initialize(GlobalState *GLOBAL_STATE, asic_init_mode_t mode, uint32
     }
 
     ESP_LOGI(TAG, "Detecting ASIC chips...");
+    clear_asic_chain_error();
     uint8_t chip_count = ASIC_init(GLOBAL_STATE);
     
     if (chip_count == 0) {
+        const char *chain_error = get_asic_chain_error();
         ESP_LOGE(TAG, "ASIC initialization failed - chip chain detection failed");
-        GLOBAL_STATE->SYSTEM_MODULE.asic_status = "ASIC chain detection failed";
+        GLOBAL_STATE->SYSTEM_MODULE.asic_status = chain_error != NULL ? chain_error : "ASIC chain detection failed";
         return 0;
     }
 

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -636,8 +636,8 @@ void self_test_task(void * pvParameters)
             const SelfTestDomainAverage * domain_average = self_test_domain_get_const(&domain_averages, asic_nr, domain_nr);
             float domain_hashrate = self_test_domain_average_hashrate(domain_average);
             uint32_t sample_count = domain_average->sample_count;
-            uint32_t rejected_count = domain_average->rejected_sample_count;
-            uint32_t total_domain_samples = sample_count + rejected_count;
+            uint32_t rejected_sample_count = domain_average->rejected_sample_count;
+            uint32_t total_domain_samples = sample_count + rejected_sample_count;
             SelfTestDomainStatus domain_status = SELF_TEST_DOMAIN_OK;
 
             ESP_LOGI(TAG,
@@ -646,32 +646,32 @@ void self_test_task(void * pvParameters)
                      domain_nr,
                      domain_hashrate,
                      (unsigned long)sample_count,
-                     (unsigned long)rejected_count);
-            if (rejected_count > 0) {
+                     (unsigned long)rejected_sample_count);
+            if (rejected_sample_count > 0) {
                 ESP_LOGW(TAG,
                          "ASIC %d Domain %d ignored %lu implausible register sample(s); using nonce hashrate for total validation",
                          asic_nr,
                          domain_nr,
-                         (unsigned long)rejected_count);
+                         (unsigned long)rejected_sample_count);
             }
             
             float min_domain_hashrate = expected_domain_hashrate * (1.0f - SELF_TEST_DOMAIN_HASHRATE_TOLERANCE);
             float max_domain_hashrate = expected_domain_hashrate * (1.0f + SELF_TEST_DOMAIN_HASHRATE_TOLERANCE);
-            if (sample_count == 0 && rejected_count > 0) {
+            if (sample_count == 0 && rejected_sample_count > 0) {
                 domain_status = SELF_TEST_DOMAIN_UNRELIABLE;
                 ESP_LOGW(TAG,
                          "ASIC %d Domain %d self-reported counter is unreliable; all %lu sample(s) were implausible high, external nonce hashrate remains authoritative",
                          asic_nr,
                          domain_nr,
-                         (unsigned long)rejected_count);
+                         (unsigned long)rejected_sample_count);
             } else if (total_domain_samples > 0 &&
-                       ((float)rejected_count / (float)total_domain_samples) >= SELF_TEST_DOMAIN_REJECTED_WARN_RATIO) {
+                       ((float)rejected_sample_count / (float)total_domain_samples) >= SELF_TEST_DOMAIN_REJECTED_WARN_RATIO) {
                 domain_status = SELF_TEST_DOMAIN_UNRELIABLE;
                 ESP_LOGW(TAG,
                          "ASIC %d Domain %d self-reported counter is unstable; %lu/%lu sample(s) were implausible, external nonce hashrate remains authoritative",
                          asic_nr,
                          domain_nr,
-                         (unsigned long)rejected_count,
+                         (unsigned long)rejected_sample_count,
                          (unsigned long)total_domain_samples);
             } else if (sample_count == 0 || domain_hashrate < min_domain_hashrate || domain_hashrate > max_domain_hashrate) {
                 domain_status = SELF_TEST_DOMAIN_FAIL;

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -341,7 +341,7 @@ void self_test_reset()
     }
 }
 
-void self_test_show_message(void * pvParameters, char * msg)
+void self_test_show_message(void * pvParameters, const char * msg)
 {
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
     

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -1,4 +1,7 @@
 #include <string.h>
+#include <stdlib.h>
+#include <math.h>
+#include <inttypes.h>
 #include "driver/gpio.h"
 #include "esp_log.h"
 #include "esp_timer.h"
@@ -13,16 +16,27 @@
 #include "asic_reset.h"
 #include "device_config.h"
 #include "hashrate_monitor_task.h"
+#include "PID.h"
+#include "self_test.h"
 
 #define GPIO_ASIC_ENABLE CONFIG_GPIO_ASIC_ENABLE
 
 /////Test Constants/////
 // Test Fan Speed
 #define FAN_SPEED_TARGET_MIN 1000 // RPM
+#define SELF_TEST_WARMUP_TEMP_C 55.0f
+#define SELF_TEST_TARGET_TEMP_C 65.0f
+#define SELF_TEST_MAX_TEMP_C 70.0f
+#define SELF_TEST_MIN_FAN_PERCENT 10.0f
+#define SELF_TEST_MAX_FAN_PERCENT 100.0f
+#define SELF_TEST_PID_SAMPLE_TIME_MS 100
+#define SELF_TEST_PID_P 5.0f
+#define SELF_TEST_PID_I 0.1f
+#define SELF_TEST_PID_D 2.0f
+#define SELF_TEST_DOMAIN_HASHRATE_TOLERANCE 0.33f
+#define SELF_TEST_DOMAIN_REJECTED_WARN_RATIO 0.25f
 
-// Test Core Voltage
-#define CORE_VOLTAGE_TARGET_MIN 1000 // mV
-#define CORE_VOLTAGE_TARGET_MAX 1300 // mV
+#define SELF_TEST_CORE_VOLTAGE_TOLERANCE 0.10f
 
 // Test Power Consumption
 #define POWER_CONSUMPTION_MARGIN 3 //+/- watts
@@ -40,6 +54,236 @@ static bool isFactoryTest = false;
 
 // local function prototypes
 static void tests_done(GlobalState * GLOBAL_STATE, bool test_result);
+
+typedef struct {
+    float hashrate_sum;
+    uint32_t sample_count;
+    uint32_t rejected_sample_count;
+    uint64_t last_sample_time_us;
+} SelfTestDomainAverage;
+
+typedef struct {
+    int asic_count;
+    int hash_domains;
+    SelfTestDomainAverage *domains;
+} SelfTestDomainAverages;
+
+typedef enum {
+    SELF_TEST_DOMAIN_OK,
+    SELF_TEST_DOMAIN_FAIL,
+    SELF_TEST_DOMAIN_UNRELIABLE,
+} SelfTestDomainStatus;
+
+static size_t self_test_domain_index(const SelfTestDomainAverages * averages, int asic_nr, int domain_nr)
+{
+    return (size_t)asic_nr * averages->hash_domains + domain_nr;
+}
+
+static SelfTestDomainAverage * self_test_domain_get(SelfTestDomainAverages * averages, int asic_nr, int domain_nr)
+{
+    return &averages->domains[self_test_domain_index(averages, asic_nr, domain_nr)];
+}
+
+static esp_err_t self_test_domain_averages_init(SelfTestDomainAverages * averages, int asic_count, int hash_domains)
+{
+    memset(averages, 0, sizeof(*averages));
+    averages->asic_count = asic_count;
+    averages->hash_domains = hash_domains;
+
+    size_t domain_count = (size_t)asic_count * hash_domains;
+    averages->domains = calloc(domain_count, sizeof(*averages->domains));
+    if (!averages->domains) {
+        memset(averages, 0, sizeof(*averages));
+        return ESP_ERR_NO_MEM;
+    }
+
+    return ESP_OK;
+}
+
+static void self_test_domain_averages_free(SelfTestDomainAverages * averages)
+{
+    free(averages->domains);
+    memset(averages, 0, sizeof(*averages));
+}
+
+static void self_test_domain_averages_prime(GlobalState * GLOBAL_STATE, SelfTestDomainAverages * averages)
+{
+    HashrateMonitorModule * monitor = &GLOBAL_STATE->HASHRATE_MONITOR_MODULE;
+    if (!monitor->is_initialized || !averages->domains) {
+        return;
+    }
+
+    pthread_mutex_lock(&monitor->lock);
+    for (int asic_nr = 0; asic_nr < averages->asic_count; asic_nr++) {
+        for (int domain_nr = 0; domain_nr < averages->hash_domains; domain_nr++) {
+            SelfTestDomainAverage * average = self_test_domain_get(averages, asic_nr, domain_nr);
+            average->last_sample_time_us = monitor->domain_measurements[asic_nr][domain_nr].time_us;
+        }
+    }
+    pthread_mutex_unlock(&monitor->lock);
+}
+
+static void self_test_domain_averages_sample(GlobalState * GLOBAL_STATE,
+                                             SelfTestDomainAverages * averages,
+                                             float expected_domain_hashrate)
+{
+    HashrateMonitorModule * monitor = &GLOBAL_STATE->HASHRATE_MONITOR_MODULE;
+    if (!monitor->is_initialized || !averages->domains) {
+        return;
+    }
+
+    float max_plausible_hashrate = expected_domain_hashrate * 3.0f;
+
+    pthread_mutex_lock(&monitor->lock);
+    for (int asic_nr = 0; asic_nr < averages->asic_count; asic_nr++) {
+        for (int domain_nr = 0; domain_nr < averages->hash_domains; domain_nr++) {
+            measurement_t measurement = monitor->domain_measurements[asic_nr][domain_nr];
+            SelfTestDomainAverage * average = self_test_domain_get(averages, asic_nr, domain_nr);
+
+            if (measurement.time_us == 0 || measurement.time_us == average->last_sample_time_us) {
+                continue;
+            }
+
+            if (average->last_sample_time_us == 0) {
+                average->last_sample_time_us = measurement.time_us;
+                continue;
+            }
+            average->last_sample_time_us = measurement.time_us;
+
+            bool rejected = !isfinite(measurement.hashrate) || measurement.hashrate > max_plausible_hashrate;
+
+            if (rejected) {
+                average->rejected_sample_count++;
+                continue;
+            }
+
+            average->hashrate_sum += measurement.hashrate;
+            average->sample_count++;
+        }
+    }
+    pthread_mutex_unlock(&monitor->lock);
+}
+
+static const SelfTestDomainAverage * self_test_domain_get_const(const SelfTestDomainAverages * averages, int asic_nr, int domain_nr)
+{
+    return &averages->domains[self_test_domain_index(averages, asic_nr, domain_nr)];
+}
+
+static float self_test_domain_average_hashrate(const SelfTestDomainAverage * average)
+{
+    return average->sample_count > 0 ? average->hashrate_sum / average->sample_count : 0.0f;
+}
+
+static void self_test_set_fan_percent(GlobalState * GLOBAL_STATE, float fan_percent)
+{
+    if (fan_percent > SELF_TEST_MAX_FAN_PERCENT) fan_percent = SELF_TEST_MAX_FAN_PERCENT;
+    if (fan_percent < 0.0f) fan_percent = 0.0f;
+
+    GLOBAL_STATE->POWER_MANAGEMENT_MODULE.fan_perc = fan_percent;
+    if (Thermal_set_fan_percent(&GLOBAL_STATE->DEVICE_CONFIG, fan_percent / 100.0f) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set fan speed to %.1f%%", fan_percent);
+        self_test_show_message(GLOBAL_STATE, "FAN:FAIL");
+        tests_done(GLOBAL_STATE, false);
+    }
+}
+
+static bool self_test_temp_invalid(float temp)
+{
+    return !isfinite(temp) || temp == -1.0f || temp == 127.0f;
+}
+
+static float self_test_get_control_temp(GlobalState * GLOBAL_STATE)
+{
+    float temp = Thermal_get_chip_temp(GLOBAL_STATE);
+    float temp2 = Thermal_get_chip_temp2(GLOBAL_STATE);
+
+    if (self_test_temp_invalid(temp)) {
+        return temp2;
+    }
+
+    if (!self_test_temp_invalid(temp2) && temp2 > temp) {
+        return temp2;
+    }
+
+    return temp;
+}
+
+static float self_test_get_valid_control_temp(GlobalState * GLOBAL_STATE)
+{
+    float temp = self_test_get_control_temp(GLOBAL_STATE);
+    if (self_test_temp_invalid(temp)) {
+        ESP_LOGE(TAG, "Open circuit or no result on temperature sensor: %.1f°C", temp);
+        self_test_show_message(GLOBAL_STATE, "TEMP:FAIL");
+        tests_done(GLOBAL_STATE, false);
+    }
+    return temp;
+}
+
+static void self_test_start_nonce_measurement(GlobalState * GLOBAL_STATE)
+{
+    SelfTestNonceMeasurement * measurement = &GLOBAL_STATE->SELF_TEST_MODULE.nonce_measurement;
+
+    pthread_mutex_lock(&measurement->lock);
+    measurement->accepted_count = 0;
+    measurement->rejected_count = 0;
+    measurement->hashes = 0.0;
+    measurement->is_active = true;
+    pthread_mutex_unlock(&measurement->lock);
+}
+
+static void self_test_stop_nonce_measurement(GlobalState * GLOBAL_STATE)
+{
+    SelfTestNonceMeasurement * measurement = &GLOBAL_STATE->SELF_TEST_MODULE.nonce_measurement;
+
+    pthread_mutex_lock(&measurement->lock);
+    measurement->is_active = false;
+    pthread_mutex_unlock(&measurement->lock);
+}
+
+static void self_test_get_nonce_measurement(GlobalState * GLOBAL_STATE,
+                                            uint64_t * accepted_count,
+                                            uint64_t * rejected_count,
+                                            double * hashes)
+{
+    SelfTestNonceMeasurement * measurement = &GLOBAL_STATE->SELF_TEST_MODULE.nonce_measurement;
+
+    pthread_mutex_lock(&measurement->lock);
+    if (accepted_count) *accepted_count = measurement->accepted_count;
+    if (rejected_count) *rejected_count = measurement->rejected_count;
+    if (hashes) *hashes = measurement->hashes;
+    pthread_mutex_unlock(&measurement->lock);
+}
+
+static float self_test_get_nonce_hashrate(GlobalState * GLOBAL_STATE, uint64_t elapsed_us)
+{
+    if (elapsed_us == 0) {
+        return 0.0f;
+    }
+
+    double hashes;
+    self_test_get_nonce_measurement(GLOBAL_STATE, NULL, NULL, &hashes);
+
+    double seconds = elapsed_us / 1000000.0;
+    return (float)(hashes / seconds / 1000000000.0);
+}
+
+void self_test_record_nonce(void * pvParameters, double nonce_diff)
+{
+    GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
+    SelfTestNonceMeasurement * measurement = &GLOBAL_STATE->SELF_TEST_MODULE.nonce_measurement;
+    double ticket_diff = GLOBAL_STATE->DEVICE_CONFIG.family.asic.difficulty;
+
+    pthread_mutex_lock(&measurement->lock);
+    if (measurement->is_active) {
+        if (nonce_diff >= ticket_diff) {
+            measurement->accepted_count++;
+            measurement->hashes += ticket_diff * NONCE_SPACE;
+        } else {
+            measurement->rejected_count++;
+        }
+    }
+    pthread_mutex_unlock(&measurement->lock);
+}
 
 static bool self_test_should_run()
 {
@@ -60,6 +304,7 @@ esp_err_t self_test_init(void * pvParameters)
         GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
         GLOBAL_STATE->SELF_TEST_MODULE.is_active = true;
+        pthread_mutex_init(&GLOBAL_STATE->SELF_TEST_MODULE.nonce_measurement.lock, NULL);
         GLOBAL_STATE->DEVICE_CONFIG.family.asic.difficulty = DIFFICULTY;
         GLOBAL_STATE->SYSTEM_MODULE.is_connected = true;
 
@@ -109,23 +354,14 @@ void self_test_show_message(void * pvParameters, char * msg)
 static esp_err_t test_fan_sense(GlobalState * GLOBAL_STATE)
 {
     uint16_t fan_speed = Thermal_get_fan_speed(&GLOBAL_STATE->DEVICE_CONFIG);
+    uint16_t target_speed = FAN_SPEED_TARGET_MIN;
+
     ESP_LOGI(TAG, "fanSpeed: %d RPM", fan_speed);
-    switch (GLOBAL_STATE->DEVICE_CONFIG.family.id) {
-        case GAMMA:
-            if (fan_speed > 1000) {
-                return ESP_OK;
-            }
-            break;
-        case GAMMA_TURBO:
-            if (fan_speed > 500) {
-                return ESP_OK;
-            }
-            break;
-        default:
-            if (fan_speed > 1000) {
-                return ESP_OK;
-            }
-            break;
+    if (GLOBAL_STATE->DEVICE_CONFIG.family.id == GAMMA_TURBO) {
+        target_speed = 500;
+    }
+    if (fan_speed > target_speed) {
+        return ESP_OK;
     }
 
     // fan test failed
@@ -157,13 +393,15 @@ static esp_err_t test_power_consumption(GlobalState * GLOBAL_STATE)
 static esp_err_t test_core_voltage(GlobalState * GLOBAL_STATE)
 {
     uint16_t core_voltage = VCORE_get_voltage_mv(GLOBAL_STATE);
-    ESP_LOGI(TAG, "Voltage: %u mV", core_voltage);
+    uint16_t target_voltage = GLOBAL_STATE->DEVICE_CONFIG.family.asic.default_voltage_mv;
+    float margin = target_voltage * SELF_TEST_CORE_VOLTAGE_TOLERANCE;
+    ESP_LOGI(TAG, "Core voltage: %u mV (target: %u mV +/- %.0f mV)", core_voltage, target_voltage, margin);
 
-    if (core_voltage > CORE_VOLTAGE_TARGET_MIN && core_voltage < CORE_VOLTAGE_TARGET_MAX) {
+    if (core_voltage >= target_voltage - margin && core_voltage <= target_voltage + margin) {
         return ESP_OK;
     }
-    // tests failed
-    ESP_LOGE(TAG, "Core Voltage TEST FAIL, INCORRECT CORE VOLTAGE");
+
+    ESP_LOGE(TAG, "Core voltage test failed");
     self_test_show_message(GLOBAL_STATE, "VCORE:FAIL");
     return ESP_FAIL;
 }
@@ -303,85 +541,184 @@ void self_test_task(void * pvParameters)
         tests_done(GLOBAL_STATE, false);
     }
 
-    Thermal_set_fan_percent(&GLOBAL_STATE->DEVICE_CONFIG, 1);
+    self_test_set_fan_percent(GLOBAL_STATE, SELF_TEST_MAX_FAN_PERCENT);
 
-    float asic_temp = Thermal_get_chip_temp(GLOBAL_STATE);
+    float asic_temp = self_test_get_valid_control_temp(GLOBAL_STATE);
     ESP_LOGI(TAG, "ASIC Temp %.1f°C", asic_temp);
 
-    // detect open circuit / no result
-    if (asic_temp == -1.0 || asic_temp == 127.0) {
-        ESP_LOGE(TAG, "Open circuit or no result on temperature sensor: %.1f°C", asic_temp);
-        snprintf(logString, sizeof(logString), "TEMP:FAIL: %.1f°C", asic_temp);
-        self_test_show_message(GLOBAL_STATE, logString);
-        tests_done(GLOBAL_STATE, false);
-    }
-
-    Thermal_set_fan_percent(&GLOBAL_STATE->DEVICE_CONFIG, 0.1f);
-    while (asic_temp < 50.0f)
+    self_test_set_fan_percent(GLOBAL_STATE, SELF_TEST_MIN_FAN_PERCENT);
+    while (asic_temp < SELF_TEST_WARMUP_TEMP_C)
     {
         vTaskDelay(500 / portTICK_PERIOD_MS);
-        asic_temp = Thermal_get_chip_temp(GLOBAL_STATE);
-        ESP_LOGI(TAG, "Warming up: %.1f°C", asic_temp);
+        asic_temp = self_test_get_valid_control_temp(GLOBAL_STATE);
+        ESP_LOGI(TAG, "Warming up to %.1f°C: %.1f°C", SELF_TEST_WARMUP_TEMP_C, asic_temp);
         snprintf(logString, sizeof(logString), "ASIC Temp: %.1f°C", asic_temp);
         self_test_show_message(GLOBAL_STATE, logString);
     }
-    Thermal_set_fan_percent(&GLOBAL_STATE->DEVICE_CONFIG, 1.0f);
 
-    uint32_t start_ms = esp_timer_get_time() / 1000;
-    uint32_t hashtest_ms = 30000;
+    PIDController pid = {0};
+    float pid_input = asic_temp;
+    float pid_output = SELF_TEST_MIN_FAN_PERCENT;
+    float pid_setpoint = SELF_TEST_TARGET_TEMP_C;
+    pid_init(&pid, &pid_input, &pid_output, &pid_setpoint,
+             SELF_TEST_PID_P, SELF_TEST_PID_I, SELF_TEST_PID_D, PID_P_ON_E, PID_REVERSE);
+    pid_set_sample_time(&pid, SELF_TEST_PID_SAMPLE_TIME_MS);
+    pid_set_output_limits(&pid, SELF_TEST_MIN_FAN_PERCENT, SELF_TEST_MAX_FAN_PERCENT);
+    pid_set_mode(&pid, AUTOMATIC);
+
+    uint64_t start_us = esp_timer_get_time();
+    uint64_t hashtest_us = 30000000;
     float hashrate = 0;
+    float expected_hashrate = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value *
+                              GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count *
+                              GLOBAL_STATE->DEVICE_CONFIG.family.asic_count / 1000.0f *
+                              GLOBAL_STATE->DEVICE_CONFIG.family.asic.hashrate_test_percentage_target;
+    float expected_domain_hashrate = expected_hashrate /
+                                     GLOBAL_STATE->DEVICE_CONFIG.family.asic.hash_domains /
+                                     GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
 
-    ESP_LOGI(TAG, "Starting 30s hashrate monitoring loop");
-    while ((esp_timer_get_time() / 1000) - start_ms < hashtest_ms) {
-        hashrate = GLOBAL_STATE->SYSTEM_MODULE.current_hashrate;
-        asic_temp = Thermal_get_chip_temp(GLOBAL_STATE);
+    SelfTestDomainAverages domain_averages;
+    if (self_test_domain_averages_init(&domain_averages,
+                                       GLOBAL_STATE->DEVICE_CONFIG.family.asic_count,
+                                       GLOBAL_STATE->DEVICE_CONFIG.family.asic.hash_domains) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to allocate domain hashrate averages");
+        self_test_show_message(GLOBAL_STATE, "MEM:FAIL");
+        tests_done(GLOBAL_STATE, false);
+    }
+    self_test_domain_averages_prime(GLOBAL_STATE, &domain_averages);
+
+    self_test_start_nonce_measurement(GLOBAL_STATE);
+    ESP_LOGI(TAG, "Starting 30s hashrate monitoring loop, target temp %.1f°C", SELF_TEST_TARGET_TEMP_C);
+    while ((esp_timer_get_time() - start_us) < hashtest_us) {
+        uint64_t elapsed_us = esp_timer_get_time() - start_us;
+        hashrate = self_test_get_nonce_hashrate(GLOBAL_STATE, elapsed_us);
+        asic_temp = self_test_get_valid_control_temp(GLOBAL_STATE);
+        pid_input = asic_temp;
+        if (pid_compute(&pid)) {
+            self_test_set_fan_percent(GLOBAL_STATE, pid_output);
+        }
         
-        if (asic_temp > 62) {
+        if (asic_temp > SELF_TEST_MAX_TEMP_C) {
             ESP_LOGE(TAG, "Overheat: %.1f°C", asic_temp);
             snprintf(logString, sizeof(logString), "TEMP:FAIL: %.1f°C", asic_temp);
             self_test_show_message(GLOBAL_STATE, logString);
             tests_done(GLOBAL_STATE, false);
         }
 
-        uint32_t remaining = (hashtest_ms - ((esp_timer_get_time() / 1000) - start_ms)) / 1000;
+        uint32_t remaining = elapsed_us < hashtest_us ? (hashtest_us - elapsed_us) / 1000000 : 0;
         snprintf(logString, sizeof(logString), "%.0f Gh/s %.1f°C %" PRIu32 "s", hashrate, asic_temp, remaining);
         ESP_LOGI(TAG, "%s", logString);
 
         self_test_show_message(GLOBAL_STATE, logString);
 
+        self_test_domain_averages_sample(GLOBAL_STATE, &domain_averages, expected_domain_hashrate);
         vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
+    self_test_stop_nonce_measurement(GLOBAL_STATE);
+    hashrate = self_test_get_nonce_hashrate(GLOBAL_STATE, esp_timer_get_time() - start_us);
+    self_test_domain_averages_sample(GLOBAL_STATE, &domain_averages, expected_domain_hashrate);
 
-    float expected_hashrate_mhs = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value *
-                                  GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count *
-                                  GLOBAL_STATE->DEVICE_CONFIG.family.asic_count / 1000.0f *
-                                  GLOBAL_STATE->DEVICE_CONFIG.family.asic.hashrate_test_percentage_target;
-
-    ESP_LOGI(TAG, "Hashrate: %.2f Gh/s, Expected: %.2f Gh/s", hashrate, expected_hashrate_mhs);
-
-    if (hashrate < expected_hashrate_mhs) {
-        ESP_LOGE(TAG, "Total hashrate too low");
-        self_test_show_message(GLOBAL_STATE, "HASHRATE:FAIL");
-        tests_done(GLOBAL_STATE, false);
-    }
+    uint64_t accepted_count;
+    uint64_t rejected_count;
+    self_test_get_nonce_measurement(GLOBAL_STATE, &accepted_count, &rejected_count, NULL);
+    ESP_LOGI(TAG, "Hashrate: %.2f Gh/s, Expected: %.2f Gh/s", hashrate, expected_hashrate);
+    ESP_LOGI(TAG,
+             "Nonce measurement: %llu valid, %llu rejected",
+             (unsigned long long)accepted_count,
+             (unsigned long long)rejected_count);
 
     // Check domain hashrates from monitor module
-    HashrateMonitorModule * monitor = &GLOBAL_STATE->HASHRATE_MONITOR_MODULE;
+    bool domain_failed = false;
+    uint32_t failed_asic_mask = 0;
     for (int asic_nr = 0; asic_nr < GLOBAL_STATE->DEVICE_CONFIG.family.asic_count; asic_nr++) {
         int hash_domains = GLOBAL_STATE->DEVICE_CONFIG.family.asic.hash_domains;
         for (int domain_nr = 0; domain_nr < hash_domains; domain_nr++) {
-            float domain_hashrate = monitor->domain_measurements[asic_nr][domain_nr].hashrate;
-            ESP_LOGI(TAG, "ASIC %d Domain %d Hashrate: %.2f Gh/s", asic_nr, domain_nr, domain_hashrate);
+            const SelfTestDomainAverage * domain_average = self_test_domain_get_const(&domain_averages, asic_nr, domain_nr);
+            float domain_hashrate = self_test_domain_average_hashrate(domain_average);
+            uint32_t sample_count = domain_average->sample_count;
+            uint32_t rejected_count = domain_average->rejected_sample_count;
+            uint32_t total_domain_samples = sample_count + rejected_count;
+            SelfTestDomainStatus domain_status = SELF_TEST_DOMAIN_OK;
+
+            ESP_LOGI(TAG,
+                     "ASIC %d Domain %d Average Hashrate: %.2f Gh/s (%lu samples, %lu rejected)",
+                     asic_nr,
+                     domain_nr,
+                     domain_hashrate,
+                     (unsigned long)sample_count,
+                     (unsigned long)rejected_count);
+            if (rejected_count > 0) {
+                ESP_LOGW(TAG,
+                         "ASIC %d Domain %d ignored %lu implausible register sample(s); using nonce hashrate for total validation",
+                         asic_nr,
+                         domain_nr,
+                         (unsigned long)rejected_count);
+            }
             
-            float expected_domain_hashrate = expected_hashrate_mhs / hash_domains / GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
-            if(domain_hashrate < expected_domain_hashrate / 3 || domain_hashrate > expected_domain_hashrate * 3) {
-                ESP_LOGE(TAG, "ASIC %d Domain %d:FAIL - hashrate %.2f Gh/s, expected ~%.2f Gh/s", asic_nr, domain_nr, domain_hashrate, expected_domain_hashrate);
-                char error_buf[30];
-                snprintf(error_buf, 30, "ASIC %d DOMAIN %d:FAIL", asic_nr, domain_nr);
-                self_test_show_message(GLOBAL_STATE, error_buf);
-                tests_done(GLOBAL_STATE, false);
+            float min_domain_hashrate = expected_domain_hashrate * (1.0f - SELF_TEST_DOMAIN_HASHRATE_TOLERANCE);
+            float max_domain_hashrate = expected_domain_hashrate * (1.0f + SELF_TEST_DOMAIN_HASHRATE_TOLERANCE);
+            if (sample_count == 0 && rejected_count > 0) {
+                domain_status = SELF_TEST_DOMAIN_UNRELIABLE;
+                ESP_LOGW(TAG,
+                         "ASIC %d Domain %d self-reported counter is unreliable; all %lu sample(s) were implausible high, external nonce hashrate remains authoritative",
+                         asic_nr,
+                         domain_nr,
+                         (unsigned long)rejected_count);
+            } else if (total_domain_samples > 0 &&
+                       ((float)rejected_count / (float)total_domain_samples) >= SELF_TEST_DOMAIN_REJECTED_WARN_RATIO) {
+                domain_status = SELF_TEST_DOMAIN_UNRELIABLE;
+                ESP_LOGW(TAG,
+                         "ASIC %d Domain %d self-reported counter is unstable; %lu/%lu sample(s) were implausible, external nonce hashrate remains authoritative",
+                         asic_nr,
+                         domain_nr,
+                         (unsigned long)rejected_count,
+                         (unsigned long)total_domain_samples);
+            } else if (sample_count == 0 || domain_hashrate < min_domain_hashrate || domain_hashrate > max_domain_hashrate) {
+                domain_status = SELF_TEST_DOMAIN_FAIL;
+                ESP_LOGE(TAG,
+                         "ASIC %d Domain %d:FAIL - hashrate %.2f Gh/s, expected %.2f-%.2f Gh/s",
+                         asic_nr,
+                         domain_nr,
+                         domain_hashrate,
+                         min_domain_hashrate,
+                         max_domain_hashrate);
+            }
+
+            if (domain_status == SELF_TEST_DOMAIN_FAIL) {
+                domain_failed = true;
+                if (asic_nr < 32) {
+                    failed_asic_mask |= (1u << asic_nr);
+                }
             }
         }
+    }
+    self_test_domain_averages_free(&domain_averages);
+    if (domain_failed) {
+        if (GLOBAL_STATE->DEVICE_CONFIG.family.asic_count == 2 && failed_asic_mask == 0x3) {
+            self_test_show_message(GLOBAL_STATE, "BOTH ASICS DOMAIN:FAIL");
+        } else {
+            int failed_asic = -1;
+            for (int asic_nr = 0; asic_nr < GLOBAL_STATE->DEVICE_CONFIG.family.asic_count && asic_nr < 32; asic_nr++) {
+                if (failed_asic_mask & (1u << asic_nr)) {
+                    failed_asic = asic_nr;
+                    break;
+                }
+            }
+
+            if (failed_asic >= 0) {
+                snprintf(logString, sizeof(logString), "ASIC %d DOMAIN:FAIL", failed_asic);
+                self_test_show_message(GLOBAL_STATE, logString);
+            } else {
+                self_test_show_message(GLOBAL_STATE, "DOMAIN:FAIL");
+            }
+        }
+        tests_done(GLOBAL_STATE, false);
+    }
+
+    if (hashrate < expected_hashrate) {
+        ESP_LOGE(TAG, "Total hashrate too low");
+        self_test_show_message(GLOBAL_STATE, "HASHRATE:FAIL");
+        tests_done(GLOBAL_STATE, false);
     }
 
     if (test_core_voltage(GLOBAL_STATE) != ESP_OK) {
@@ -408,6 +745,7 @@ void self_test_task(void * pvParameters)
 static void tests_done(GlobalState * GLOBAL_STATE, bool isTestPassed)
 {
     GLOBAL_STATE->SELF_TEST_MODULE.is_finished = true;
+    self_test_stop_nonce_measurement(GLOBAL_STATE);
     VCORE_set_voltage(GLOBAL_STATE, 0.0f);
     asic_hold_reset_low();
 

--- a/main/self_test/self_test.h
+++ b/main/self_test/self_test.h
@@ -7,5 +7,6 @@ esp_err_t self_test_init(void * pvParameters);
 void self_test_task(void * pvParameters);
 void self_test_show_message(void * pvParameters, char * msg);
 void self_test_reset(void);
+void self_test_record_nonce(void * pvParameters, double nonce_diff);
 
 #endif

--- a/main/self_test/self_test.h
+++ b/main/self_test/self_test.h
@@ -5,7 +5,7 @@
 
 esp_err_t self_test_init(void * pvParameters);
 void self_test_task(void * pvParameters);
-void self_test_show_message(void * pvParameters, char * msg);
+void self_test_show_message(void * pvParameters, const char * msg);
 void self_test_reset(void);
 void self_test_record_nonce(void * pvParameters, double nonce_diff);
 

--- a/main/system.c
+++ b/main/system.c
@@ -236,7 +236,7 @@ esp_err_t SYSTEM_init_peripherals(GlobalState * GLOBAL_STATE) {
     if (GLOBAL_STATE->SELF_TEST_MODULE.is_active) {
         vTaskDelay(500 / portTICK_PERIOD_MS);
 
-        ret = VCORE_set_voltage(GLOBAL_STATE, 1.150);
+        ret = VCORE_set_voltage(GLOBAL_STATE, (float)GLOBAL_STATE->DEVICE_CONFIG.family.asic.default_voltage_mv / 1000.0f);
         if (ret != ESP_OK) {
             self_test_show_message(GLOBAL_STATE, "VCORE:FAIL");
             ESP_LOGE(TAG, "VCORE set failed");

--- a/main/task_monitor.c
+++ b/main/task_monitor.c
@@ -2,6 +2,7 @@
 #include "freertos/task.h"
 #include "esp_log.h"
 #include "global_state.h"
+#include <inttypes.h>
 
 #define MAX_TASKS 40
 #define INTERVAL_MS 60000
@@ -9,6 +10,7 @@
 static const char* TAG = "task_monitor";
 
 void task_monitor_task(void *pvParameters) {
+#ifdef CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
     TaskStatus_t *task_array1 = malloc(MAX_TASKS * sizeof(TaskStatus_t));
     TaskStatus_t *task_array2 = malloc(MAX_TASKS * sizeof(TaskStatus_t));
     if (task_array1 == NULL || task_array2 == NULL) {
@@ -19,7 +21,7 @@ void task_monitor_task(void *pvParameters) {
     }
 
     while (1) {
-        uint64_t total_runtime1 = 0;
+        configRUN_TIME_COUNTER_TYPE total_runtime1 = 0;
         uint32_t num_tasks1 = uxTaskGetSystemState(task_array1, MAX_TASKS, &total_runtime1);
         if (num_tasks1 == 0) {
             ESP_LOGE(TAG, "Failed to get initial task state");
@@ -30,7 +32,7 @@ void task_monitor_task(void *pvParameters) {
         // Wait for the interval
         vTaskDelay(pdMS_TO_TICKS(INTERVAL_MS));
 
-        uint64_t total_runtime2 = 0;
+        configRUN_TIME_COUNTER_TYPE total_runtime2 = 0;
         uint32_t num_tasks2 = uxTaskGetSystemState(task_array2, MAX_TASKS, &total_runtime2);
         if (num_tasks2 == 0) {
             ESP_LOGE(TAG, "Failed to get second task state");
@@ -38,7 +40,7 @@ void task_monitor_task(void *pvParameters) {
         }
 
         // Compute total delta (elapsed wall time in timer units)
-        uint64_t total_delta = total_runtime2 - total_runtime1;
+        configRUN_TIME_COUNTER_TYPE total_delta = total_runtime2 - total_runtime1;
         if (total_delta == 0) {
             ESP_LOGI(TAG, "No runtime change in interval");
             continue;
@@ -55,7 +57,7 @@ void task_monitor_task(void *pvParameters) {
 
         // Process each task in array2 (current tasks)
         for (uint32_t j = 0; j < num_tasks2; j++) {
-            uint64_t task_delta = task_array2[j].ulRunTimeCounter;
+            configRUN_TIME_COUNTER_TYPE task_delta = task_array2[j].ulRunTimeCounter;
 
             // Look for match in array1
             for (uint32_t i = 0; i < num_tasks1; i++) {
@@ -67,9 +69,14 @@ void task_monitor_task(void *pvParameters) {
 
             // If not found, it's a new task: delta remains run2 (all during interval)
             double delta_percentage = (task_delta * 100.0) / total_delta;
-            uint64_t lifetime_runtime = task_array2[j].ulRunTimeCounter;
+            configRUN_TIME_COUNTER_TYPE lifetime_runtime = task_array2[j].ulRunTimeCounter;
             double lifetime_percentage = (lifetime_runtime * 100.0) / total_runtime2;
-            printf("%-20s\t%" PRIu64 "\t\t\t%.2f%%\t\t%" PRIu64 "\t\t\t%.2f%%\n", task_array2[j].pcTaskName, task_delta, delta_percentage, lifetime_runtime, lifetime_percentage);
+            printf("%-20s\t%" PRIu64 "\t\t\t%.2f%%\t\t%" PRIu64 "\t\t\t%.2f%%\n",
+                   task_array2[j].pcTaskName,
+                   (uint64_t)task_delta,
+                   delta_percentage,
+                   (uint64_t)lifetime_runtime,
+                   lifetime_percentage);
         }
         printf("\n");
 
@@ -82,17 +89,21 @@ void task_monitor_task(void *pvParameters) {
     // Cleanup (though loop is infinite)
     free(task_array1);
     free(task_array2);
+#else
+    ESP_LOGW(TAG, "Task runtime statistics are disabled");
+#endif
     vTaskDelete(NULL);
 }
 
 void cpu_monitor_task(void *pvParameters) {
     GlobalState *GLOBAL_STATE = (GlobalState *)pvParameters;
+#ifdef CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
     float avg_idle = -1.0f;
     const float alpha = 0.5f;
 
     while (1) {
-        uint64_t idleTimeCore0 = ulTaskGetIdleRunTimePercentForCore(0);
-        uint64_t idleTimeCore1 = ulTaskGetIdleRunTimePercentForCore(1);
+        configRUN_TIME_COUNTER_TYPE idleTimeCore0 = ulTaskGetIdleRunTimePercentForCore(0);
+        configRUN_TIME_COUNTER_TYPE idleTimeCore1 = ulTaskGetIdleRunTimePercentForCore(1);
 
         double current_idle = (idleTimeCore0 + idleTimeCore1) * 0.5f;
         if (avg_idle < 0) {
@@ -105,4 +116,8 @@ void cpu_monitor_task(void *pvParameters) {
         
         vTaskDelay(pdMS_TO_TICKS(1000));
     }
+#else
+    GLOBAL_STATE->SYSTEM_MODULE.cpu_usage = 0.0f;
+    vTaskDelete(NULL);
+#endif
 }

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -13,6 +13,7 @@
 #include "asic.h"
 #include "freertos/task.h"
 #include "scoreboard.h"
+#include "self_test.h"
 
 static const char *TAG = "asic_result";
 
@@ -55,7 +56,10 @@ void ASIC_result_task(void *pvParameters)
         // check the nonce difficulty
         double nonce_diff = test_nonce_value(active_job, asic_result->nonce, asic_result->rolled_version);
 
-        if (GLOBAL_STATE->SELF_TEST_MODULE.is_active) continue;
+        if (GLOBAL_STATE->SELF_TEST_MODULE.is_active) {
+            self_test_record_nonce(GLOBAL_STATE, nonce_diff);
+            continue;
+        }
 
         uint32_t version_bits = asic_result->rolled_version ^ active_job->version;
         if (nonce_diff >= active_job->pool_diff)

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -227,7 +227,9 @@ void POWER_MANAGEMENT_task(void * pvParameters)
             }
         }
 
-        uint16_t core_voltage = nvs_config_get_u16(NVS_CONFIG_ASIC_VOLTAGE);
+        uint16_t core_voltage = GLOBAL_STATE->SELF_TEST_MODULE.is_active
+                                 ? GLOBAL_STATE->DEVICE_CONFIG.family.asic.default_voltage_mv
+                                 : nvs_config_get_u16(NVS_CONFIG_ASIC_VOLTAGE);
         float asic_frequency = nvs_config_get_float(NVS_CONFIG_ASIC_FREQUENCY);
 
         if (core_voltage != last_core_voltage) {


### PR DESCRIPTION
## Summary
- improve factory self-test thermal control with a bounded PID loop and dual-sensor validation
- validate hashrate from measured nonces while averaging per-domain counters and tolerating unreliable counter samples
- derive self-test core voltage from the ASIC model instead of fixed values
- guard optional FreeRTOS runtime-statistics monitoring when disabled

## Verification
- `. ~/esp/v5.5.1/esp-idf/export.sh && idf.py build`