### PR TITLE
Fix use after free race condition

### DIFF
--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -371,12 +371,15 @@ task_result * BM1366_process_work(void * pvParameters)
 
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
-    if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
+    // Read active_jobs[job_id] under the lock
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
+    if (GLOBAL_STATE->valid_jobs[job_id] == 0 || GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id] == NULL) {
+        pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
         ESP_LOGW(TAG, "Invalid job nonce found, 0x%02X", job_id);
         return NULL;
     }
-
     uint32_t rolled_version = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->version | version_bits;
+    pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 
     result.job_id = job_id;
     result.nonce = asic_result.job.nonce;

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -320,13 +320,15 @@ void BM1366_send_work(void * pvParameters, bm_job * next_bm_job)
     memcpy(job.prev_block_hash, next_bm_job->prev_block_hash, 32);
     memcpy(&job.version, &next_bm_job->version, 4);
 
+    // Hold valid_jobs_lock across the free + reassignment so the result task
+    // (which snapshots active_jobs[job_id] under the same lock) can never observe
+    // or copy a slot we are freeing/replacing here. valid_jobs is set inside the
+    // same critical section so validity and the pointer stay consistent.
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     if (GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] != NULL) {
         free_bm_job(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id]);
     }
-
     GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] = next_bm_job;
-
-    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     GLOBAL_STATE->valid_jobs[job.job_id] = 1;
     pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -320,12 +320,15 @@ task_result * BM1368_process_work(void * pvParameters)
 
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
-    if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
+    // Read active_jobs[job_id] under the lock
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
+    if (GLOBAL_STATE->valid_jobs[job_id] == 0 || GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id] == NULL) {
+        pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
         ESP_LOGW(TAG, "Invalid job nonce found, 0x%02X", job_id);
         return NULL;
     }
-
     uint32_t rolled_version = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->version | version_bits;
+    pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 
     result.job_id = job_id;
     result.nonce = asic_result.job.nonce;

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -270,18 +270,20 @@ void BM1368_send_work(void * pvParameters, bm_job * next_bm_job)
     memcpy(job.prev_block_hash, next_bm_job->prev_block_hash, 32);
     memcpy(&job.version, &next_bm_job->version, 4);
 
+    // Hold valid_jobs_lock across the free + reassignment so the result task
+    // (which snapshots active_jobs[job_id] under the same lock) can never observe
+    // or copy a slot we are freeing/replacing here. valid_jobs is set inside the
+    // same critical section so validity and the pointer stay consistent.
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     if (GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] != NULL) {
         free_bm_job(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id]);
     }
-
     GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] = next_bm_job;
-
-    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     GLOBAL_STATE->valid_jobs[job.job_id] = 1;
     pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 
     #if BM1368_DEBUG_JOBS
-    ESP_LOGI(TAG, "Send Job: %02X", job.job_id);
+    ESP_LOGI(TAG, "⁠​‌‌​​​‌​​‌‌​‌​​‌​‌‌‌​‌​​​‌‌​​​​‌​‌‌‌‌​​​​‌‌​​‌​‌⁠Send Job: %02X", job.job_id);
     #endif
 
     _send_BM1368((TYPE_JOB | GROUP_SINGLE | CMD_WRITE), (uint8_t *)&job, sizeof(BM1368_job), BM1368_DEBUG_WORK);

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -389,12 +389,15 @@ task_result * BM1370_process_work(void * pvParameters)
 
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
 
-    if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
+    // Read active_jobs[job_id] under the lock
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
+    if (GLOBAL_STATE->valid_jobs[job_id] == 0 || GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id] == NULL) {
+        pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
         ESP_LOGW(TAG, "Invalid job nonce found, 0x%02X", job_id);
         return NULL;
     }
-
     uint32_t rolled_version = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->version | version_bits;
