### PR TITLE
Add GAMMA_12V board family for 12V single-phase Gamma clones (Starminer 601a)

### DIFF
--- a/main/device_config.h
+++ b/main/device_config.h
@@ -43,6 +43,7 @@ typedef enum
     GAMMA_DUO,
     SUPRA_HEX,
     GAMMA_TURBO,
+    GAMMA_12V,
 } Family;
 
 typedef struct {
@@ -111,6 +112,7 @@ static const FamilyConfig FAMILY_GAMMA       = { .id = GAMMA,       .name = "Gam
 static const FamilyConfig FAMILY_GAMMA_DUO   = { .id = GAMMA_DUO,   .name = "GammaDuo",   .asic = ASIC_BM1370XP, .asic_count = 2, .max_power =  40, .power_offset = 5,  .nominal_voltage = 5,  .voltage_domains = 1, .swarm_color = "green",    };
 static const FamilyConfig FAMILY_SUPRA_HEX   = { .id = SUPRA_HEX,   .name = "SupraHex",   .asic = ASIC_BM1368,   .asic_count = 6, .max_power = 120, .power_offset = 25, .nominal_voltage = 12, .voltage_domains = 3, .swarm_color = "darkblue", };
 static const FamilyConfig FAMILY_GAMMA_TURBO = { .id = GAMMA_TURBO, .name = "GammaTurbo", .asic = ASIC_BM1370,   .asic_count = 2, .max_power =  60, .power_offset = 10, .nominal_voltage = 12, .voltage_domains = 1, .swarm_color = "cyan",     };
+static const FamilyConfig FAMILY_GAMMA_12V   = { .id = GAMMA_12V,   .name = "Gamma12V",   .asic = ASIC_BM1370,   .asic_count = 1, .max_power =  40, .power_offset = 5,  .nominal_voltage = 12, .voltage_domains = 1, .swarm_color = "green",    };
 
 static const FamilyConfig default_families[] = {
     FAMILY_MAX,
@@ -120,6 +122,7 @@ static const FamilyConfig default_families[] = {
     FAMILY_GAMMA,
     FAMILY_SUPRA_HEX,
     FAMILY_GAMMA_TURBO,
+    FAMILY_GAMMA_12V,
 };
 
 static const DeviceConfig default_configs[] = {
@@ -140,6 +143,7 @@ static const DeviceConfig default_configs[] = {
     { .board_version = "403",  .family = FAMILY_SUPRA,       .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 8,  },
     { .board_version = "600",  .family = FAMILY_GAMMA,       .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 19, },
     { .board_version = "601",  .family = FAMILY_GAMMA,       .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 19, },
+    { .board_version = "601a", .family = FAMILY_GAMMA_12V,   .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 19, },
     { .board_version = "602",  .family = FAMILY_GAMMA,       .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 22, },
     { .board_version = "603",  .family = FAMILY_GAMMA,       .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 22, },
     { .board_version = "650",  .family = FAMILY_GAMMA_DUO,   .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 35, },

--- a/main/power/vcore.c
+++ b/main/power/vcore.c
@@ -42,6 +42,26 @@ static TPS546_CONFIG get_tps546_config(const FamilyConfig * family)
         config.TPS546_INIT_COMPENSATION_CONFIG[4] = 0x04;
         break;
 
+    case GAMMA_12V:
+        // Same single-phase / VOUT profile as the stock 5V Gamma (one TPS546, BM1370 @1.2V),
+        // but with VIN thresholds for a 12V-input redesign (values reused from the
+        // already-validated GAMMA_TURBO/HEX 12V profiles below).
+        config.TPS546_INIT_PHASE = TPS546_INIT_PHASE_SINGLE;
+        config.TPS546_INIT_VIN_ON = 11.0;
+        config.TPS546_INIT_VIN_OFF = 10.5;
+        config.TPS546_INIT_VIN_UV_WARN_LIMIT = 11.0;
+        config.TPS546_INIT_VIN_OV_FAULT_LIMIT = 14.0;
+        config.TPS546_INIT_SCALE_LOOP = 0.25;
+        config.TPS546_INIT_VOUT_MIN = 1;
+        config.TPS546_INIT_VOUT_MAX = 2;
+        config.TPS546_INIT_VOUT_COMMAND = 1.2;
+        config.TPS546_INIT_IOUT_OC_WARN_LIMIT = 25.00;
+        config.TPS546_INIT_IOUT_OC_FAULT_LIMIT = 30.00;
+        // Single-phase configuration (one physical TPS546 module)
+        config.TPS546_INIT_STACK_CONFIG = 0x0000; // 1 module
+        config.TPS546_INIT_SYNC_CONFIG = 0x10;    // Disable SYNC
+        break;
+
     case HEX:
     case SUPRA_HEX:
         config.TPS546_INIT_PHASE = TPS546_INIT_PHASE_SINGLE;


### PR DESCRIPTION
## Problem

Some Gamma clones (e.g. Starminer 601a) use a 12V input redesign while keeping a single TPS546 and BM1370. The community firmware fails self-test with:

VCORE:PWM FAULT
SELF-TEST FAIL

Root cause confirmed via serial log:
TPS546: VIN Overvoltage Fault
TPS546: The voltage regulator is turned off

The VIN_OV_FAULT_LIMIT was set to 6.5V (designed for 5V input boards). When the chip sees 12V on VIN, it triggers overvoltage protection and shuts down.

## Solution

Added a new GAMMA_12V family with corrected VIN thresholds:
- VIN_ON = 11.0V (was 4.8V)
- VIN_OV_FAULT_LIMIT = 14.0V (was 6.5V)
- Single-phase TPS546 (same as standard Gamma)
- BM1370 ASIC, VOUT = 1.2V (same as standard Gamma)

Registered boardversion="601a" to use this new family.

## Tested on Starminer 601a hardware

- Hashrate: 1.04 TH/s
- Power: 20W
- Input Voltage: 12V (confirmed in dashboard)
- Measured ASIC Voltage: 1.14V
- Error rate: 0.00%
- Shares: accepted, 0 rejected
- Self-test: PASS