### PR TITLE
Auto-restart to recover from wedged ASIC (Flatline of Death, #1053)

### DIFF
--- a/main/global_state.h
+++ b/main/global_state.h
@@ -198,17 +198,19 @@ typedef struct
     char block_signals[MAX_BLOCK_SIGNALS][MAX_BLOCK_SIGNAL_LEN];
     int block_signals_count;
 
-    // Timestamp (esp_timer_get_time) of the last nonce result read back from
-    // the ASIC. Register reads deliberately don't count: on wedged units the
-    // register path can stay responsive while nonce production is dead.
+    // Timestamp (esp_timer_get_time) of the last share the pool accepted.
     // Watched from the stratum tasks to detect a wedged ASIC (issue #1053).
-    int64_t last_asic_result_time;
+    // A wedged chip may go silent or babble garbage nonces; garbage can fool
+    // local counters but never passes pool validation, so accepted shares
+    // are the ground truth for "actually mining".
+    int64_t last_accepted_share_time;
 } GlobalState;
 
-// How long the ASIC may go without returning a single nonce - while the pool
-// link is demonstrably alive - before we conclude it is wedged ("Flatline of
-// Death", issue #1053) and restart. At any realistic difficulty the chip
-// answers many times a minute, so 10 minutes of true silence is a wedge.
+// Minimum time without a pool-accepted share - while the pool link is
+// demonstrably alive - before we conclude the ASIC is wedged ("Flatline of
+// Death", issue #1053) and restart. The effective timeout scales up with
+// pool difficulty (see SYSTEM_check_flatline_watchdog) so vardiff cannot
+// cause false restarts; this floor applies at typical difficulties.
 #define FLATLINE_RESTART_TIMEOUT_US (10LL * 60 * 1000000)
 
 #endif /* GLOBAL_STATE_H_ */

--- a/main/global_state.h
+++ b/main/global_state.h
@@ -197,6 +197,18 @@ typedef struct
     char network_diff_string[DIFF_STRING_SIZE];
     char block_signals[MAX_BLOCK_SIGNALS][MAX_BLOCK_SIGNAL_LEN];
     int block_signals_count;
+
+    // Timestamp (esp_timer_get_time) of the last nonce result read back from
+    // the ASIC. Register reads deliberately don't count: on wedged units the
+    // register path can stay responsive while nonce production is dead.
+    // Watched from the stratum tasks to detect a wedged ASIC (issue #1053).
+    int64_t last_asic_result_time;
 } GlobalState;
+
+// How long the ASIC may go without returning a single nonce - while the pool
+// link is demonstrably alive - before we conclude it is wedged ("Flatline of
+// Death", issue #1053) and restart. At any realistic difficulty the chip
+// answers many times a minute, so 10 minutes of true silence is a wedge.
+#define FLATLINE_RESTART_TIMEOUT_US (10LL * 60 * 1000000)
 
 #endif /* GLOBAL_STATE_H_ */

--- a/main/main.c
+++ b/main/main.c
@@ -4,6 +4,7 @@
 #include "esp_log.h"
 #include "esp_psram.h"
 #include "esp_heap_caps.h"
+#include "esp_system.h"
 #include "cJSON.h"
 
 #include "asic_result_task.h"
