### PR TITLE
Clean up stale WebSocket clients safely

### DIFF
--- a/main/http_server/websocket.c
+++ b/main/http_server/websocket.c
@@ -1,4 +1,7 @@
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 #include <unistd.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -26,6 +29,109 @@ static SemaphoreHandle_t clients_mutex = NULL;
 static httpd_handle_t server_handle = NULL;
 static TaskHandle_t s_websocket_log_task_handle = NULL;
 
+static void websocket_drop_client(int fd);
+
+static const char *websocket_type_name(WebSocketClientType type)
+{
+    return type == WS_TYPE_LOGS ? "log" : "api";
+}
+
+static bool websocket_type_is_valid(WebSocketClientType type)
+{
+    return type >= 0 && type < WS_TYPE_MAX;
+}
+
+static bool websocket_take_clients_mutex(void)
+{
+    if (clients_mutex == NULL) {
+        ESP_LOGE(TAG, "WebSocket client mutex is not initialized");
+        return false;
+    }
+    if (xSemaphoreTake(clients_mutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+        ESP_LOGE(TAG, "Failed to acquire WebSocket client mutex");
+        return false;
+    }
+    return true;
+}
+
+static void websocket_forget_client_locked(int fd)
+{
+    for (int i = 0; i < MAX_WEBSOCKET_CLIENTS; i++) {
+        if (clients[i].fd == fd) {
+            WebSocketClientType type = (WebSocketClientType)clients[i].type;
+            clients[i].fd = -1;
+            clients[i].type = 0;
+
+            if (websocket_type_is_valid(type) && type_counts[type] > 0) {
+                type_counts[type]--;
+            }
+
+            return;
+        }
+    }
+}
+
+static void websocket_prune_inactive_clients(void)
+{
+    if (server_handle == NULL) {
+        return;
+    }
+
+    int client_fds[MAX_WEBSOCKET_CLIENTS];
+    int client_count = 0;
+
+    if (!websocket_take_clients_mutex()) {
+        return;
+    }
+
+    for (int i = 0; i < MAX_WEBSOCKET_CLIENTS; i++) {
+        int fd = clients[i].fd;
+        if (fd == -1) {
+            continue;
+        }
+
+        client_fds[client_count++] = fd;
+    }
+
+    xSemaphoreGive(clients_mutex);
+
+    for (int i = 0; i < client_count; i++) {
+        int fd = client_fds[i];
+        if (httpd_ws_get_fd_info(server_handle, fd) != HTTPD_WS_CLIENT_WEBSOCKET) {
+            ESP_LOGW(TAG, "Pruning stale WebSocket client, fd: %d", fd);
+            websocket_drop_client(fd);
+        }
+    }
+}
+
+static int websocket_get_total_client_count(void)
+{
+    int active_clients = MAX_WEBSOCKET_CLIENTS;
+
+    websocket_prune_inactive_clients();
+
+    if (!websocket_take_clients_mutex()) {
+        return active_clients;
+    }
+
+    active_clients = 0;
+    for (int i = 0; i < WS_TYPE_MAX; i++) {
+        active_clients += type_counts[i];
+    }
+
+    xSemaphoreGive(clients_mutex);
+    return active_clients;
+}
+
+static void websocket_drop_client(int fd)
+{
+    if (fd == -1) {
+        return;
+    }
+
+    websocket_remove_client(fd);
+}
+
 void websocket_set_log_task_handle(TaskHandle_t task_handle)
 {
     s_websocket_log_task_handle = task_handle;
@@ -33,32 +139,78 @@ void websocket_set_log_task_handle(TaskHandle_t task_handle)
 
 int websocket_get_active_client_count(WebSocketClientType type)
 {
-    if (type >= 0 && type < WS_TYPE_MAX) return type_counts[type];
-    return 0;
+    if (!websocket_type_is_valid(type)) {
+        return 0;
+    }
+
+    int count = 0;
+    websocket_prune_inactive_clients();
+
+    if (!websocket_take_clients_mutex()) {
+        return count;
+    }
+
+    count = type_counts[type];
+
+    xSemaphoreGive(clients_mutex);
+    return count;
 }
 
 void websocket_log_notify(void)
 {
-    if (s_websocket_log_task_handle != NULL && type_counts[WS_TYPE_LOGS] > 0) {
+    if (s_websocket_log_task_handle != NULL && websocket_get_active_client_count(WS_TYPE_LOGS) > 0) {
         xTaskNotifyGive(s_websocket_log_task_handle);
     }
 }
 
 esp_err_t websocket_add_client(int fd, WebSocketClientType type)
 {
-    if (xSemaphoreTake(clients_mutex, pdMS_TO_TICKS(100)) != pdTRUE) {
-        ESP_LOGE(TAG, "Failed to acquire mutex for adding client");
+    if (!websocket_type_is_valid(type)) {
+        ESP_LOGE(TAG, "Invalid WebSocket client type: %d", type);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    websocket_prune_inactive_clients();
+
+    if (!websocket_take_clients_mutex()) {
         return ESP_FAIL;
     }
 
     esp_err_t ret = ESP_FAIL;
+    int active_clients = 0;
+    int updated_slot = -1;
+    int added_slot = -1;
+    for (int i = 0; i < WS_TYPE_MAX; i++) {
+        active_clients += type_counts[i];
+    }
+
+    if (active_clients >= MAX_WEBSOCKET_CLIENTS) {
+        ESP_LOGE(TAG, "Max WebSocket clients reached, cannot add fd: %d", fd);
+        xSemaphoreGive(clients_mutex);
+        return ESP_ERR_NO_MEM;
+    }
+
     for (int i = 0; i < MAX_WEBSOCKET_CLIENTS; i++) {
+        if (clients[i].fd == fd) {
+            WebSocketClientType old_type = (WebSocketClientType)clients[i].type;
+            if (old_type != type) {
+                if (websocket_type_is_valid(old_type) && type_counts[old_type] > 0) {
+                    type_counts[old_type]--;
+                }
+                type_counts[type]++;
+                clients[i].type = type;
+            }
+            updated_slot = i;
+            ret = ESP_OK;
+            break;
+        }
+
         if (clients[i].fd == -1) {
             clients[i].fd = fd;
             clients[i].type = type;
-            if (type >= 0 && type < WS_TYPE_MAX) type_counts[type]++;
+            type_counts[type]++;
 
-            ESP_LOGI(TAG, "Added WebSocket %s client, fd: %d, slot: %d", type == WS_TYPE_LOGS ? "log" : "api", fd, i);
+            added_slot = i;
             ret = ESP_OK;
             if (type == WS_TYPE_LOGS && s_websocket_log_task_handle) {
                 xTaskNotifyGive(s_websocket_log_task_handle);
@@ -66,32 +218,26 @@ esp_err_t websocket_add_client(int fd, WebSocketClientType type)
             break;
         }
     }
-    if (ret != ESP_OK) {
+    xSemaphoreGive(clients_mutex);
+
+    if (updated_slot >= 0) {
+        ESP_LOGI(TAG, "Updated WebSocket %s client, fd: %d, slot: %d", websocket_type_name(type), fd, updated_slot);
+    } else if (added_slot >= 0) {
+        ESP_LOGI(TAG, "Added WebSocket %s client, fd: %d, slot: %d", websocket_type_name(type), fd, added_slot);
+    } else if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Max WebSocket clients reached, cannot add fd: %d", fd);
     }
 
-    xSemaphoreGive(clients_mutex);
     return ret;
 }
 
 void websocket_remove_client(int fd)
 {
-    if (xSemaphoreTake(clients_mutex, pdMS_TO_TICKS(100)) != pdTRUE) {
-        ESP_LOGE(TAG, "Failed to acquire mutex for removing client");
+    if (!websocket_take_clients_mutex()) {
         return;
     }
 
-    for (int i = 0; i < MAX_WEBSOCKET_CLIENTS; i++) {
-        if (clients[i].fd == fd) {
-            WebSocketClientType type = (WebSocketClientType)clients[i].type;
-            clients[i].fd = -1;
-            clients[i].type = 0;
-            if (type >= 0 && type < WS_TYPE_MAX) type_counts[type]--;
-
-            ESP_LOGI(TAG, "Removed WebSocket %s client, fd: %d, slot: %d", type == WS_TYPE_LOGS ? "log" : "api", fd, i);
-            break;
-        }
-    }
+    websocket_forget_client_locked(fd);
 
     xSemaphoreGive(clients_mutex);
 }
@@ -99,8 +245,18 @@ void websocket_remove_client(int fd)
 void websocket_send_to_client(int fd, httpd_ws_frame_t *pkt)
 {
     if (server_handle == NULL || fd == -1) return;
-    if (httpd_ws_send_frame_async(server_handle, fd, pkt) != ESP_OK) {
-        ESP_LOGW(TAG, "Failed to send WebSocket frame to fd: %d", fd);
+
+    httpd_ws_client_info_t client_info = httpd_ws_get_fd_info(server_handle, fd);
+    if (client_info != HTTPD_WS_CLIENT_WEBSOCKET) {
+        ESP_LOGW(TAG, "Dropping stale WebSocket client before send, fd: %d", fd);
+        websocket_drop_client(fd);
+        return;
+    }
+
+    esp_err_t ret = httpd_ws_send_frame_async(server_handle, fd, pkt);
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to send WebSocket frame to fd %d: %s", fd, esp_err_to_name(ret));
+        websocket_drop_client(fd);
     }
 }
 
@@ -108,10 +264,25 @@ void websocket_broadcast(WebSocketClientType type, httpd_ws_frame_t *pkt)
 {
     if (server_handle == NULL) return;
 
+    int client_fds[MAX_WEBSOCKET_CLIENTS];
+    int client_count = 0;
+
+    websocket_prune_inactive_clients();
+
+    if (!websocket_take_clients_mutex()) {
+        return;
+    }
+
     for (int i = 0; i < MAX_WEBSOCKET_CLIENTS; i++) {
         if (clients[i].fd != -1 && (clients[i].type == type)) {
-            websocket_send_to_client(clients[i].fd, pkt);
+            client_fds[client_count++] = clients[i].fd;
         }
+    }
+
+    xSemaphoreGive(clients_mutex);
+
+    for (int i = 0; i < client_count; i++) {
+        websocket_send_to_client(client_fds[i], pkt);
     }
 }
 
@@ -124,14 +295,23 @@ void websocket_close_fn(httpd_handle_t hd, int fd)
 void websocket_init(httpd_handle_t server)
 {
     server_handle = server;
+    if (clients_mutex == NULL) {
+        clients_mutex = xSemaphoreCreateMutex();
+    }
+
+    if (!websocket_take_clients_mutex()) {
+        return;
+    }
+
     for (int i = 0; i < MAX_WEBSOCKET_CLIENTS; i++) {
         clients[i].fd = -1;
         clients[i].type = 0;
     }
-
-    if (clients_mutex == NULL) {
-        clients_mutex = xSemaphoreCreateMutex();
+    for (int i = 0; i < WS_TYPE_MAX; i++) {
+        type_counts[i] = 0;
     }
+
+    xSemaphoreGive(clients_mutex);
 }
 
 esp_err_t websocket_handler(httpd_req_t *req)
@@ -145,14 +325,12 @@ esp_err_t websocket_handler(httpd_req_t *req)
             return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
         }
 
-        int active_clients = 0;
-        for (int i = 0; i < WS_TYPE_MAX; i++) active_clients += type_counts[i];
-        if (active_clients >= MAX_WEBSOCKET_CLIENTS) {
+        if (websocket_get_total_client_count() >= MAX_WEBSOCKET_CLIENTS) {
             ESP_LOGE(TAG, "Max WebSocket clients reached, rejecting new connection");
             return httpd_resp_send_custom_err(req, "429 Too Many Requests", "Max WebSocket clients reached");
         }
 
-        uint32_t type = (uint32_t)(uintptr_t)req->user_ctx;
+        WebSocketClientType type = (WebSocketClientType)(uintptr_t)req->user_ctx;
         int fd = httpd_req_to_sockfd(req);
         if (websocket_add_client(fd, type) != ESP_OK) {
             ESP_LOGE(TAG, "Unexpected failure adding client, fd: %d", fd);
@@ -173,7 +351,13 @@ esp_err_t websocket_handler(httpd_req_t *req)
     // Get frame header to allow ESP-IDF to handle control frames (Ping/Pong/Close)
     esp_err_t ret = httpd_ws_recv_frame(req, &ws_pkt, 0);
     if (ret != ESP_OK) {
+        websocket_drop_client(httpd_req_to_sockfd(req));
         return ret;
+    }
+
+    if (ws_pkt.type == HTTPD_WS_TYPE_CLOSE) {
+        websocket_drop_client(httpd_req_to_sockfd(req));
+        return ESP_OK;
     }
 
     // If there's a payload, drain it


### PR DESCRIPTION
Related to #773.

## Summary
- Keep WebSocket client registry updates under the existing mutex.
- Prune stale WebSocket file descriptors before counting or broadcasting.
- Snapshot broadcast recipients under the mutex, then send outside the mutex.
- Drop failed or no-longer-WebSocket clients from ESP-Miner's registry.
- Avoid logging while holding the WebSocket client mutex, because log handling can re-enter WebSocket client-count checks.

## Root cause
The HTTP server can keep running while ESP-Miner's WebSocket registry retains stale client entries. Before this patch, failed async sends only logged a warning and `websocket_broadcast()` iterated the shared client list without the mutex used by add/remove. Once stale clients consume the small WebSocket slot pool, the web UI/API can become difficult or impossible to use while the device still responds to ping.

During hardware testing, an earlier cleanup revision exposed another failure mode: logging while holding the WebSocket client mutex could re-enter the WebSocket log/count path and leave the firmware repeatedly failing to acquire that mutex before a reset. This patch keeps socket checks and sends outside the mutex, and moves add/update logs after the mutex is released.

## Fix
The patch adds shared helpers for client type validation, mutex acquisition, stale-client pruning, and locked registry removal. Count and broadcast paths prune inactive ESP-IDF WebSocket fds first, then use short mutex-protected sections only for registry reads/writes. Broadcast sends happen after the snapshot is copied, so a slow or dead client cannot hold the registry mutex.

## Verification
- `git diff --check` passed.
- `ESP-IDF environment loaded, then idf.py build` passed.

## Hardware validation
- OTA-tested on Gamma `local test device` with firmware built from this branch.
- Reproduced the previous raw `/api/ws/live` WebSocket handshake plus masked CLOSE-frame probe 5 times.
- Before the final mutex/logging correction, this probe caused `Failed to acquire WebSocket client mutex` spam followed by a software reset due to exception/panic.
- With this PR's final commit, the same 5-iteration probe completed successfully.
- Post-probe `/api/system/info` stayed HTTP 200, uptime continued increasing, reset reason stayed `Software reset via esp_restart`, mining resumed around normal Gamma hashrate, and rejected shares stayed at `0`.
- Post-probe logs for `v2.14.0b4-1-ge950ddd` showed the WebSocket connects without the mutex-acquire failure spam.

## Remaining risk
This is focused on stale WebSocket registry cleanup and the mutex re-entry issue seen during testing. It does not attempt to redesign Wi-Fi scan behavior or broader HTTP server session management.