### PR TITLE
fix: keep fractional SV2 pool difficulty to avoid difficulty-too-low rejects

### DIFF
--- a/components/stratum/include/mining.h
+++ b/components/stratum/include/mining.h
@@ -38,6 +38,11 @@ void calculate_merkle_root_hash(const uint8_t coinbase_tx_hash[32], const uint8_
 
 void construct_bm_job(mining_notify *params, const uint8_t merkle_root[32], const uint32_t version_mask, const double difficulty, bm_job* new_job);
 
+// Convert a 256-bit value (block hash or pool target, little-endian) to
+// difficulty (pdiff = truediffone / value). Shared by SV1 (test_nonce_value)
+// and SV2 (target). Returns a double to preserve fractional difficulty.
+double hash_to_pdiff(const uint8_t hash[32]);
+
 double test_nonce_value(const bm_job *job, const uint32_t nonce, const uint32_t rolled_version);
 
 void extranonce_2_generate(uint64_t extranonce_2, uint32_t length, char dest[static length * 2 + 1]);

--- a/components/stratum/mining.c
+++ b/components/stratum/mining.c
@@ -131,6 +131,13 @@ void extranonce_2_generate(uint64_t extranonce_2, uint32_t length, char dest[sta
     bin2hex(extranonce_2_bytes, length, dest, length * 2 + 1);
 }
 
+double hash_to_pdiff(const uint8_t hash[32])
+{
+    double s64 = le256todouble(hash);
+    if (s64 == 0.0) return (double)UINT32_MAX;
+    return truediffone / s64;
+}
+
 ///////cgminer nonce testing
 /* testing a nonce and return the diff - 0 means invalid */
 double test_nonce_value(const bm_job *job, const uint32_t nonce, const uint32_t rolled_version)
@@ -154,9 +161,7 @@ double test_nonce_value(const bm_job *job, const uint32_t nonce, const uint32_t 
     uint8_t hash_result[32];
     double_sha256_bin(header, 80, hash_result);
 
-    double d64 = truediffone;
-    double s64 = le256todouble(hash_result);
-    return d64 / s64;
+    return hash_to_pdiff(hash_result);
 }
 
 uint32_t increment_bitmask(const uint32_t value, const uint32_t mask)

--- a/components/stratum_v2/include/sv2_protocol.h
+++ b/components/stratum_v2/include/sv2_protocol.h
@@ -195,11 +195,4 @@ sv2_ext_job_t *sv2_parse_new_extended_mining_job(const uint8_t *payload, uint32_
 
 void sv2_ext_job_free(sv2_ext_job_t *job);
 
-// --- Helpers ---
-
-// Convert U256 LE target to pool difficulty (pdiff). Returns a double to
-// preserve fractional difficulty (e.g. 931.1) so the submit threshold matches
-// the pool's exact target.
-double sv2_target_to_pdiff(const uint8_t target[32]);
-
 #endif /* SV2_PROTOCOL_H */

--- a/components/stratum_v2/include/sv2_protocol.h
+++ b/components/stratum_v2/include/sv2_protocol.h
@@ -197,7 +197,9 @@ void sv2_ext_job_free(sv2_ext_job_t *job);
 
 // --- Helpers ---
 
-// Convert U256 LE target to pool difficulty (pdiff)
-uint32_t sv2_target_to_pdiff(const uint8_t target[32]);
+// Convert U256 LE target to pool difficulty (pdiff). Returns a double to
+// preserve fractional difficulty (e.g. 931.1) so the submit threshold matches
+// the pool's exact target.
+double sv2_target_to_pdiff(const uint8_t target[32]);
 
 #endif /* SV2_PROTOCOL_H */

--- a/components/stratum_v2/sv2_protocol.c
+++ b/components/stratum_v2/sv2_protocol.c
@@ -545,12 +545,14 @@ void sv2_ext_job_free(sv2_ext_job_t *job)
 
 // --- Helpers ---
 
-uint32_t sv2_target_to_pdiff(const uint8_t target[32])
+double sv2_target_to_pdiff(const uint8_t target[32])
 {
     double target_d = le256todouble(target);
-    if (target_d == 0.0) return UINT32_MAX;
+    if (target_d == 0.0) return (double)UINT32_MAX;
     double pdiff = truediffone / target_d;
-    if (pdiff > (double)UINT32_MAX) return UINT32_MAX;
-    if (pdiff < 1.0) return 1;
-    return (uint32_t)pdiff;
+    // Keep full precision: pools may use fractional difficulty (e.g. 931.1).
+    // Truncating to an integer here makes the submit threshold too low, so
+    // shares in [floor(pdiff), pdiff) get sent and rejected as difficulty-too-low.
+    if (pdiff < 1.0) return 1.0;
+    return pdiff;
 }

--- a/components/stratum_v2/sv2_protocol.c
+++ b/components/stratum_v2/sv2_protocol.c
@@ -542,17 +542,3 @@ void sv2_ext_job_free(sv2_ext_job_t *job)
     free(job->coinbase_suffix);
     free(job);
 }
-
-// --- Helpers ---
-
-double sv2_target_to_pdiff(const uint8_t target[32])
-{
-    double target_d = le256todouble(target);
-    if (target_d == 0.0) return (double)UINT32_MAX;
-    double pdiff = truediffone / target_d;
-    // Keep full precision: pools may use fractional difficulty (e.g. 931.1).
-    // Truncating to an integer here makes the submit threshold too low, so
-    // shares in [floor(pdiff), pdiff) get sent and rejected as difficulty-too-low.
-    if (pdiff < 1.0) return 1.0;
-    return pdiff;
-}

--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -11,6 +11,7 @@
 #include "connect.h"
 #include "sv2_protocol.h"
 #include "sv2_noise.h"
+#include "mining.h"
 #include "nvs_config.h"
 #include "work_queue.h"
 #include "utils.h"
@@ -546,7 +547,7 @@ static void stratum_v2_handle_set_target(GlobalState *GLOBAL_STATE, sv2_conn_t *
     }
 
     memcpy(conn->target, max_target, 32);
-    double pdiff = sv2_target_to_pdiff(max_target);
+    double pdiff = hash_to_pdiff(max_target);
     ESP_LOGI(TAG, "Set pool difficulty: %g", pdiff);
     GLOBAL_STATE->pool_difficulty = pdiff;
     GLOBAL_STATE->new_set_mining_difficulty_msg = true;
@@ -885,7 +886,7 @@ void stratum_v2_task(void *pvParameters)
             conn->channel_opened = true;
             memcpy(conn->target, target, 32);
 
-            double pdiff = sv2_target_to_pdiff(target);
+            double pdiff = hash_to_pdiff(target);
             GLOBAL_STATE->pool_difficulty = pdiff;
             GLOBAL_STATE->new_set_mining_difficulty_msg = true;
 

--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -546,8 +546,8 @@ static void stratum_v2_handle_set_target(GlobalState *GLOBAL_STATE, sv2_conn_t *
     }
 
     memcpy(conn->target, max_target, 32);
-    uint32_t pdiff = sv2_target_to_pdiff(max_target);
-    ESP_LOGI(TAG, "Set pool difficulty: %lu", pdiff);
+    double pdiff = sv2_target_to_pdiff(max_target);
+    ESP_LOGI(TAG, "Set pool difficulty: %g", pdiff);
     GLOBAL_STATE->pool_difficulty = pdiff;
     GLOBAL_STATE->new_set_mining_difficulty_msg = true;
 }
@@ -885,14 +885,14 @@ void stratum_v2_task(void *pvParameters)
             conn->channel_opened = true;
             memcpy(conn->target, target, 32);
 
-            uint32_t pdiff = sv2_target_to_pdiff(target);
+            double pdiff = sv2_target_to_pdiff(target);
             GLOBAL_STATE->pool_difficulty = pdiff;
             GLOBAL_STATE->new_set_mining_difficulty_msg = true;
 
             ESP_LOGI(TAG, "Mining channel opened: channel_id=%lu, group=%lu, type=%s",
                      channel_id, group_channel_id,
                      channel_type == SV2_CHANNEL_EXTENDED ? SV2_CHANNEL_TYPE_EXTENDED : SV2_CHANNEL_TYPE_STANDARD);
-            ESP_LOGI(TAG, "Set pool difficulty: %lu", pdiff);
+            ESP_LOGI(TAG, "Set pool difficulty: %g", pdiff);
         }
 
         // Connection successful, reset retry counter


### PR DESCRIPTION
In SV2 the pool derives the channel target from the miner's `nominal_hash_rate`, so fractional pool difficulties (e.g. `931.1`) are normal. `sv2_target_to_pdiff()` computed it as a `double` but returned `uint32_t`, truncating `931.1` → `931`. The submit threshold (`nonce_diff >= active_job->pool_diff`) then used `931`, so shares in `[931, 931.1)` were submitted and rejected by the pool as `difficulty-too-low`:

```
asic_result: ... Nonce 42B7858F diff 931.1 of 931.
stratum_v2_task: Share rejected: difficulty-too-low
```

Return the difficulty as a `double` to keep full precision through to the submit threshold. `GLOBAL_STATE->pool_difficulty` is already a `double`; only the two callers and the log format (`%lu` → `%g`) change. No valid shares are lost — the avoided ones were below the pool's real target and were being rejected anyway.
