### PR TITLE
Add camelCase overheat mode API alias

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -1088,7 +1088,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
     updateMessage(!!systemInfoError.duration, 'SYSTEM_INFO_ERROR', 'error', `Unable to reach the device for ${DateAgoPipe.transform(systemInfoError.duration, { strict: true })}`);
     updateMessage(!!(info as any).miningPaused, 'MINING_PAUSED', 'warn', 'Mining is paused');
-    updateMessage(!!info.overheat_mode, 'DEVICE_OVERHEAT', 'error', 'Device has overheated - See settings');
+    updateMessage(!!(info.overheatMode ?? info.overheat_mode), 'DEVICE_OVERHEAT', 'error', 'Device has overheated - See settings');
     updateMessage(!!info.power_fault, 'POWER_FAULT', 'error', `${info.power_fault} Check your Power Supply.`);
     updateMessage(!!info.hardware_fault, 'HARDWARE_FAULT', 'error', `${info.hardware_fault}`);
     updateMessage(!info.frequency || info.frequency < 400, 'FREQUENCY_LOW', 'warn', 'Device frequency is set low - See settings');

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -369,6 +369,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
       IP,
       ...existing,
       power_fault: null,
+      overheatMode: null,
       overheat_mode: null,
       isUsingFallbackStratum: null,
       blockFound: null,
@@ -469,7 +470,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
     switch (true) {
       case !!axe.miningPaused:
         return { color: 'yellow', msg: 'Paused' };
-      case axe.overheat_mode === 1:
+      case (axe.overheatMode ?? axe.overheat_mode) === 1:
         return { color: 'red', msg: 'Overheated' };
       case !!axe.power_fault:
         return { color: 'red', msg: 'Power Fault' };

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -141,6 +141,7 @@ export class SystemApiService {
 
         boardtemp1: 30,
         boardtemp2: 40,
+        overheatMode: 0,
         overheat_mode: 0,
         statsLimit: 720,
 

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -157,6 +157,7 @@ components:
         - maxPower
         - minFanSpeed
         - nominalVoltage
+        - overheatMode
         - overheat_mode
         - overclockEnabled
         - poolConnectionInfo
@@ -357,6 +358,9 @@ components:
         nominalVoltage:
           type: integer
           description: Nominal board voltage
+        overheatMode:
+          type: number
+          description: CamelCase compatibility alias for overheat_mode
         overheat_mode:
           type: number
           description: Overheat protection mode

--- a/main/http_server/system_api_json.c
+++ b/main/http_server/system_api_json.c
@@ -96,6 +96,7 @@ static void system_api_add_telemetry(cJSON *root, GlobalState *g) {
     cJSON_AddNumberToObject(root, "uptimeSeconds", (uint32_t)((esp_timer_get_time() - g->SYSTEM_MODULE.start_time) / 1000000));
     cJSON_AddFloatToObject(root, "cpuUsage", g->SYSTEM_MODULE.cpu_usage);
     cJSON_AddBoolToObject(root, "miningPaused", g->SYSTEM_MODULE.mining_paused);
+    cJSON_AddNumberToObject(root, "overheatMode", g->SYSTEM_MODULE.overheat_mode ? 1 : 0);
     cJSON_AddNumberToObject(root, "overheat_mode", g->SYSTEM_MODULE.overheat_mode ? 1 : 0);
     cJSON_AddStringToObject(root, "wifiStatus", g->SYSTEM_MODULE.wifi_status);
 


### PR DESCRIPTION
Fixes #621.

## Summary
- Add `overheatMode` to `/api/system/info`.
- Keep the existing `overheat_mode` field for backward compatibility.
- Document both fields in OpenAPI, with `overheat_mode` marked as the compatibility alias.
- Update AxeOS to prefer `overheatMode` while falling back to `overheat_mode`.

## Root cause
Most system-info response fields use camelCase, but overheat status was exposed only as `overheat_mode`. That leaves API clients and generated models with a one-off snake_case field, which is the inconsistency reported in #621.

## Fix
This keeps the API backward-compatible by adding the camelCase alias without removing the existing snake_case field. Existing UI clients and third-party API consumers that read `overheat_mode` continue to work, while new clients can use `overheatMode`.

## Verification
- `npm run test:ci` in `main/http_server/axe-os` passed: `33 SUCCESS`.
- Generated ignored `SystemInfo` model contains both `overheatMode` and `overheat_mode`.
- `git diff --check` passed.
- `ESP-IDF environment loaded, then idf.py build` passed.

## Hardware validation
- OTA-tested on Gamma `local test device` with firmware and web UI artifacts from this branch.
- Verified the device booted, AxeOS/API were reachable, mining resumed, and the patched `/api/system/info` response included the new `overheatMode` field while preserving `overheat_mode`.
- Rolled the device back to stock `v2.13.1` afterward; API remained healthy and mining resumed.