### PR TITLE
Clamp SV1 version rolling mask to ASIC-supported bits

### DIFF
--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -10,6 +10,7 @@
 #include "asic.h"
 #include "device_config.h"
 #include "frequency_transition_bmXX.h"
+#include "utils.h"
 
 static const char *TAG = "asic";
 
@@ -102,6 +103,26 @@ void ASIC_set_version_mask(GlobalState * GLOBAL_STATE, uint32_t mask)
             ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set version mask", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
             break;
     }
+}
+
+uint32_t ASIC_get_supported_version_mask(GlobalState * GLOBAL_STATE)
+{
+    switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
+        case BM1366:
+        case BM1368:
+        case BM1370:
+            return STRATUM_DEFAULT_VERSION_MASK;
+        case BM1397:
+            return UINT32_MAX;
+        default:
+            ESP_LOGE(TAG, "Unknown ASIC id %d, cannot get supported version mask", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
+            return 0;
+    }
+}
+
+uint32_t ASIC_clamp_version_mask(GlobalState * GLOBAL_STATE, uint32_t mask)
+{
+    return mask & ASIC_get_supported_version_mask(GLOBAL_STATE);
 }
 
 void ASIC_set_frequency(GlobalState * GLOBAL_STATE)

--- a/components/asic/include/asic.h
+++ b/components/asic/include/asic.h
@@ -10,6 +10,8 @@ task_result * ASIC_process_work(GlobalState * GLOBAL_STATE);
 int ASIC_set_max_baud(GlobalState * GLOBAL_STATE);
 void ASIC_send_work(GlobalState * GLOBAL_STATE, void * next_job);
 void ASIC_set_version_mask(GlobalState * GLOBAL_STATE, uint32_t mask);
+uint32_t ASIC_get_supported_version_mask(GlobalState * GLOBAL_STATE);
+uint32_t ASIC_clamp_version_mask(GlobalState * GLOBAL_STATE, uint32_t mask);
 void ASIC_set_frequency(GlobalState * GLOBAL_STATE);
 void ASIC_set_nonce_space(GlobalState * GLOBAL_STATE);
 double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE);

--- a/components/asic/test/CMakeLists.txt
+++ b/components/asic/test/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRC_DIRS "."
-                       INCLUDE_DIRS "."
+                       INCLUDE_DIRS "." "../../../main" "../../../main/tasks"
                        REQUIRES cmock stratum asic)

--- a/components/asic/test/test_job_command.c
+++ b/components/asic/test/test_job_command.c
@@ -1,9 +1,51 @@
 #include "unity.h"
 
+#include "asic.h"
 #include "serial.h"
 #include "bm1397.h"
+#include "utils.h"
 
 #include <string.h>