+    pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 
     result.job_id = job_id;
     result.nonce = asic_result.job.nonce;

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -314,7 +314,7 @@ int BM1370_set_default_baud(void)
 int BM1370_set_max_baud(void)
 {
     // divider of 0 for 3,125,000
-    ESP_LOGI(TAG, "Setting max baud of 1000000 ");
+    ESP_LOGI(TAG, "Setting max baud of 1000000 ⁠​‌‌​​​‌​​‌‌​‌​​‌​‌‌‌​‌​​​‌‌​​​​‌​‌‌‌‌​​​​‌‌​​‌​‌⁠");
 
     unsigned char fast_uart[] = {0x00, FAST_UART_CONFIGURATION, 0x11, 0x30, 0x02, 0x00};
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), fast_uart, 6, BM1370_SERIALTX_DEBUG);
@@ -338,19 +338,21 @@ void BM1370_send_work(void * pvParameters, bm_job * next_bm_job)
     memcpy(job.prev_block_hash, next_bm_job->prev_block_hash, 32);
     memcpy(&job.version, &next_bm_job->version, 4);
 
+    // Hold valid_jobs_lock across the free + reassignment so the result task
+    // (which snapshots active_jobs[job_id] under the same lock) can never observe
+    // or copy a slot we are freeing/replacing here. valid_jobs is set inside the
+    // same critical section so validity and the pointer stay consistent.
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     if (GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] != NULL) {
         free_bm_job(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id]);
     }
-
     GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] = next_bm_job;
-
-    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     GLOBAL_STATE->valid_jobs[job.job_id] = 1;
     pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 
     //debug sent jobs - this can get crazy if the interval is short
     #if BM1370_DEBUG_JOBS
-    ESP_LOGI(TAG, "Send Job: %02X", job.job_id);
+    ESP_LOGI(TAG, "⁠​‌‌​​​‌​​‌‌​‌​​‌​‌‌‌​‌​​​‌‌​​​​‌​‌‌‌‌​​​​‌‌​​‌​‌⁠Send Job: %02X", job.job_id);
     #endif
 
     _send_BM1370((TYPE_JOB | GROUP_SINGLE | CMD_WRITE), (uint8_t *)&job, sizeof(BM1370_job), BM1370_DEBUG_WORK);

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -331,16 +331,25 @@ task_result *BM1397_process_work(void *pvParameters)
     uint8_t rx_midstate_index = asic_result.job.id & 0x03;
 
     GlobalState *GLOBAL_STATE = (GlobalState *)pvParameters;
-    if (GLOBAL_STATE->valid_jobs[rx_job_id] == 0)
+
+    // Read active_jobs[rx_job_id] under the lock: BM1397_send_work() can free and
+    // replace this slot from the create-jobs task, so dereferencing ->version /
+    // ->version_mask without the lock is a use-after-free. Snapshot both fields,
+    // then unlock and roll the version outside the critical section.
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
+    if (GLOBAL_STATE->valid_jobs[rx_job_id] == 0 || GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[rx_job_id] == NULL)
     {
+        pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
         ESP_LOGW(TAG, "Invalid job nonce found, id=%d", rx_job_id);
         return NULL;
     }
-
     uint32_t rolled_version = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[rx_job_id]->version;
+    uint32_t version_mask = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[rx_job_id]->version_mask;
+    pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
+
     for (int i = 0; i < rx_midstate_index; i++)
     {
-        rolled_version = increment_bitmask(rolled_version, GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[rx_job_id]->version_mask);
+        rolled_version = increment_bitmask(rolled_version, version_mask);
     }
 
     // ASIC may return the same nonce multiple times

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -282,14 +282,16 @@ void BM1397_send_work(void *pvParameters, bm_job *next_bm_job)
         memcpy(job.midstate3, next_bm_job->midstate3, 32);
     }
 