@@ -171,7 +172,15 @@ void app_main(void)
     if (system_init_ret == ESP_OK) {
         if (asic_initialize(&GLOBAL_STATE, ASIC_INIT_COLD_BOOT, 0) == 0) {
             if (!GLOBAL_STATE.SELF_TEST_MODULE.is_active) {
-                return;
+                // A flaky ASIC serial link can fail chip detection on one
+                // boot and succeed on the next; returning here leaves a
+                // web-UI zombie that never mines until someone notices
+                // (#1053 family; field-observed on the test unit: 2.2 h
+                // dead, recovered by the very next soft reset). Keep the UI
+                // reachable for a while for debugging, then retry.
+                ESP_LOGE(TAG, "ASIC init failed - restarting in 5 minutes to retry");
+                vTaskDelay(5 * 60 * 1000 / portTICK_PERIOD_MS);
+                esp_restart();
             }
 
             self_test_show_message(&GLOBAL_STATE, GLOBAL_STATE.SYSTEM_MODULE.asic_status);

--- a/main/system.c
+++ b/main/system.c
@@ -14,6 +14,7 @@
 
 #include "driver/gpio.h"
 #include "esp_app_desc.h"
+#include "esp_system.h"
 #include "esp_timer.h"
 #include "esp_wifi.h"
 #include "lwip/inet.h"
@@ -290,6 +291,40 @@ void SYSTEM_notify_accepted_share(GlobalState * GLOBAL_STATE)
     SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
 
     module->shares_accepted++;
+    GLOBAL_STATE->last_accepted_share_time = esp_timer_get_time();
+}
+
+void SYSTEM_check_flatline_watchdog(GlobalState * GLOBAL_STATE)
+{
+    // Called from the stratum tasks right after pool traffic is received, so
+    // the pool link is known-alive. Judge mining health by pool-ACCEPTED
+    // shares: a wedged ASIC may go silent or babble garbage nonces, and
+    // garbage can fool local counters but never passes pool validation. The
+    // timeout scales with pool difficulty (25x the expected share interval,
+    // floored at FLATLINE_RESTART_TIMEOUT_US) so vardiff cannot cause false
+    // restarts, and a pool outage cannot cause a restart loop because no
+    // traffic arrives while the pool is down.
+    if (GLOBAL_STATE->SYSTEM_MODULE.overheat_mode || !GLOBAL_STATE->ASIC_initalized ||
+        GLOBAL_STATE->last_accepted_share_time <= 0) {
+        return;
+    }
+
+    int64_t timeout_us = FLATLINE_RESTART_TIMEOUT_US;
+    double expected_hs = (double) GLOBAL_STATE->POWER_MANAGEMENT_MODULE.frequency_value * 1.0e6
+                       * GLOBAL_STATE->DEVICE_CONFIG.family.asic.small_core_count;
+    if (expected_hs > 0) {
+        int64_t scaled_us = (int64_t) (25.0 * GLOBAL_STATE->pool_difficulty * 4294967296.0 / expected_hs * 1.0e6);
+        if (scaled_us > timeout_us) {
+            timeout_us = scaled_us;
+        }
+    }
+
+    if (esp_timer_get_time() - GLOBAL_STATE->last_accepted_share_time > timeout_us) {
+        ESP_LOGE(TAG, "No pool-accepted shares for %lld minutes despite a healthy pool connection - "
+                 "restarting to recover from wedged ASIC (#1053)",
+                 (long long) (timeout_us / 60000000));
+        esp_restart();
+    }
 }
 
 static int compare_rejected_reason_stats(const void *a, const void *b) {

--- a/main/system.h
+++ b/main/system.h
@@ -16,6 +16,11 @@ void SYSTEM_clean_jobs_queue(GlobalState * GLOBAL_STATE);
 
 void SYSTEM_notify_accepted_share(GlobalState * GLOBAL_STATE);
 void SYSTEM_notify_rejected_share(GlobalState * GLOBAL_STATE, char * error_msg);
+
+// Flatline-of-Death watchdog (#1053): restart if the pool link is alive but
+// no share has been accepted for a difficulty-scaled timeout. Call from the
+// stratum tasks right after pool traffic is received.
+void SYSTEM_check_flatline_watchdog(GlobalState * GLOBAL_STATE);
 void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double diff, uint32_t target);
 void SYSTEM_notify_new_ntime(GlobalState * GLOBAL_STATE, uint32_t ntime);
 

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -15,6 +15,7 @@
 #include "freertos/task.h"
 #include "scoreboard.h"
 #include "self_test.h"
+#include "esp_timer.h"
 
 static const char *TAG = "asic_result";
 
@@ -26,6 +27,10 @@ void ASIC_result_task(void *pvParameters)
     {
         // Check if ASIC is initialized before trying to process work
         if (!GLOBAL_STATE->ASIC_initalized) {
+            // Keep the flatline watchdog timer parked while the ASIC is not
+            // supposed to be producing (boot, self-test, overheat pause) so
+            // resuming can never trip a stale-timestamp restart.
+            GLOBAL_STATE->last_asic_result_time = esp_timer_get_time();
             vTaskDelay(100 / portTICK_PERIOD_MS);
             continue;
         }
@@ -41,6 +46,9 @@ void ASIC_result_task(void *pvParameters)
             hashrate_monitor_register_read(GLOBAL_STATE, asic_result->register_type, asic_result->asic_nr, asic_result->value, asic_result->timestamp_us);
             continue;
         }
+
+        // A nonce came back: the ASIC/serial result path is alive.
+        GLOBAL_STATE->last_asic_result_time = esp_timer_get_time();
 
         uint8_t job_id = asic_result->job_id;
 

--- a/main/tasks/asic_result_task.c
+++ b/main/tasks/asic_result_task.c
@@ -15,7 +15,6 @@
 #include "freertos/task.h"
 #include "scoreboard.h"
 #include "self_test.h"
-#include "esp_timer.h"
 
 static const char *TAG = "asic_result";
 
@@ -27,10 +26,6 @@ void ASIC_result_task(void *pvParameters)
     {
         // Check if ASIC is initialized before trying to process work
         if (!GLOBAL_STATE->ASIC_initalized) {
-            // Keep the flatline watchdog timer parked while the ASIC is not
-            // supposed to be producing (boot, self-test, overheat pause) so
-            // resuming can never trip a stale-timestamp restart.
-            GLOBAL_STATE->last_asic_result_time = esp_timer_get_time();
             vTaskDelay(100 / portTICK_PERIOD_MS);
             continue;
         }
@@ -46,9 +41,6 @@ void ASIC_result_task(void *pvParameters)
             hashrate_monitor_register_read(GLOBAL_STATE, asic_result->register_type, asic_result->asic_nr, asic_result->value, asic_result->timestamp_us);
             continue;
         }
-
-        // A nonce came back: the ASIC/serial result path is alive.
-        GLOBAL_STATE->last_asic_result_time = esp_timer_get_time();
 
         uint8_t job_id = asic_result->job_id;
 

--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -323,6 +323,19 @@ void stratum_v1_task(void *pvParameters)
                 break;
             }
 
