### PR TITLE
fix: reduce sv2 minimum extranonce size from 6->2 bytes

### DIFF
--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -815,7 +815,7 @@ void stratum_v2_task(void *pvParameters)
             if (channel_type == SV2_CHANNEL_EXTENDED) {
                 ESP_LOGI(TAG, "Opening extended mining channel (user=%s)", user ? user : "(empty)");
                 frame_len = sv2_build_open_extended_mining_channel(frame_buf, SV2_MAX_FRAME_SIZE,
-                                                                    1, user ? user : "", hash_rate, 6);
+                                                                    1, user ? user : "", hash_rate, 2);
             } else {
                 ESP_LOGI(TAG, "Opening standard mining channel (user=%s)", user ? user : "(empty)");
                 frame_len = sv2_build_open_standard_mining_channel(frame_buf, SV2_MAX_FRAME_SIZE,


### PR DESCRIPTION
closes: #1780

should this be extracted into a constant, and where? we could also use this value to create the `version-rolling.min-bit-count` value for sv1 version rolling. i run a 2-byte extranonce myself, havent had any issues so im hoping this doesnt introduce any.

E: also, this hard minimum should be documented somewhere...