### PR TITLE
Report found blocks only after pool acceptance

### DIFF
--- a/main/system.c
+++ b/main/system.c
@@ -310,6 +310,31 @@ void SYSTEM_notify_rejected_share(GlobalState * GLOBAL_STATE, char * error_msg)
     }    
 }
 
+bool SYSTEM_is_block_candidate(GlobalState * GLOBAL_STATE, double diff, uint8_t job_id)
+{
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
+    bool valid = (GLOBAL_STATE->valid_jobs[job_id] != 0);
+    bm_job *active_job = valid ? GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id] : NULL;
+    uint32_t target = active_job != NULL ? active_job->target : 0;
+    pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
+
+    if (!valid || active_job == NULL) {
+        return false;
+    }
+
+    double network_diff = networkDifficulty(target);
+    return diff >= network_diff;
+}
+
+void SYSTEM_notify_accepted_block(GlobalState * GLOBAL_STATE, double diff)
+{
+    SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
+
+    module->block_found++;
+    module->show_new_block = true;
+    ESP_LOGI(TAG, "FOUND BLOCK accepted by pool: %f (count: %d)", diff, module->block_found);
+}
+
 void SYSTEM_notify_new_ntime(GlobalState * GLOBAL_STATE, uint32_t ntime)
 {
     SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
@@ -333,13 +358,6 @@ void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint8_t 
     if ((uint64_t) diff > module->best_session_nonce_diff) {
         module->best_session_nonce_diff = (uint64_t) diff;
         suffixString((uint64_t) diff, module->best_session_diff_string, DIFF_STRING_SIZE, 0);
-    }
-
-    double network_diff = networkDifficulty(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->target);
-    if (diff >= network_diff) {
-        module->block_found++;
-        module->show_new_block = true;
-        ESP_LOGI(TAG, "FOUND BLOCK!!!!!!!!!!!!!!!!!!!!!! %f >= %f (count: %d)", diff, network_diff, module->block_found);
     }
 
     if ((uint64_t) diff <= module->best_nonce_diff) {

--- a/main/system.h
+++ b/main/system.h
@@ -15,6 +15,8 @@ void SYSTEM_clean_jobs_queue(GlobalState * GLOBAL_STATE);
 
 void SYSTEM_notify_accepted_share(GlobalState * GLOBAL_STATE);
 void SYSTEM_notify_rejected_share(GlobalState * GLOBAL_STATE, char * error_msg);
+bool SYSTEM_is_block_candidate(GlobalState * GLOBAL_STATE, double diff, uint8_t job_id);
+void SYSTEM_notify_accepted_block(GlobalState * GLOBAL_STATE, double diff);
 void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint8_t job_id);
 void SYSTEM_notify_new_ntime(GlobalState * GLOBAL_STATE, uint32_t ntime);
 

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -7,6 +7,7 @@
 #include "esp_log.h"
 #include "nvs_config.h"
 #include "utils.h"
+#include "stratum_v1_task.h"
 #include "stratum_v2_task.h"
 #include "sv2_protocol.h"
 #include "hashrate_monitor_task.h"
@@ -58,6 +59,9 @@ void ASIC_result_task(void *pvParameters)
         if (GLOBAL_STATE->SELF_TEST_MODULE.is_active) continue;
 
         uint32_t version_bits = asic_result->rolled_version ^ active_job->version;
+        bool is_block_candidate = SYSTEM_is_block_candidate(GLOBAL_STATE, nonce_diff, job_id);
+        SYSTEM_notify_found_nonce(GLOBAL_STATE, nonce_diff, job_id);
+
         if (nonce_diff >= active_job->pool_diff)
         {
             if (GLOBAL_STATE->stratum_protocol == STRATUM_V2) {
@@ -76,12 +80,16 @@ void ASIC_result_task(void *pvParameters)
                                                            asic_result->nonce,
                                                            active_job->ntime,
                                                            asic_result->rolled_version,
-                                                           extranonce_2, en2_len);
+                                                           extranonce_2, en2_len,
+                                                           is_block_candidate,
+                                                           nonce_diff);
                 } else {
                     ret = stratum_v2_submit_share(GLOBAL_STATE, sv2_job_id,
                                                    asic_result->nonce,
                                                    active_job->ntime,
-                                                   asic_result->rolled_version);
+                                                   asic_result->rolled_version,
+                                                   is_block_candidate,
+                                                   nonce_diff);
                 }
 
                 if (ret < 0) {
@@ -115,6 +123,8 @@ void ASIC_result_task(void *pvParameters)
                     if (ret < 0) {
                         ESP_LOGW(TAG, "Unable to write share to socket (ret: %d, errno %d: %s)", ret, errno, strerror(errno));
                         // stratum_task recv loop will detect a broken connection on its next read and handle reconnection
+                    } else {
+                        stratum_v1_record_share_block_candidate(uid, is_block_candidate, nonce_diff);
                     }
 
                     float process_time = (sent_time_us - asic_result->timestamp_us) / 1000.0f;
@@ -126,8 +136,6 @@ void ASIC_result_task(void *pvParameters)
 
         //log the ASIC response
         ESP_LOGI(TAG, "ID: %s, ASIC nr: %d, Core: %d/%d, ver: %08" PRIX32 " Nonce %08" PRIX32 " diff %.1f of %g.", active_job->jobid, asic_result->asic_nr, asic_result->core_id, asic_result->small_core_id, asic_result->rolled_version, asic_result->nonce, nonce_diff, active_job->pool_diff);
-
-        SYSTEM_notify_found_nonce(GLOBAL_STATE, nonce_diff, job_id);
 
         scoreboard_add(&GLOBAL_STATE->SYSTEM_MODULE.scoreboard, nonce_diff, active_job->jobid, active_job->extranonce2, active_job->ntime, asic_result->nonce, version_bits);
     }