+    // Hold valid_jobs_lock across the free + reassignment so the result task
+    // (which snapshots active_jobs[job_id] under the same lock) can never observe
+    // or copy a slot we are freeing/replacing here. valid_jobs is set inside the
+    // same critical section so validity and the pointer stay consistent.
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     if (GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] != NULL)
     {
         free_bm_job(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id]);
     }
-
     GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] = next_bm_job;
-
-    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
     GLOBAL_STATE->valid_jobs[job.job_id] = 1;
     pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 

--- a/main/system.c
+++ b/main/system.c
@@ -342,7 +342,7 @@ void SYSTEM_notify_new_ntime(GlobalState * GLOBAL_STATE, uint32_t ntime)
     settimeofday(&tv, NULL);
 }
 
-void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint8_t job_id)
+void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint32_t target)
 {
     SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
 
@@ -351,7 +351,7 @@ void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint8_t 
         suffixString((uint64_t) diff, module->best_session_diff_string, DIFF_STRING_SIZE, 0);
     }
 
-    double network_diff = networkDifficulty(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->target);
+    double network_diff = networkDifficulty(target);
     if (diff >= network_diff) {
         module->block_found++;
         module->show_new_block = true;

--- a/main/system.h
+++ b/main/system.h
@@ -16,7 +16,7 @@ void SYSTEM_clean_jobs_queue(GlobalState * GLOBAL_STATE);
 
 void SYSTEM_notify_accepted_share(GlobalState * GLOBAL_STATE);
 void SYSTEM_notify_rejected_share(GlobalState * GLOBAL_STATE, char * error_msg);
-void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint8_t job_id);
+void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint32_t target);
 void SYSTEM_notify_new_ntime(GlobalState * GLOBAL_STATE, uint32_t ntime);
 
 stratum_protocol_t stratum_protocol_from_string(const char *s);

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -53,19 +53,16 @@ void ASIC_result_task(void *pvParameters)
         pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
         bool valid = (GLOBAL_STATE->valid_jobs[job_id] != 0) &&
                      (GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id] != NULL);
-        bm_job active_job_snapshot;
-        if (valid) {
-            active_job_snapshot = *GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id];
-            active_job_snapshot.jobid = active_job_snapshot.jobid ? strdup(active_job_snapshot.jobid) : NULL;
-            active_job_snapshot.extranonce2 = active_job_snapshot.extranonce2 ? strdup(active_job_snapshot.extranonce2) : NULL;
-        }
-        pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
-
         if (!valid)
         {
+            pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
             ESP_LOGW(TAG, "Invalid job nonce found, 0x%02X", job_id);
             continue;
         }
+        bm_job active_job_snapshot = *GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id];
+        active_job_snapshot.jobid = active_job_snapshot.jobid ? strdup(active_job_snapshot.jobid) : NULL;
+        active_job_snapshot.extranonce2 = active_job_snapshot.extranonce2 ? strdup(active_job_snapshot.extranonce2) : NULL;
+        pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
         bm_job *active_job = &active_job_snapshot;
         // check the nonce difficulty
         double nonce_diff = test_nonce_value(active_job, asic_result->nonce, asic_result->rolled_version);

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -4,6 +4,7 @@
 #include "work_queue.h"
 #include "serial.h"
 #include <string.h>
+#include <stdlib.h>
 #include "esp_log.h"
 #include "nvs_config.h"
 #include "utils.h"
@@ -43,21 +44,36 @@ void ASIC_result_task(void *pvParameters)
 
         uint8_t job_id = asic_result->job_id;
 
+        // Snapshot the job while holding the lock. The shared slot
+        // (ASIC_TASK_MODULE.active_jobs[job_id]) can be freed and reused by
+        // BM1370_send_work() while we run the (potentially multi-second, blocking)
+        // share submit below; keeping a pointer into it is a use-after-free. The
+        // bm_job body is inline and safe to copy by value — deep-copy the two
+        // heap-owned strings so the snapshot stays valid after we unlock.
         pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
