### PR TITLE
HTTP Handler Audit

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -166,8 +166,12 @@ esp_err_t HTTP_send_json(httpd_req_t * req, const cJSON * item, int * prebuffer_
 /* Handler for WiFi scan endpoint */
 static esp_err_t GET_wifi_scan(httpd_req_t *req)
 {
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+
     httpd_resp_set_type(req, "application/json");
-    
+
     // Give some time for the connected flag to take effect
     vTaskDelay(100 / portTICK_PERIOD_MS);
     
@@ -577,7 +581,7 @@ bool check_settings_and_update(const cJSON * const root)
             }
         }
 
-        if (key == NVS_CONFIG_DISPLAY && get_display_config(item->valuestring) == NULL) {
+        if (key == NVS_CONFIG_DISPLAY && cJSON_IsString(item) && get_display_config(item->valuestring) == NULL) {
             ESP_LOGW(TAG, "Invalid display config: '%s'", item->valuestring);
             result = false;
         }
@@ -585,13 +589,13 @@ bool check_settings_and_update(const cJSON * const root)
             ESP_LOGW(TAG, "Invalid display rotation: '%d'", item->valueint);
             result = false;
         }
-        if (key == NVS_CONFIG_STRATUM_PROTOCOL || key == NVS_CONFIG_FALLBACK_STRATUM_PROTOCOL) {
+        if ((key == NVS_CONFIG_STRATUM_PROTOCOL || key == NVS_CONFIG_FALLBACK_STRATUM_PROTOCOL) && cJSON_IsString(item)) {
             if (stratum_protocol_from_string(item->valuestring) == STRATUM_PROTOCOL_UNKNOWN) {
                 ESP_LOGW(TAG, "Invalid stratum protocol: '%s'", item->valuestring);
                 result = false;
             }
         }
-        if (key == NVS_CONFIG_SV2_CHANNEL_TYPE || key == NVS_CONFIG_FALLBACK_SV2_CHANNEL_TYPE) {
+        if ((key == NVS_CONFIG_SV2_CHANNEL_TYPE || key == NVS_CONFIG_FALLBACK_SV2_CHANNEL_TYPE) && cJSON_IsString(item)) {
             if (sv2_channel_type_from_string(item->valuestring) == SV2_CHANNEL_UNKNOWN) {
                 ESP_LOGW(TAG, "Invalid SV2 channel type: '%s'", item->valuestring);
                 result = false;
@@ -1035,13 +1039,11 @@ static esp_err_t GET_scoreboard(httpd_req_t * req)
         return ESP_OK;
     }
 
-    const char *response = cJSON_Print(root);
-    httpd_resp_sendstr(req, response);
+    esp_err_t res = HTTP_send_json(req, root, &api_common_prebuffer_len);
 
-    free((void *)response);
     cJSON_Delete(root);
 
-    return ESP_OK;
+    return res;
 }
 
 esp_err_t POST_WWW_update(httpd_req_t * req)

--- a/main/http_server/http_server.h
+++ b/main/http_server/http_server.h
@@ -6,6 +6,7 @@
 #include "cJSON.h"
 
 esp_err_t is_network_allowed(httpd_req_t * req);
+esp_err_t set_cors_headers(httpd_req_t * req);
 esp_err_t start_rest_server(void *pvParameters);
 esp_err_t HTTP_send_json(httpd_req_t * req, const cJSON * item, int * prebuffer_len);
 

--- a/main/http_server/theme_api.c
+++ b/main/http_server/theme_api.c
@@ -5,20 +5,17 @@
 #include "cJSON.h"
 #include "http_server.h"
 
-static int theme_prebuffer_len = 256;
+static const char *TAG = "theme_api";
 
-// Helper function to set CORS headers
-static esp_err_t set_cors_headers(httpd_req_t *req)
-{
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type");
-    return ESP_OK;
-}
+static int theme_prebuffer_len = 256;
 
 // GET /api/theme handler
 static esp_err_t theme_get_handler(httpd_req_t *req)
 {
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+
     httpd_resp_set_type(req, "application/json");
     set_cors_headers(req);
 
@@ -26,12 +23,14 @@ static esp_err_t theme_get_handler(httpd_req_t *req)
     char *colors = nvs_config_get_string(NVS_CONFIG_THEME_COLORS);
 
     cJSON *root = cJSON_CreateObject();
-    cJSON_AddStringToObject(root, "colorScheme", scheme);
-    
+    cJSON_AddStringToObject(root, "colorScheme", scheme ? scheme : "");
+
     // Parse stored colors JSON string
-    cJSON *colors_json = cJSON_Parse(colors);
-    if (colors_json) {
-        cJSON_AddItemToObject(root, "accentColors", colors_json);
+    if (colors) {
+        cJSON *colors_json = cJSON_Parse(colors);
+        if (colors_json) {
+            cJSON_AddItemToObject(root, "accentColors", colors_json);
+        }
     }
 
     esp_err_t res = HTTP_send_json(req, root, &theme_prebuffer_len);
@@ -47,6 +46,10 @@ static esp_err_t theme_get_handler(httpd_req_t *req)
 // POST /api/theme handler
 static esp_err_t theme_post_handler(httpd_req_t *req)
 {
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+
     set_cors_headers(req);
 
     // Read POST data
@@ -67,12 +70,20 @@ static esp_err_t theme_post_handler(httpd_req_t *req)
     // Update theme settings
     cJSON *item;
     if ((item = cJSON_GetObjectItem(root, "colorScheme")) != NULL) {
-        nvs_config_set_string(NVS_CONFIG_THEME_SCHEME, item->valuestring);
+        if (!cJSON_IsString(item) || item->valuestring == NULL) {
+            ESP_LOGW(TAG, "colorScheme: expected string, ignoring");
+        } else {
+            nvs_config_set_string(NVS_CONFIG_THEME_SCHEME, item->valuestring);
+        }
     }
     if ((item = cJSON_GetObjectItem(root, "accentColors")) != NULL) {
         char *colors_str = cJSON_Print(item);
-        nvs_config_set_string(NVS_CONFIG_THEME_COLORS, colors_str);
-        free(colors_str);
+        if (colors_str == NULL) {
+            ESP_LOGW(TAG, "accentColors: cJSON_Print returned NULL, ignoring");
+        } else {
+            nvs_config_set_string(NVS_CONFIG_THEME_COLORS, colors_str);
+            free(colors_str);
+        }
     }
 
     cJSON_Delete(root);


### PR DESCRIPTION
As mentioned in #1732, first item:
> /api/theme bypasses the normal network gate and has unsafe type handling. Unlike other API handlers, it does not call is_network_allowed(). POST also accepts unvalidated JSON types and can pass NULL into string handling.

 * Add `is_network_allowed` to `/api/theme` and `/api/system/wifi/scan`
 * JSON type safety on several places
 * Several OOM protections