### PR TITLE
Add a Test SV2 connection button to the pool settings

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -26,6 +26,7 @@ SRCS
     "./http_server/websocket_api.c"
     "./http_server/cjson_utils.c"
     "./http_server/system_api_json.c"
+    "./http_server/sv2_connection_test.c"
     "./http_server/theme_api.c"
     "./http_server/axe-os/api/system/asic_settings.c"
     "./self_test/self_test.c"

--- a/main/http_server/axe-os/src/app/components/pool/pool.component.html
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.html
@@ -141,6 +141,21 @@
                                     </small>
                                 </div>
                             </div>
+
+                            <div class="field grid p-fluid">
+                                <div class="col-12 md:col-10 md:col-offset-2">
+                                    <button pButton
+                                        type="button"
+                                        class="p-button-secondary"
+                                        label="Test SV2 connection"
+                                        [loading]="testingSv2[pool]"
+                                        [disabled]="testingSv2[pool] || !form.get(pool + 'URL')?.value"
+                                        (click)="testSv2(pool)"></button>
+                                    <small class="block text-400 mt-2">
+                                        Checks whether the pool supports Stratum V2 before you save, so you don't end up on the fallback pool.
+                                    </small>
+                                </div>
+                            </div>
                         </ng-container>
 
                         <!-- SV1-only options -->