--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -45,6 +45,30 @@
 static const char *TAG = "stratum_v1_task";
 
 static StratumApiV1Message stratum_api_v1_message = {};
+static int stratum_v1_share_request_id[MAX_REQUEST_IDS] = {0};
+static bool stratum_v1_share_block_candidate[MAX_REQUEST_IDS] = {0};
+static double stratum_v1_share_diff[MAX_REQUEST_IDS] = {0};
+
+void stratum_v1_record_share_block_candidate(int request_id, bool is_block_candidate, double diff)
+{
+    if (request_id < 0) {
+        return;
+    }
+
+    int slot = request_id % MAX_REQUEST_IDS;
+    stratum_v1_share_request_id[slot] = request_id;
+    stratum_v1_share_block_candidate[slot] = is_block_candidate;
+    stratum_v1_share_diff[slot] = diff;
+}
+
+static void stratum_v1_clear_share_block_candidates(void)
+{
+    for (int i = 0; i < MAX_REQUEST_IDS; i++) {
+        stratum_v1_share_request_id[i] = -1;
+    }
+    memset(stratum_v1_share_block_candidate, 0, sizeof(stratum_v1_share_block_candidate));
+    memset(stratum_v1_share_diff, 0, sizeof(stratum_v1_share_diff));
+}
 
 static int stratum_get_next_uid(GlobalState * GLOBAL_STATE)
 {
@@ -61,6 +85,7 @@ static void stratum_v1_reset_uid(GlobalState *GLOBAL_STATE)
     taskENTER_CRITICAL(&GLOBAL_STATE->stratum_mux);
     GLOBAL_STATE->send_uid = 1;
     taskEXIT_CRITICAL(&GLOBAL_STATE->stratum_mux);
+    stratum_v1_clear_share_block_candidates();
 }
 
 void stratum_v1_close_connection(GlobalState *GLOBAL_STATE)
