### PR TITLE
Fix inverted update system mock checks

### DIFF
--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -332,11 +332,11 @@ export class SystemApiService {
   }
 
   public updateSystem(uri: string = '', update: any): Observable<any | ISystemUpdateResponse> {
-    if (environment.mock && this.api && !uri) {
+    if (!environment.mock && this.api && !uri) {
       return from(this.api.invoke(functions.updateSystemSettings, { body: update as Settings }));
     }
 
-    if (environment.mock && uri) {
+    if (!environment.mock && uri) {
       return this.httpClient.patch(`${uri}/api/system`, update);
     }
 


### PR DESCRIPTION
## What changed

- Use the generated API client for local system-setting updates when mock mode is disabled.
- Use the HTTP PATCH endpoint for URI-targeted updates when mock mode is disabled.
- Preserve the existing mock responses when mock mode is enabled.

## Why

The `environment.mock` checks in `SystemApiService.updateSystem()` were inverted relative to the rest of the service. In production builds, both real update paths were skipped and the method fell through to a mock response, so settings could appear to update without being sent to the device.

## Validation

- `npm run build`
- `git diff --check`

The production frontend build completes successfully with the existing stylesheet budget warning for `home.component.scss`.

Fixes #1808