--- a/main/http_server/axe-os/src/app/components/pool/pool.component.ts
+++ b/main/http_server/axe-os/src/app/components/pool/pool.component.ts
@@ -57,6 +57,8 @@ export class PoolComponent implements OnInit {
 
   public asicModel: string = '';
 
+  public testingSv2: { [key in PoolType]: boolean } = { stratum: false, fallbackStratum: false };
+
   @Input() uri = '';
 
   constructor(
@@ -305,6 +307,29 @@ export class PoolComponent implements OnInit {
 
   isPoolV2Enabled(pool: PoolType): boolean {
     return pool === 'stratum' ? this.isStratumV2Enabled() : this.isFallbackStratumV2Enabled();
+  }
+
+  testSv2(pool: PoolType): void {
+    const url = this.form.get(`${pool}URL`)?.value;
+    const port = this.form.get(`${pool}Port`)?.value;
+
+    this.testingSv2[pool] = true;
+    this.systemService.testSv2Connection(this.uri, url, port)
+      .pipe(first())
+      .subscribe({
+        next: (res) => {
+          this.testingSv2[pool] = false;
+          if (res.supported) {
+            this.toastr.success(res.message);
+          } else {
+            this.toastr.warning(res.message);
+          }
+        },
+        error: (err: HttpErrorResponse) => {
+          this.testingSv2[pool] = false;
+          this.toastr.error(err?.error?.message || err?.message || 'SV2 connection test failed');
+        }
+      });
   }
 
   isStandardChannelDisabled(): boolean {

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -340,6 +340,20 @@ export class SystemApiService {
     return of(undefined);
   }
 
+  public testSv2Connection(uri: string = '', url: string, port: number): Observable<{ supported: boolean; message: string }> {
+    const body = { url, port };
+
+    if (environment.production && this.api && !uri) {
+      return from(this.api.invoke(functions.testSv2Connection, { body }) as Promise<{ supported: boolean; message: string }>).pipe(timeout(API_TIMEOUT));
+    }
+
+    if (environment.production && uri) {
+      return this.httpClient.post<{ supported: boolean; message: string }>(`${uri}/api/system/test/sv2`, body).pipe(timeout(API_TIMEOUT));
+    }
+
+    return of({ supported: true, message: 'Stratum V2 supported (mock)' });
+  }
+
   private otaUpdate(file: File | Blob, url: string): Observable<HttpEvent<string>> {
     return new Observable<HttpEvent<string>>((subscriber) => {
       const reader = new FileReader();

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -37,6 +37,7 @@
 #include "websocket_log.h"
 #include "websocket_api.h"
 #include "system_api_json.h"
+#include "sv2_connection_test.h"
 #include "log_buffer.h"
 #include "cjson_utils.h"
 #include "utils.h"
@@ -694,6 +695,69 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     cJSON_Delete(root);
     httpd_resp_send_chunk(req, NULL, 0);
     return ESP_OK;
+}
+
+/* Probe whether the given pool speaks Stratum V2, so users can verify SV2
+ * support before committing to it. Tests the url/port from the request body
+ * (the values currently in the form, not yet saved). */
+static esp_err_t POST_test_sv2(httpd_req_t * req)
+{
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+
+    if (set_cors_headers(req) != ESP_OK) {
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
+
+    int total_len = req->content_len;
+    int cur_len = 0;
+    char * buf = ((rest_server_context_t *) (req->user_ctx))->scratch;
+    int received = 0;
+    if (total_len >= SCRATCH_BUFSIZE) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "content too long");
+        return ESP_OK;
+    }
+    while (cur_len < total_len) {
+        received = httpd_req_recv(req, buf + cur_len, total_len);
+        if (received <= 0) {
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to read request");
+            return ESP_OK;
+        }
+        cur_len += received;
+    }
+    buf[total_len] = '\0';
+
+    cJSON * root = cJSON_Parse(buf);
+    if (root == NULL) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid JSON");
+        return ESP_OK;
+    }
+
+    cJSON * url_item = cJSON_GetObjectItem(root, "url");
+    cJSON * port_item = cJSON_GetObjectItem(root, "port");
+    if (!cJSON_IsString(url_item) || !cJSON_IsNumber(port_item)) {
+        cJSON_Delete(root);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Missing url or port");
+        return ESP_OK;
+    }
+
+    sv2_test_result_t result;
+    sv2_test_connection(url_item->valuestring, (uint16_t) port_item->valueint, &result);
+    cJSON_Delete(root);
+
+    httpd_resp_set_type(req, "application/json");
+    cJSON * resp = cJSON_CreateObject();
+    if (resp == NULL) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Memory allocation failed");
+        return ESP_OK;
+    }
+    cJSON_AddBoolToObject(resp, "supported", result.supported);
+    cJSON_AddStringToObject(resp, "message", result.message);
+    esp_err_t res = HTTP_send_json(req, resp, &api_common_prebuffer_len);
+    cJSON_Delete(resp);
+    return res;
 }
 
 static esp_err_t POST_identify(httpd_req_t * req)
@@ -1364,6 +1428,14 @@ esp_err_t start_rest_server(void * pvParameters)
         .user_ctx = rest_context
     };
     httpd_register_uri_handler(server, &update_system_settings_uri);
+
+    httpd_uri_t system_test_sv2_uri = {
+        .uri = "/api/system/test/sv2",
+        .method = HTTP_POST,
+        .handler = POST_test_sv2,
+        .user_ctx = rest_context
+    };
+    httpd_register_uri_handler(server, &system_test_sv2_uri);
 
     httpd_uri_t update_post_ota_firmware = {
         .uri = "/api/system/OTA", 

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -1034,6 +1034,50 @@ paths:
         '500':
           description: Internal server error
 
+  /api/system/test/sv2:
+    post:
+      summary: Test Stratum V2 support of a pool
+      description: Opens a throwaway Stratum V2 (Noise) handshake to the given pool and reports whether it supports SV2. Does not affect the running miner.
+      operationId: testSv2Connection
+      tags:
+        - system
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - url
+                - port
+              properties:
+                url:
+                  type: string
+                  description: Pool host to test
+                port:
+                  type: number
+                  description: Pool port to test
+      responses:
+        '200':
+          description: Test completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  supported:
+                    type: boolean
+                    description: Whether the pool responded to a Stratum V2 handshake
+                  message:
+                    type: string
+                    description: Human-readable result
+        '400':
+          description: Missing or invalid url/port
+        '401':
+          description: Unauthorized - Client not in allowed network range
+        '500':
+          description: Internal server error
+
   /api/system/identify:
     post:
       summary: Identify the device

--- a/main/http_server/sv2_connection_test.c
+++ b/main/http_server/sv2_connection_test.c
@@ -1,0 +1,101 @@
+#include "sv2_connection_test.h"
+
+#include <string.h>
+
+#include "esp_log.h"
+#include "esp_random.h"
+#include "esp_transport.h"
+#include "esp_transport_tcp.h"
+#include "stratum_socket.h"
+
+static const char *TAG = "sv2_test";
+
+#define SV2_TEST_CONNECT_TIMEOUT_MS 5000
+#define SV2_TEST_READ_TIMEOUT_MS    3000
+#define SV2_NOISE_ACT1_LEN          64   // ephemeral key the initiator sends
+#define SV2_NOISE_ACT2_LEN          234  // responder's reply for Noise_NX
+
+static void set_result(sv2_test_result_t *out, bool supported, const char *msg)
+{
+    out->supported = supported;
+    strncpy(out->message, msg, sizeof(out->message) - 1);
+    out->message[sizeof(out->message) - 1] = '\0';
+}
+
+// A text protocol (SV1 JSON-RPC, HTTP, ...) replies with printable ASCII; the
+// binary Noise response almost certainly has non-printable bytes early on.
+static bool looks_like_text(const uint8_t *buf, int len)
+{
+    int n = len < 16 ? len : 16;
+    for (int i = 0; i < n; i++) {
+        uint8_t c = buf[i];
+        bool printable = (c >= 0x20 && c <= 0x7e) || c == '\r' || c == '\n' || c == '\t';
+        if (!printable) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void sv2_test_connection(const char *host, uint16_t port, sv2_test_result_t *out)
+{
+    if (!host || host[0] == '\0' || port == 0) {
+        set_result(out, false, "Invalid pool address");
+        return;
+    }
+
+    stratum_connection_info_t conn_info;
+    if (stratum_socket_resolve(host, port, &conn_info) != ESP_OK) {
+        set_result(out, false, "Could not resolve pool host");
+        return;
+    }
+
+    esp_transport_handle_t transport = esp_transport_tcp_init();
+    if (!transport) {
+        set_result(out, false, "Internal error (transport init)");
+        return;
+    }
+
+    if (esp_transport_connect(transport, conn_info.host_ip, port, SV2_TEST_CONNECT_TIMEOUT_MS) != 0) {
+        set_result(out, false, "Pool unreachable");
+        esp_transport_destroy(transport);
+        return;
+    }
+
+    // Noise_NX Act 1: the initiator sends a 64-byte ElligatorSwift-encoded
+    // ephemeral public key. ElligatorSwift decodes any 64 bytes to a valid
+    // curve point, so a throwaway random value is enough to make an SV2
+    // responder reply with its Act 2 — we only care whether it answers, not
+    // about completing the handshake, so this needs no crypto on our side.
+    uint8_t act1[SV2_NOISE_ACT1_LEN];
+    esp_fill_random(act1, sizeof(act1));
+    if (esp_transport_write(transport, (const char *)act1, sizeof(act1), SV2_TEST_CONNECT_TIMEOUT_MS) <= 0) {
+        set_result(out, false, "Pool unreachable");
+        esp_transport_close(transport);
+        esp_transport_destroy(transport);
+        return;
+    }
+
+    // An SV2 pool replies with the 234-byte Act 2. An SV1 / text pool either
+    // ignores the binary blob (read times out) or answers with text.
+    uint8_t resp[SV2_NOISE_ACT2_LEN];
+    int got = esp_transport_read(transport, (char *)resp, sizeof(resp), SV2_TEST_READ_TIMEOUT_MS);
+
+    esp_transport_close(transport);
+    esp_transport_destroy(transport);
+
+    if (got <= 0) {
+        ESP_LOGI(TAG, "%s:%u did not answer the SV2 handshake", host, port);
+        set_result(out, false, "Pool did not respond to a Stratum V2 handshake — it likely only supports Stratum V1");
+        return;
+    }
+
+    if (looks_like_text(resp, got)) {
+        ESP_LOGI(TAG, "%s:%u replied with a text response (%d bytes)", host, port, got);
+        set_result(out, false, "Pool replied with a non-SV2 response — it likely only supports Stratum V1");
+        return;
+    }
+
+    ESP_LOGI(TAG, "%s:%u answered the SV2 handshake (%d bytes)", host, port, got);
+    set_result(out, true, "Pool responded to the Stratum V2 handshake — Stratum V2 is supported");
+}

--- a/main/http_server/sv2_connection_test.h
+++ b/main/http_server/sv2_connection_test.h
@@ -1,0 +1,18 @@
+#ifndef SV2_CONNECTION_TEST_H
+#define SV2_CONNECTION_TEST_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+    bool supported;       // true if the pool answered the SV2 Noise handshake
+    char message[160];    // human-readable result for the UI
+} sv2_test_result_t;
+
+// Probe whether host:port speaks Stratum V2. Opens a throwaway TCP connection,
+// sends a Noise handshake init and checks whether the pool replies with a Noise
+// response. Does not complete the handshake and does not touch the live mining
+// connection. Fills out with the verdict and a message.
+void sv2_test_connection(const char *host, uint16_t port, sv2_test_result_t *out);
+
+#endif /* SV2_CONNECTION_TEST_H */


### PR DESCRIPTION
Might be a confusion future: someone picks SV2 on a pool that only speaks SV1, the device quietly falls back, and they wonder why they're on the fallback pool. This adds a "Test SV2 connection" button under the SV2 authority key field (shown when a pool is set to SV2) so you can check before saving.

The test opens a throwaway TCP connection to the entered pool, sends a Noise handshake init and checks whether the pool answers with a Noise response — an SV1 pool won't. It deliberately doesn't complete the handshake (no crypto needed on our side, since ElligatorSwift accepts any 64-byte ephemeral) and runs on its own short-lived socket, so the running miner isn't touched.

Backend does the probe and returns `{ supported, message }`; the frontend just shows the result as a toast. Works for both the primary and fallback pool.

Tested on hardware against an SV2 and an SV1 pool.

**SV2 compatible:**

<img width="2756" height="1482" alt="grafik" src="https://github.com/user-attachments/assets/56c6f2db-af81-4d52-bf49-7f1b0b39770e" />



**Not SV2 compatible**

<img width="2758" height="1251" alt="grafik" src="https://github.com/user-attachments/assets/b66f37b5-9ed1-407e-8e64-8088958ec93a" />