+
+static void set_test_asic(GlobalState *state, Asic asic_id)
+{
+    memset(state, 0, sizeof(*state));
+    state->DEVICE_CONFIG.family.asic.id = asic_id;
+}
+
+TEST_CASE("ASIC supported version mask for BM1366/BM1368/BM1370", "[asic]")
+{
+    GlobalState state;
+
+    set_test_asic(&state, BM1366);
+    TEST_ASSERT_EQUAL_HEX32(STRATUM_DEFAULT_VERSION_MASK, ASIC_get_supported_version_mask(&state));
+
+    set_test_asic(&state, BM1368);
+    TEST_ASSERT_EQUAL_HEX32(STRATUM_DEFAULT_VERSION_MASK, ASIC_get_supported_version_mask(&state));
+
+    set_test_asic(&state, BM1370);
+    TEST_ASSERT_EQUAL_HEX32(STRATUM_DEFAULT_VERSION_MASK, ASIC_get_supported_version_mask(&state));
+}
+
+TEST_CASE("ASIC clamps version rolling masks to supported bits", "[asic]")
+{
+    GlobalState state;
+
+    set_test_asic(&state, BM1370);
+
+    TEST_ASSERT_EQUAL_HEX32(0x1fffe000, ASIC_clamp_version_mask(&state, 0xffffffff));
+    TEST_ASSERT_EQUAL_HEX32(0x00000000, ASIC_clamp_version_mask(&state, 0x00001fff));
+    TEST_ASSERT_EQUAL_HEX32(0x00000000, ASIC_clamp_version_mask(&state, 0xe0000000));
+}
+
+TEST_CASE("ASIC keeps BM1397 version mask compatibility", "[asic]")
+{
+    GlobalState state;
+
+    set_test_asic(&state, BM1397);
+
+    TEST_ASSERT_EQUAL_HEX32(0xffffffff, ASIC_clamp_version_mask(&state, 0xffffffff));
+}
 
 /*
 static uint8_t uart_initialized = 0;

--- a/components/stratum/include/stratum_api.h
+++ b/components/stratum/include/stratum_api.h
@@ -96,6 +96,8 @@ void STRATUM_V1_free_mining_notify(mining_notify *params);
 
 int STRATUM_V1_authorize(esp_transport_handle_t transport, int send_uid, const char *username, const char *pass);
 
+int STRATUM_V1_build_configure_version_rolling_message(char *buffer, size_t buffer_size, int send_uid, uint32_t version_mask);
+
 int STRATUM_V1_configure_version_rolling(esp_transport_handle_t transport, int send_uid, uint32_t * version_mask);
 
 int STRATUM_V1_pong(esp_transport_handle_t transport, int message_id);

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 #define TRANSPORT_TIMEOUT_MS 5000
 #define BUFFER_SIZE 1024
@@ -588,12 +589,19 @@ int STRATUM_V1_submit_share(esp_transport_handle_t transport, int send_uid, cons
     return ret;
 }
 
+int STRATUM_V1_build_configure_version_rolling_message(char *buffer, size_t buffer_size, int send_uid, uint32_t version_mask)
+{
+    return snprintf(buffer, buffer_size,
+        "{\"id\":%d,\"method\":\"mining.configure\",\"params\":[[\"version-rolling\"],{\"version-rolling.mask\":\"%08" PRIx32 "\"}]}\n",
+        send_uid, version_mask);
+}
+
 int STRATUM_V1_configure_version_rolling(esp_transport_handle_t transport, int send_uid, uint32_t * version_mask)
 {
     char configure_msg[BUFFER_SIZE];
-    snprintf(configure_msg, sizeof(configure_msg),
-        "{\"id\":%d,\"method\":\"mining.configure\",\"params\":[[\"version-rolling\"],{\"version-rolling.mask\":\"ffffffff\"}]}\n",
-        send_uid);
+    uint32_t requested_mask = version_mask != NULL ? *version_mask : STRATUM_DEFAULT_VERSION_MASK;
+
+    STRATUM_V1_build_configure_version_rolling_message(configure_msg, sizeof(configure_msg), send_uid, requested_mask);
     debug_stratum_tx(configure_msg);
 
     return esp_transport_write(transport, configure_msg, strlen(configure_msg), TRANSPORT_TIMEOUT_MS);

--- a/components/stratum/test/test_stratum_json.c
+++ b/components/stratum/test/test_stratum_json.c
@@ -1,5 +1,7 @@
 #include "unity.h"
 #include "stratum_api.h"
+#include "utils.h"
+#include <string.h>
 
 TEST_CASE("Parse stratum method", "[stratum]")
 {
@@ -115,6 +117,17 @@ TEST_CASE("Parse stratum mining.set_version_mask params", "[stratum]")
     TEST_ASSERT_EQUAL(1, stratum_api_v1_message.message_id);
     TEST_ASSERT_EQUAL(MINING_SET_VERSION_MASK, stratum_api_v1_message.method);
     TEST_ASSERT_EQUAL_HEX32(0x1fffe000, stratum_api_v1_message.version_mask);
+}
+
+TEST_CASE("Build version rolling configure with supported mask", "[stratum]")
+{
+    char configure_msg[256];
+
+    STRATUM_V1_build_configure_version_rolling_message(
+        configure_msg, sizeof(configure_msg), 1, STRATUM_DEFAULT_VERSION_MASK);
+
+    TEST_ASSERT_NOT_NULL(strstr(configure_msg, "\"version-rolling.mask\":\"1fffe000\""));
+    TEST_ASSERT_NULL(strstr(configure_msg, "\"version-rolling.mask\":\"ffffffff\""));
 }
 
 TEST_CASE("Parse stratum result success", "[stratum]")

--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -12,6 +12,7 @@
 #include "esp_timer.h"
 #include "esp_transport.h"
 #include "esp_transport_tcp.h"
+#include "asic.h"
 #include <stdbool.h>
 #include <string.h>
 #include "utils.h"
@@ -285,7 +286,8 @@ void stratum_v1_task(void *pvParameters)
 
         ///// Start Stratum Action
         // mining.configure - ID: 1
-        STRATUM_V1_configure_version_rolling(GLOBAL_STATE->transport, stratum_get_next_uid(GLOBAL_STATE), &GLOBAL_STATE->version_mask);
+        uint32_t supported_version_mask = ASIC_get_supported_version_mask(GLOBAL_STATE);
+        STRATUM_V1_configure_version_rolling(GLOBAL_STATE->transport, stratum_get_next_uid(GLOBAL_STATE), &supported_version_mask);
 
         // mining.subscribe - ID: 2
         STRATUM_V1_subscribe(GLOBAL_STATE->transport, stratum_get_next_uid(GLOBAL_STATE), GLOBAL_STATE->DEVICE_CONFIG.family.asic.name);
@@ -348,8 +350,9 @@ void stratum_v1_task(void *pvParameters)
                 GLOBAL_STATE->new_set_mining_difficulty_msg = true;
             } else if (stratum_api_v1_message.method == MINING_SET_VERSION_MASK ||
                     stratum_api_v1_message.method == STRATUM_RESULT_VERSION_MASK) {
-                ESP_LOGI(TAG, "Set version mask: %08lx", stratum_api_v1_message.version_mask);
-                GLOBAL_STATE->version_mask = stratum_api_v1_message.version_mask;
+                uint32_t version_mask = ASIC_clamp_version_mask(GLOBAL_STATE, stratum_api_v1_message.version_mask);
+                ESP_LOGI(TAG, "Set version mask: %08lx (pool: %08lx)", version_mask, stratum_api_v1_message.version_mask);
+                GLOBAL_STATE->version_mask = version_mask;
                 GLOBAL_STATE->new_stratum_version_rolling_msg = true;
             } else if (stratum_api_v1_message.method == MINING_SET_EXTRANONCE ||
                     stratum_api_v1_message.method == STRATUM_RESULT_SUBSCRIBE) {


### PR DESCRIPTION
Fixes #1169.

## Summary
- Advertise `1fffe000` for SV1 version rolling on BM1366, BM1368, and BM1370 instead of `ffffffff`.
- Clamp pool-provided `mining.configure` and `mining.set_version_mask` values before storing or applying them.
- Keep BM1397 all-bits compatibility behavior unchanged.
- Add focused coverage for configure JSON and ASIC mask clamping.

## Root cause
The SV1 `mining.configure` request advertised `ffffffff` as the supported `version-rolling.mask`. BM1366, BM1368, and BM1370 program only the 16-bit roll value derived from `version_mask >> 13`, so their practical supported mask is `0x1fffe000`. Advertising or applying unsupported bits can let a pool assign version bits the miner cannot actually roll.

## Fix
This adds ASIC-level supported-mask helpers, uses the supported mask when requesting SV1 version rolling, and clamps pool-returned masks before applying them to mining state. BM1397 keeps the previous behavior because its version-mask setter is currently a placeholder and this PR should not change that runtime path.

## Verification
- `git diff --check` passed.
- `ESP-IDF environment loaded, then GITHUB_ACTIONS=true idf.py -C test-ci build` passed.
- `ESP-IDF environment loaded, then idf.py build` passed.

## Hardware validation
- OTA-tested on Gamma `local test device` / BM1370 with firmware from this branch.
- OTA-tested on Supra `local test device` / BM1368 with firmware from this branch.
- Both devices booted, AxeOS/API were reachable, mining resumed, and latest snapshots showed `0` rejected shares after warmup.
- Both devices were rolled back to stock `v2.13.1` afterward; API remained healthy and mining resumed.

## Remaining risk
The local `test-ci build` compiles the unit-test app but does not execute those tests on hardware/QEMU. A stronger mining-impact proof would use a controlled SV1 pool that returns masks outside `0x1fffe000` and compare accepted shares/rejects before and after on BM1368/BM1370 hardware.