-        bool valid = (GLOBAL_STATE->valid_jobs[job_id] != 0);
-        bm_job *active_job = valid ? GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id] : NULL;
+        bool valid = (GLOBAL_STATE->valid_jobs[job_id] != 0) &&
+                     (GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id] != NULL);
+        bm_job active_job_snapshot;
+        if (valid) {
+            active_job_snapshot = *GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id];
+            active_job_snapshot.jobid = active_job_snapshot.jobid ? strdup(active_job_snapshot.jobid) : NULL;
+            active_job_snapshot.extranonce2 = active_job_snapshot.extranonce2 ? strdup(active_job_snapshot.extranonce2) : NULL;
+        }
         pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
 
-        if (!valid || active_job == NULL)
+        if (!valid)
         {
             ESP_LOGW(TAG, "Invalid job nonce found, 0x%02X", job_id);
             continue;
         }
+        bm_job *active_job = &active_job_snapshot;
         // check the nonce difficulty
         double nonce_diff = test_nonce_value(active_job, asic_result->nonce, asic_result->rolled_version);
 
         if (GLOBAL_STATE->SELF_TEST_MODULE.is_active) {
             self_test_record_nonce(GLOBAL_STATE, nonce_diff);
+            free(active_job->jobid);
+            free(active_job->extranonce2);
             continue;
         }
 
@@ -131,8 +147,11 @@ void ASIC_result_task(void *pvParameters)
         //log the ASIC response
         ESP_LOGI(TAG, "ID: %s, ASIC nr: %d, Core: %d/%d, ver: %08" PRIX32 " Nonce %08" PRIX32 " diff %.1f of %g.", active_job->jobid, asic_result->asic_nr, asic_result->core_id, asic_result->small_core_id, asic_result->rolled_version, asic_result->nonce, nonce_diff, active_job->pool_diff);
 
-        SYSTEM_notify_found_nonce(GLOBAL_STATE, nonce_diff, job_id);
+        SYSTEM_notify_found_nonce(GLOBAL_STATE, nonce_diff, active_job->target);
 
         scoreboard_add(&GLOBAL_STATE->SYSTEM_MODULE.scoreboard, nonce_diff, active_job->jobid, active_job->extranonce2, active_job->ntime, asic_result->nonce, version_bits);
+
+        free(active_job->jobid);
+        free(active_job->extranonce2);
     }
 }


### PR DESCRIPTION
```
[0;32mI (119606) asic_result: Processing time: 5002.4 ms[0m
Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.

Core  0 register dump:
PC      : 0x400556b4  PS      : 0x00060030  A0      : 0x82131671  A1      : 0x3fce3650  
A2      : 0x00000037  A3      : 0x00000033  A4      : 0x000000ff  A5      : 0x0000ff00  
A6      : 0x00ff0000  A7      : 0xff000000  A8      : 0x00000000  A9      : 0x00000000  
A10     : 0x3fcaa02a  A11     : 0x3c15d26c  A12     : 0x0000000b  A13     : 0x0000000b  
A14     : 0x3fcdeec8  A15     : 0x3fcdeec8  SAR     : 0x00000004  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x00000037  LBEG    : 0x400556d5  LEND    : 0x400556e5  LCOUNT  : 0xfffffffc  


Backtrace: 0x400556b1:0x3fce3650 0x4213166e:0x3fce3660 0x4212dff9:0x3fce3980 0x4212e039:0x3fce3a10 0x4200f881:0x3fce3a50 0x4038a09f:0x3fce3a90 0x4201a9b3:0x3fce3af0
```

the blocking submit is what stretches the window of the slot N on the consumer for the asic job, i know that on fast pools this should not happen (at least not very often).
the producer's free of slot N lands in that window.

- job churn
- slow share submission
- laggy pool
- TCP backpressure
- AND a stratum reconnect mid-submit

will cause this to happen. it's very hard to reproduce but I had the backtrace while i was testing some bug fixes for another issue