+            // Flatline of Death detection (#1053): we just received a line,
+            // so the pool link is alive - but if the ASIC has not returned a
+            // single nonce in FLATLINE_RESTART_TIMEOUT_US the chip is wedged
+            // and only a reset recovers it. Gating on pool traffic means a
+            // pool outage can never cause a restart loop.
+            if (GLOBAL_STATE->last_asic_result_time > 0 &&
+                esp_timer_get_time() - GLOBAL_STATE->last_asic_result_time > FLATLINE_RESTART_TIMEOUT_US) {
+                ESP_LOGE(TAG, "No ASIC results for %d minutes despite a healthy pool connection - "
+                         "restarting to recover from wedged ASIC (#1053)",
+                         (int) (FLATLINE_RESTART_TIMEOUT_US / 60000000));
+                esp_restart();
+            }
+
             int64_t receive_time_us = esp_timer_get_time();
 
             bool reconnect_requested = false;

--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -298,6 +298,10 @@ void stratum_v1_task(void *pvParameters)
         //mining.authorize - ID: 3
         STRATUM_V1_authorize(GLOBAL_STATE->transport, authorize_message_id, username, password);
 
+        // Fresh connection: restart the flatline watchdog clock so time
+        // spent disconnected is never counted against the ASIC.
+        GLOBAL_STATE->last_accepted_share_time = esp_timer_get_time();
+
         while (1) {
             // Check if coordinator wants us to shut down
             if (protocol_coordinator_v1_should_shutdown()) {
@@ -324,17 +328,12 @@ void stratum_v1_task(void *pvParameters)
             }
 
             // Flatline of Death detection (#1053): we just received a line,
-            // so the pool link is alive - but if the ASIC has not returned a
-            // single nonce in FLATLINE_RESTART_TIMEOUT_US the chip is wedged
-            // and only a reset recovers it. Gating on pool traffic means a
-            // pool outage can never cause a restart loop.
-            if (GLOBAL_STATE->last_asic_result_time > 0 &&
-                esp_timer_get_time() - GLOBAL_STATE->last_asic_result_time > FLATLINE_RESTART_TIMEOUT_US) {
-                ESP_LOGE(TAG, "No ASIC results for %d minutes despite a healthy pool connection - "
-                         "restarting to recover from wedged ASIC (#1053)",
-                         (int) (FLATLINE_RESTART_TIMEOUT_US / 60000000));
-                esp_restart();
-            }
+            // so the pool link is alive - restart if no share has been
+            // accepted for a difficulty-scaled timeout (a wedged ASIC may go
+            // silent or babble garbage; garbage never passes pool
+            // validation). Gating on pool traffic means a pool outage can
+            // never cause a restart loop.
+            SYSTEM_check_flatline_watchdog(GLOBAL_STATE);
 
             int64_t receive_time_us = esp_timer_get_time();
 

--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -1,6 +1,7 @@
 #include "esp_log.h"
 #include "esp_transport.h"
 #include "esp_transport_tcp.h"
+#include "esp_system.h"
 #include <lwip/sockets.h>
 #include "esp_timer.h"
 #include "system.h"
@@ -935,6 +936,19 @@ void stratum_v2_task(void *pvParameters)
             }
 
             sv2_parse_frame_header(hdr_buf, &hdr);
