### PR TITLE
Add SoloLuck pool to quicklink service

### DIFF
--- a/main/http_server/axe-os/src/app/services/quicklink.service.ts
+++ b/main/http_server/axe-os/src/app/services/quicklink.service.ts
@@ -32,6 +32,7 @@ export class QuicklinkService {
       { search: 'solohash.co.uk', url: `https://solohash.co.uk/user/${user}` },
       { search: 'solo.stratum.braiins.com', url: `https://solo.braiins.com/stats/${user}` },
       { search: 'parasite.wtf', url: `https://parasite.space/user/${user}` },
+      { search: 'sololuck.io', url: `https://sololuck.io/users/${user}` },
       { regex: /^(eu|au)?solo[46]?.ckpool\.org/, url: `https://$1solostats.ckpool.org/users/${user}` },
       { search: 'atlaspool.io', url: `https://atlaspool.io/dashboard.html?wallet=${user}` },
       { regex: /^(eu\.|tinyminer\.)?m45core\.com$/, url: `https://$1m45core.com/user/${user}` },


### PR DESCRIPTION
## What
Adds **SoloLuck** (`https://sololuck.io`) to the quick-link pool list so AxeOS shows a working "View stats" link for miners pointed at SoloLuck.

## Why
SoloLuck is a true-solo, non-custodial Bitcoin pool that exposes a per-address stats page at `/users/<address>` — the same convention several pools already in this list use. The stratum username is `<btc-address>.<worker>`, and `getQuickLink()` already derives `user = stratumUser.split('.')[0]`, so the address maps directly to the stats URL.

## Change
One entry added to the `pools` array, in the existing `search` format:

```ts
{ search: 'sololuck.io', url: `https://sololuck.io/users/${user}` },
```

The existing `=== search || endsWith('.' + search)` rule means this matches both `stratum.sololuck.io` and `pool.sololuck.io`.

## Verification
- `https://sololuck.io/users/<address>` returns that address's live stats page (HTTP 200, valid TLS).
- Mirrors the exact shape of existing entries such as `public-pool.io` and `atlaspool.io`.