@@ -170,6 +195,8 @@ static void decode_mining_notification(GlobalState * GLOBAL_STATE, const mining_
 void stratum_v1_task(void *pvParameters)
 {
     GlobalState *GLOBAL_STATE = (GlobalState *)pvParameters;
+
+    stratum_v1_clear_share_block_candidates();
 
     bool use_fallback = GLOBAL_STATE->SYSTEM_MODULE.is_using_fallback;
     char *stratum_url = use_fallback ? GLOBAL_STATE->SYSTEM_MODULE.fallback_pool_url : GLOBAL_STATE->SYSTEM_MODULE.pool_url;
@@ -372,7 +399,16 @@ void stratum_v1_task(void *pvParameters)
                 stratum_v1_close_connection(GLOBAL_STATE);
                 break;
             } else if (stratum_api_v1_message.method == STRATUM_RESULT) {
-                float response_time_ms = STRATUM_V1_get_response_time_ms(stratum_api_v1_message.message_id, receive_time_us);
+                int response_message_id = stratum_api_v1_message.message_id;
+                if (response_message_id < 0) {
+                    ESP_LOGW(TAG, "Ignoring stratum result with invalid message id: %d", response_message_id);
+                    STRATUM_V1_reset_message(&stratum_api_v1_message);
+                    continue;
+                }
+
+                int slot = response_message_id % MAX_REQUEST_IDS;
+                bool matching_share = stratum_v1_share_request_id[slot] == response_message_id;
+                float response_time_ms = STRATUM_V1_get_response_time_ms(response_message_id, receive_time_us);
                 if (stratum_api_v1_message.response_success) {
                     ESP_LOGI(TAG, "message result accepted");
                     if (response_time_ms >= 0) {
@@ -380,10 +416,23 @@ void stratum_v1_task(void *pvParameters)
                         GLOBAL_STATE->SYSTEM_MODULE.response_time = response_time_ms;
                         SYSTEM_notify_accepted_share(GLOBAL_STATE);
                     }
+                    if (matching_share) {
+                        if (stratum_v1_share_block_candidate[slot]) {
+                            SYSTEM_notify_accepted_block(GLOBAL_STATE, stratum_v1_share_diff[slot]);
+                        }
+                        stratum_v1_share_request_id[slot] = -1;
+                        stratum_v1_share_block_candidate[slot] = false;
+                        stratum_v1_share_diff[slot] = 0;
+                    }
                 } else {
                     ESP_LOGW(TAG, "message result rejected: %s", stratum_api_v1_message.error_str);
                     if (response_time_ms >= 0) {
                         SYSTEM_notify_rejected_share(GLOBAL_STATE, stratum_api_v1_message.error_str);
+                    }
+                    if (matching_share) {
+                        stratum_v1_share_request_id[slot] = -1;
+                        stratum_v1_share_block_candidate[slot] = false;
+                        stratum_v1_share_diff[slot] = 0;
                     }
                 }
             } else if (stratum_api_v1_message.method == STRATUM_RESULT_SETUP) {

--- a/main/tasks/stratum_v1_task.h
+++ b/main/tasks/stratum_v1_task.h
@@ -1,9 +1,11 @@
 #ifndef STRATUM_V1_TASK_H_
 #define STRATUM_V1_TASK_H_
 
+#include <stdbool.h>
 #include "global_state.h"
 
 void stratum_v1_task(void *pvParameters);
 void stratum_v1_close_connection(GlobalState *GLOBAL_STATE);
+void stratum_v1_record_share_block_candidate(int request_id, bool is_block_candidate, double diff);
 
 #endif // STRATUM_V1_TASK_H_

--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -106,15 +106,50 @@ void stratum_v2_close_connection(GlobalState *GLOBAL_STATE)
 // (ring buffer) and measure against the specific share being acknowledged
 // rather than just the most recent submit.
 #define SV2_SUBMIT_TIMING_SLOTS 32
+#define SV2_MAX_ACCEPTED_SHARE_NOTIFICATIONS 0xffffu
 static int64_t stratum_v2_submit_time_us[SV2_SUBMIT_TIMING_SLOTS] = {0};
+static uint32_t stratum_v2_submit_sequence_number[SV2_SUBMIT_TIMING_SLOTS] = {0};
+static bool stratum_v2_submit_valid[SV2_SUBMIT_TIMING_SLOTS] = {0};
+static bool stratum_v2_share_block_candidate[SV2_SUBMIT_TIMING_SLOTS] = {0};
+static double stratum_v2_share_diff[SV2_SUBMIT_TIMING_SLOTS] = {0};
 
-static inline void stratum_v2_record_submit_time(uint32_t sequence_number)
+static inline void stratum_v2_record_submit(uint32_t sequence_number, bool is_block_candidate, double diff)
 {
-    stratum_v2_submit_time_us[sequence_number % SV2_SUBMIT_TIMING_SLOTS] = esp_timer_get_time();
+    int slot = sequence_number % SV2_SUBMIT_TIMING_SLOTS;
+    stratum_v2_submit_time_us[slot] = esp_timer_get_time();
+    stratum_v2_submit_sequence_number[slot] = sequence_number;
+    stratum_v2_submit_valid[slot] = true;
+    stratum_v2_share_block_candidate[slot] = is_block_candidate;
+    stratum_v2_share_diff[slot] = diff;
+}
+
+static inline bool stratum_v2_submit_slot_matches(uint32_t sequence_number, int *slot)
+{
+    int submit_slot = sequence_number % SV2_SUBMIT_TIMING_SLOTS;
+    if (slot) {
+        *slot = submit_slot;
+    }
+    return stratum_v2_submit_valid[submit_slot] &&
+           stratum_v2_submit_sequence_number[submit_slot] == sequence_number;
+}
+
+static inline void stratum_v2_clear_submit_slot(uint32_t sequence_number)
+{
+    int slot;
+    if (!stratum_v2_submit_slot_matches(sequence_number, &slot)) {
+        return;
+    }
+
+    stratum_v2_submit_time_us[slot] = 0;
+    stratum_v2_submit_sequence_number[slot] = 0;
+    stratum_v2_submit_valid[slot] = false;
+    stratum_v2_share_block_candidate[slot] = false;
+    stratum_v2_share_diff[slot] = 0;
 }
 
 int stratum_v2_submit_share(GlobalState *GLOBAL_STATE, uint32_t job_id, uint32_t nonce,
-                            uint32_t ntime, uint32_t version)
+                            uint32_t ntime, uint32_t version,
+                            bool is_block_candidate, double diff)
 {
     if (!GLOBAL_STATE->transport || !GLOBAL_STATE->sv2_conn || !GLOBAL_STATE->sv2_noise_ctx) {
         return -1;
@@ -130,13 +165,18 @@ int stratum_v2_submit_share(GlobalState *GLOBAL_STATE, uint32_t job_id, uint32_t
                                                 job_id, nonce, ntime, version);
     if (len < 0) return -1;
 
-    stratum_v2_record_submit_time(sequence_number);
-    return sv2_noise_send(GLOBAL_STATE->sv2_noise_ctx, GLOBAL_STATE->transport, buf, len);
+    stratum_v2_record_submit(sequence_number, is_block_candidate, diff);
+    int ret = sv2_noise_send(GLOBAL_STATE->sv2_noise_ctx, GLOBAL_STATE->transport, buf, len);
+    if (ret < 0) {
+        stratum_v2_clear_submit_slot(sequence_number);
+    }
+    return ret;
 }
 
 int stratum_v2_submit_share_extended(GlobalState *GLOBAL_STATE, uint32_t job_id,
                                      uint32_t nonce, uint32_t ntime, uint32_t version,
-                                     const uint8_t *extranonce, uint8_t extranonce_len)
+                                     const uint8_t *extranonce, uint8_t extranonce_len,
+                                     bool is_block_candidate, double diff)
 {
     if (!GLOBAL_STATE->transport || !GLOBAL_STATE->sv2_conn || !GLOBAL_STATE->sv2_noise_ctx) {
         return -1;
@@ -153,8 +193,12 @@ int stratum_v2_submit_share_extended(GlobalState *GLOBAL_STATE, uint32_t job_id,
                                                 extranonce, extranonce_len);
     if (len < 0) return -1;
 
-    stratum_v2_record_submit_time(sequence_number);
-    return sv2_noise_send(GLOBAL_STATE->sv2_noise_ctx, GLOBAL_STATE->transport, buf, len);
+    stratum_v2_record_submit(sequence_number, is_block_candidate, diff);
+    int ret = sv2_noise_send(GLOBAL_STATE->sv2_noise_ctx, GLOBAL_STATE->transport, buf, len);
+    if (ret < 0) {
+        stratum_v2_clear_submit_slot(sequence_number);
+    }
+    return ret;
 }
 
 bool stratum_v2_is_extended_channel(GlobalState *GLOBAL_STATE)
@@ -929,23 +973,56 @@ void stratum_v2_task(void *pvParameters)
                 case SV2_MSG_SUBMIT_SHARES_SUCCESS: {
                     uint32_t channel_id, last_sequence_number, accepted_count;
                     if (sv2_parse_submit_shares_success(recv_buf, hdr.msg_length, &channel_id, &last_sequence_number, &accepted_count) == 0) {
-                        // Measure against the share acknowledged by last_sequence_number — the
+                        uint32_t share_notify_count = accepted_count;
+                        if (share_notify_count > SV2_MAX_ACCEPTED_SHARE_NOTIFICATIONS) {
+                            ESP_LOGW(TAG, "SubmitShares.Success accepted_count %lu exceeds safe notification limit",
+                                     accepted_count);
+                            share_notify_count = SV2_MAX_ACCEPTED_SHARE_NOTIFICATIONS;
+                        }
+
+                        uint32_t track_count = accepted_count;
+                        if (track_count > SV2_SUBMIT_TIMING_SLOTS) {
+                            track_count = SV2_SUBMIT_TIMING_SLOTS;
+                        }
+                        if (track_count > 0 && last_sequence_number < track_count - 1) {
+                            ESP_LOGW(TAG, "SubmitShares.Success accepted_count %lu exceeds last sequence %lu",
+                                     accepted_count, last_sequence_number);
+                            track_count = last_sequence_number + 1;
+                        }
+
+                        // Measure against the share acknowledged by last_sequence_number, the
                         // most recent share in the ack, giving the cleanest available round trip.
                         // accepted_count is surfaced separately so the UI can flag batch acks,
                         // where the elapsed time also includes the pool's batching window.
-                        int slot = last_sequence_number % SV2_SUBMIT_TIMING_SLOTS;
-                        int64_t submit_time_us = stratum_v2_submit_time_us[slot];
-                        if (submit_time_us > 0) {
+                        int slot;
+                        if (accepted_count > 0 &&
+                            stratum_v2_submit_slot_matches(last_sequence_number, &slot) &&
+                            stratum_v2_submit_time_us[slot] > 0) {
+                            int64_t submit_time_us = stratum_v2_submit_time_us[slot];
                             float response_time_ms = (float)(esp_timer_get_time() - submit_time_us) / 1000.0f;
                             ESP_LOGI(TAG, "Shares accepted: %lu (%.1f ms)", accepted_count, response_time_ms);
                             GLOBAL_STATE->SYSTEM_MODULE.response_time = response_time_ms;
-                            GLOBAL_STATE->SYSTEM_MODULE.response_share_batch = (uint16_t)accepted_count;
-                            stratum_v2_submit_time_us[slot] = 0;
+                            GLOBAL_STATE->SYSTEM_MODULE.response_share_batch =
+                                (uint16_t)(accepted_count > 0xffffu ? 0xffffu : accepted_count);
                         } else {
                             ESP_LOGI(TAG, "Shares accepted: %lu", accepted_count);
                         }
-                        for (uint32_t i = 0; i < accepted_count; i++) {
+
+                        for (uint32_t i = 0; i < share_notify_count; i++) {
                             SYSTEM_notify_accepted_share(GLOBAL_STATE);
+                        }
+
+                        for (uint32_t i = 0; i < track_count; i++) {
+                            uint32_t sequence_number = last_sequence_number - i;
+                            int accepted_slot;
+                            if (!stratum_v2_submit_slot_matches(sequence_number, &accepted_slot)) {
+                                continue;
+                            }
+
+                            if (stratum_v2_share_block_candidate[accepted_slot]) {
+                                SYSTEM_notify_accepted_block(GLOBAL_STATE, stratum_v2_share_diff[accepted_slot]);
+                            }
+                            stratum_v2_clear_submit_slot(sequence_number);
                         }
                     }
                     break;
@@ -957,8 +1034,14 @@ void stratum_v2_task(void *pvParameters)
                     if (sv2_parse_submit_shares_error(recv_buf, hdr.msg_length,
                                                       &channel_id, &seq_num,
                                                       error_code, sizeof(error_code)) == 0) {
+                        int slot;
                         ESP_LOGW(TAG, "Share rejected: %s", error_code);
                         SYSTEM_notify_rejected_share(GLOBAL_STATE, error_code);
+                        if (stratum_v2_submit_slot_matches(seq_num, &slot)) {
+                            stratum_v2_clear_submit_slot(seq_num);
+                        } else {
+                            ESP_LOGW(TAG, "Share rejected for untracked sequence: %lu", seq_num);
+                        }
                     }
                     break;
                 }

--- a/main/tasks/stratum_v2_task.h
+++ b/main/tasks/stratum_v2_task.h
@@ -7,10 +7,12 @@
 void stratum_v2_task(void *pvParameters);
 void stratum_v2_close_connection(GlobalState *GLOBAL_STATE);
 int stratum_v2_submit_share(GlobalState *GLOBAL_STATE, uint32_t job_id, uint32_t nonce,
-                            uint32_t ntime, uint32_t version);
+                            uint32_t ntime, uint32_t version,
+                            bool is_block_candidate, double diff);
 int stratum_v2_submit_share_extended(GlobalState *GLOBAL_STATE, uint32_t job_id,
                                      uint32_t nonce, uint32_t ntime, uint32_t version,
-                                     const uint8_t *extranonce, uint8_t extranonce_len);
+                                     const uint8_t *extranonce, uint8_t extranonce_len,
+                                     bool is_block_candidate, double diff);
 bool stratum_v2_is_extended_channel(GlobalState *GLOBAL_STATE);
 
 #endif // STRATUM_V2_TASK_H


### PR DESCRIPTION
Fixes #1552.

## Summary
- Stop marking `blockFound` when the ASIC only finds a locally valid nonce.
- Track block-candidate shares only after a share submit is successfully written.
- Promote a candidate to `blockFound` only when the pool accepts that exact share.
- Correlate SV1 candidates by JSON-RPC request id and SV2 candidates by SubmitShares sequence number.

## Root cause
`SYSTEM_notify_found_nonce()` updated the UI/block counters as soon as a local nonce met network difficulty. In setups where network difficulty is lower than the pool/share difficulty, a nonce can satisfy the local block-candidate check while never being submitted or while later being rejected by the pool. That can show a false found-block state.

## Fix
This separates best-diff tracking from accepted-block notification. `SYSTEM_notify_found_nonce()` keeps updating best/session diff only. `SYSTEM_is_block_candidate()` decides whether a successfully submitted share should be tracked as a block candidate. `SYSTEM_notify_accepted_block()` updates `blockFound` and the new-block banner only after pool acceptance.

For correlation, SV1 stores exact request ids instead of relying on the modulo slot alone. SV2 stores exact SubmitShares sequence numbers and keeps accepted/rejected share accounting pool-authoritative while using exact matches only for response timing, accepted-block notification, and slot cleanup.

## Verification
- `git diff --check` passed.
- `ESP-IDF environment loaded, then idf.py build` passed.
- `ESP-IDF environment loaded, then GITHUB_ACTIONS=true idf.py -C test-ci fullclean && GITHUB_ACTIONS=true idf.py -C test-ci build` passed.

## Hardware validation
- Smoke-tested the branch on Gamma `local test device`.
- Verified the device booted, AxeOS/API were reachable, mining resumed, and the post-test snapshot remained healthy.
- Rolled the device back to stock `v2.13.1` afterward; API remained healthy and mining resumed.

## Not tested
- I did not reproduce the original regtest-pool setup from #1552 locally. The fix is based on the code path that previously incremented `blockFound` before pool acceptance, plus firmware/test-ci builds and a live mining smoke test.