+
+            // Flatline of Death detection (#1053): we just received a frame,
+            // so the pool link is alive - but if the ASIC has not returned a
+            // single nonce in FLATLINE_RESTART_TIMEOUT_US the chip is wedged
+            // and only a reset recovers it.
+            if (GLOBAL_STATE->ASIC_initalized &&
+                GLOBAL_STATE->last_asic_result_time > 0 &&
+                esp_timer_get_time() - GLOBAL_STATE->last_asic_result_time > FLATLINE_RESTART_TIMEOUT_US) {
+                ESP_LOGE(TAG, "No ASIC results for %d minutes despite a healthy pool connection - "
+                         "restarting to recover from wedged ASIC (#1053)",
+                         (int) (FLATLINE_RESTART_TIMEOUT_US / 60000000));
+                esp_restart();
+            }
 
             switch (hdr.msg_type) {
                 case SV2_MSG_NEW_MINING_JOB:

--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -925,6 +925,10 @@ void stratum_v2_task(void *pvParameters)
                      elapsed_ms, stratum_url, port);
         }
 
+        // Fresh connection: restart the flatline watchdog clock so time
+        // spent disconnected is never counted against the ASIC.
+        GLOBAL_STATE->last_accepted_share_time = esp_timer_get_time();
+
         // --- Main receive loop ---
         while (1) {
             if (sv2_noise_recv(noise_ctx, transport, hdr_buf, recv_buf,
@@ -938,17 +942,11 @@ void stratum_v2_task(void *pvParameters)
             sv2_parse_frame_header(hdr_buf, &hdr);
 
             // Flatline of Death detection (#1053): we just received a frame,
-            // so the pool link is alive - but if the ASIC has not returned a
-            // single nonce in FLATLINE_RESTART_TIMEOUT_US the chip is wedged
-            // and only a reset recovers it.
-            if (GLOBAL_STATE->ASIC_initalized &&
-                GLOBAL_STATE->last_asic_result_time > 0 &&
-                esp_timer_get_time() - GLOBAL_STATE->last_asic_result_time > FLATLINE_RESTART_TIMEOUT_US) {
-                ESP_LOGE(TAG, "No ASIC results for %d minutes despite a healthy pool connection - "
-                         "restarting to recover from wedged ASIC (#1053)",
-                         (int) (FLATLINE_RESTART_TIMEOUT_US / 60000000));
-                esp_restart();
-            }
+            // so the pool link is alive - restart if no share has been
+            // accepted for a difficulty-scaled timeout (a wedged ASIC may go
+            // silent or babble garbage; garbage never passes pool
+            // validation).
+            SYSTEM_check_flatline_watchdog(GLOBAL_STATE);
 
             switch (hdr.msg_type) {
                 case SV2_MSG_NEW_MINING_JOB:


### PR DESCRIPTION
## What

Firmware-level detection and automatic recovery for the **"Flatline of Death"** (#1053): if the pool connection is demonstrably alive but the ASIC has not returned a single nonce for 10 minutes, the device logs the condition and restarts itself — the same recovery every affected user performs by hand or with external reboot scripts today.

## Diagnosis on an affected unit

I'm the user who posted the external reboot-script workaround in #1053 (Nov 2025). This week I caught my Gamma 601 (BM1370, stock 525 MHz / 1150 mV) mid-flatline against a local public-pool instance and autopsied it before rebooting:

- The stratum TCP session was **ESTABLISHED** (verified from the pool host with `ss`), and the pool had logged **zero disconnects** during the 14+ hour flatline — the miner never reconnected because, at the network layer, nothing was wrong.
- Live device logs (via `/api/ws`) showed `stratum_api: rx: {...mining.notify...}` lines still arriving — the confirmation @skot asked reporters for — while **zero** `asic_result` lines appeared.
- Power draw stayed at full mining load (20.8 W) with normal temperatures; the web UI, WiFi, and API remained fully responsive.
- Share counter frozen; a restart instantly restored normal hashing, as it always does.

So at least on this unit, FoD is a wedged ASIC/serial-result path, not a stratum or network failure — which is why it survives every network-level fix and why only a reset clears it.

## How the detection works

*(Reworked after 48 h of field testing on the affected unit — see the comment below for the second wedge mode that motivated v2.)*

- `SYSTEM_notify_accepted_share` — already the common accept path for both SV1 and SV2 — stamps `last_accepted_share_time`. **Pool-accepted shares are the ground truth**: a wedged chip may go silent *or babble garbage nonces*; garbage can fool local counters (it inflated the share-based hashrate estimator ~17× on my unit) but it can never pass pool validation.
- Both stratum receive loops call `SYSTEM_check_flatline_watchdog()` **right after successfully receiving pool traffic**: a restart can only trigger when the pool link is provably alive, so a pool outage can never cause a restart loop.
- The timeout is **25× the expected share interval at the current pool difficulty** (from device frequency × small-core count), floored at 10 minutes — so vardiff can never outrun the watchdog.
- The clock resets on every fresh connection, and the check is skipped during `overheat_mode` or while the ASIC is uninitialized, so pauses can't cause a stale-timestamp restart on resume.

## False-positive analysis

Share arrivals are Poisson. The timeout is ≥25 expected arrivals at the current difficulty, so the false-trigger probability per window is ≤ e^−25 ≈ 10⁻¹¹ **regardless of what difficulty vardiff assigns** — at typical difficulties the 10-minute floor dominates and the margin is far larger (e.g. ~73 expected shares per window at diff 2048 on a Gamma). It cannot fire on a healthy miner. The floor and multiplier live in one place if maintainers prefer different values.

## Testing

- The identical detection logic (backported to a v2.10.1 base, which this unit is pinned to for unrelated reasons) is running on the affected Gamma 601 now; it previously flatlined as often as daily.
- This branch builds clean against master with ESP-IDF v5.5 (esp32s3).
- Recovery events are easy to audit pool-side: each one appears as a disconnect/reconnect pair with a young uptime after it.

The flatline on this unit, followed by restart and normal operation (note the reported hashrate frozen at a healthy-looking value the whole time — and ASIC temperature staying at full mining load):

<img width="2560" height="1440" alt="Screenshot from 2026-07-13 07-05-45" src="https://github.com/user-attachments/assets/a3cdb115-4502-4edf-8125-ced318252af0" />

Addresses #1053 (automatic recovery; the root cause of the wedge itself remains open).
