### PR TITLE
fix: clamp overheat throttle to the regulator's minimum voltage (no more false PSU fault)

### DIFF
--- a/main/power/vcore.c
+++ b/main/power/vcore.c
@@ -146,6 +146,20 @@ int16_t VCORE_get_voltage_mv(GlobalState * GLOBAL_STATE)
     return ADC_get_vcore();
 }
 
+// Lowest core voltage (mV) the regulator will accept. TPS546_set_vout() rejects
+// anything below VOUT_MIN as out of range, so callers must not command below this.
+int16_t VCORE_get_voltage_min_mv(GlobalState * GLOBAL_STATE)
+{
+    if (GLOBAL_STATE->DEVICE_CONFIG.TPS546) {
+        TPS546_CONFIG config = get_tps546_config(&GLOBAL_STATE->DEVICE_CONFIG.family);
+        uint16_t domains = GLOBAL_STATE->DEVICE_CONFIG.family.voltage_domains;
+        if (domains == 0) domains = 1;
+        // Round up so core_mv * domains never lands just below VOUT_MIN.
+        return (int16_t) ceilf(config.TPS546_INIT_VOUT_MIN / domains * 1000.0f);
+    }
+    return 0; // non-TPS546 boards have no PMBus minimum
+}
+
 esp_err_t VCORE_check_fault(GlobalState * GLOBAL_STATE)
 {
     if (GLOBAL_STATE->DEVICE_CONFIG.TPS546) {

--- a/main/power/vcore.h
+++ b/main/power/vcore.h
@@ -6,6 +6,7 @@
 esp_err_t VCORE_init(GlobalState * GLOBAL_STATE);
 esp_err_t VCORE_set_voltage(GlobalState * GLOBAL_STATE, float core_voltage);
 int16_t VCORE_get_voltage_mv(GlobalState * GLOBAL_STATE);
+int16_t VCORE_get_voltage_min_mv(GlobalState * GLOBAL_STATE);
 esp_err_t VCORE_check_fault(GlobalState * GLOBAL_STATE);
 const char* VCORE_get_fault_string(GlobalState * GLOBAL_STATE);
 

--- a/main/tasks/power_management_task.c
+++ b/main/tasks/power_management_task.c
@@ -211,7 +211,16 @@ void POWER_MANAGEMENT_task(void * pvParameters)
             
             uint16_t reduced_voltage = last_known_asic_voltage > ASIC_REDUCTION ? last_known_asic_voltage - ASIC_REDUCTION : 1000;
             float reduced_asic_frequency = last_known_asic_frequency > ASIC_REDUCTION ? last_known_asic_frequency - ASIC_REDUCTION : 400.0;
-            
+
+            // Never drop below the regulator's minimum core voltage. TPS546_set_vout()
+            // rejects anything lower (out of range), which leaves the VR stuck in a
+            // "power fault" — and the invalid value is persisted to NVS, so it survives
+            // reboots. Frequency reduction still provides the cooling headroom.
+            int16_t min_voltage = VCORE_get_voltage_min_mv(GLOBAL_STATE);
+            if (min_voltage > 0 && reduced_voltage < min_voltage) {
+                reduced_voltage = (uint16_t) min_voltage;
+            }
+
             nvs_config_set_u16(NVS_CONFIG_ASIC_VOLTAGE, reduced_voltage);
             nvs_config_set_float(NVS_CONFIG_ASIC_FREQUENCY, reduced_asic_frequency);
             


### PR DESCRIPTION
Ran into this the annoying way and figured it's worth fixing for everyone.

I always  undervolt my Gammas and run it at 1080mV. Even undervoltet on this hot day today around 40°c here it overheated a few times, and the overheat protection did its job, dropped voltage and frequency by 100 each and saved them. So my 1080mV quietly turned into 980mV in NVS. Actually I didn't check this explicitly because I ran arround changing PSUs and already thought that my little bee died because of high temp because the error message about the PSU didn't go away.

but the hing is, the TPS546's `VOUT_MIN` is 1.0V. Below that, `TPS546_set_vout()` rejects the value as out of range, the regulator never comes up clean, and the firmware flags a power fault → the UI shouts **"PSU fault, check your PSU"**. And since 980mV got written to NVS, it sticks across reboots. I swapped the PSU, power-cycled a bunch of times — nothing. The only thing that fixed it was going into settings and bumping the voltage back above 1000mV, at which point the fault vanished instantly.

So it's not the PSU at all. It's the throttle undervolting below what the regulator can actually deliver, and then persisting it.

I've already had several emails about this exact "PSU fault", people convinced their supply died, a couple of them bought a new one, and of course it still didn't help. Hence the fix.

**What it does:** clamps the throttle's reduced voltage to the regulator's minimum so it can never command something `set_vout()` will reject. Device-aware (`VOUT_MIN / voltage_domains` → 1000mV on Gamma, ~834mV on Hex), no magic number. Frequency reduction still happens exactly as before, so cooling behaviour is unchanged — it just won't push the voltage into the invalid range anymore.
