### PR TITLE
Add optional password protection (HTTP Basic auth) for the AxeOS web interface

### DIFF
--- a/components/http_auth/CMakeLists.txt
+++ b/components/http_auth/CMakeLists.txt
@@ -1,0 +1,13 @@
+idf_component_register(
+SRCS
+    "http_auth.c"
+
+INCLUDE_DIRS
+    "include"
+
+REQUIRES
+    "esp_http_server"
+    "mbedtls"
+    "nvs_flash"
+    "esp_hw_support"
+)

--- a/components/http_auth/http_auth.c
+++ b/components/http_auth/http_auth.c
@@ -1,0 +1,416 @@
+#include "http_auth.h"
+
+#include <string.h>
+#include <strings.h>
+#include <stdlib.h>
+
+#include "esp_log.h"
+#include "esp_random.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+#include "mbedtls/sha256.h"
+#include "mbedtls/base64.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+static const char *TAG = "http_auth";
+
+// Credentials live in their own NVS namespace so they can never collide with,
+// or be dumped alongside, the regular device settings ("main" namespace).
+#define AUTH_NVS_NAMESPACE "authcfg"
+#define AUTH_NVS_KEY_USER  "user"
+#define AUTH_NVS_KEY_HASH  "hash"
+
+#define AUTH_SALT_LEN      16
+// "<32 hex salt>:<64 hex sha256>" = 97 chars + NUL. Round up for headroom.
+#define AUTH_HASH_STR_MAX  128
+#define AUTH_DEFAULT_USER  "admin"
+
+const char *const HTTP_AUTH_WWW_AUTHENTICATE = "Basic realm=\"AxeOS\", charset=\"UTF-8\"";
+
+// In-memory cache of the stored credentials. The HTTP hot path reads this under
+// the mutex and never touches NVS, keeping per-request cost negligible.
+static struct {
+    char username[HTTP_AUTH_USERNAME_MAX + 1];
+    char hash[AUTH_HASH_STR_MAX]; // empty string == authentication disabled
+    bool loaded;
+} s_auth = {0};
+
+static SemaphoreHandle_t s_mutex = NULL;
+
+// ---------------------------------------------------------------------------
+// Small pure helpers
+// ---------------------------------------------------------------------------
+
+static void bytes_to_hex(const uint8_t *in, size_t in_len, char *out)
+{
+    static const char digits[] = "0123456789abcdef";
+    for (size_t i = 0; i < in_len; i++) {
+        out[i * 2]     = digits[(in[i] >> 4) & 0x0F];
+        out[i * 2 + 1] = digits[in[i] & 0x0F];
+    }
+    out[in_len * 2] = '\0';
+}
+
+static int hex_nibble(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+// Decode a hex string into bytes. Returns the number of bytes written, or -1 on
+// error (odd length or non-hex characters, or output buffer too small).
+static int hex_to_bytes(const char *hex, size_t hex_len, uint8_t *out, size_t out_max)
+{
+    if (hex_len % 2 != 0 || hex_len / 2 > out_max) {
+        return -1;
+    }
+    for (size_t i = 0; i < hex_len; i += 2) {
+        int hi = hex_nibble(hex[i]);
+        int lo = hex_nibble(hex[i + 1]);
+        if (hi < 0 || lo < 0) {
+            return -1;
+        }
+        out[i / 2] = (uint8_t)((hi << 4) | lo);
+    }
+    return (int)(hex_len / 2);
+}
+
+bool http_auth_ct_equals(const char *a, const char *b)
+{
+    if (a == NULL || b == NULL) {
+        return false;
+    }
+    size_t la = strlen(a);
+    size_t lb = strlen(b);
+    // Compare lengths and every byte without early exit to avoid leaking timing.
+    unsigned char diff = (unsigned char)(la ^ lb);
+    size_t max = la > lb ? la : lb;
+    for (size_t i = 0; i < max; i++) {
+        char ca = i < la ? a[i] : 0;
+        char cb = i < lb ? b[i] : 0;
+        diff |= (unsigned char)(ca ^ cb);
+    }
+    return diff == 0;
+}
+
+esp_err_t http_auth_compute_hash(const uint8_t *salt, size_t salt_len,
+                                 const char *password,
+                                 char *out, size_t out_len)
+{
+    if (salt == NULL || password == NULL || out == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    // salt hex + ':' + 64 hex + NUL
+    if (out_len < salt_len * 2 + 1 + 64 + 1) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    uint8_t digest[32];
+    mbedtls_sha256_context ctx;
+    mbedtls_sha256_init(&ctx);
+    int rc = mbedtls_sha256_starts(&ctx, 0); // 0 => SHA-256
+    if (rc == 0) rc = mbedtls_sha256_update(&ctx, salt, salt_len);
+    if (rc == 0) rc = mbedtls_sha256_update(&ctx, (const unsigned char *)password, strlen(password));
+    if (rc == 0) rc = mbedtls_sha256_finish(&ctx, digest);
+    mbedtls_sha256_free(&ctx);
+    if (rc != 0) {
+        return ESP_FAIL;
+    }
+
+    bytes_to_hex(salt, salt_len, out);
+    size_t pos = salt_len * 2;
+    out[pos++] = ':';
+    bytes_to_hex(digest, sizeof(digest), out + pos);
+    return ESP_OK;
+}
+
+bool http_auth_verify_hash(const char *stored, const char *password)
+{
+    if (stored == NULL || password == NULL) {
+        return false;
+    }
+    const char *colon = strchr(stored, ':');
+    if (colon == NULL || colon == stored) {
+        return false;
+    }
+    size_t salt_hex_len = (size_t)(colon - stored);
+
+    uint8_t salt[AUTH_SALT_LEN];
+    int salt_len = hex_to_bytes(stored, salt_hex_len, salt, sizeof(salt));
+    if (salt_len <= 0) {
+        return false;
+    }
+
+    char computed[AUTH_HASH_STR_MAX];
+    if (http_auth_compute_hash(salt, (size_t)salt_len, password, computed, sizeof(computed)) != ESP_OK) {
+        return false;
+    }
+    bool ok = http_auth_ct_equals(computed, stored);
+    // Wipe the freshly computed hash from the stack.
+    memset(computed, 0, sizeof(computed));
+    return ok;
+}
+
+esp_err_t http_auth_parse_basic(const char *auth_header,
+                                char *user_out, size_t user_len,
+                                char *pass_out, size_t pass_len)
+{
+    if (auth_header == NULL || user_out == NULL || pass_out == NULL ||
+        user_len == 0 || pass_len == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    // Expect: "Basic <token>" (scheme is case-insensitive per RFC 7617).
+    const char *p = auth_header;
+    if (strncasecmp(p, "Basic", 5) != 0) {
+        return ESP_FAIL;
+    }
+    p += 5;
+    if (*p != ' ' && *p != '\t') {
+        return ESP_FAIL;
+    }
+    while (*p == ' ' || *p == '\t') {
+        p++;
+    }
+    if (*p == '\0') {
+        return ESP_FAIL;
+    }
+
+    // Decode base64(user:pass).
+    unsigned char decoded[HTTP_AUTH_USERNAME_MAX + HTTP_AUTH_PASSWORD_MAX + 4];
+    size_t olen = 0;
+    int rc = mbedtls_base64_decode(decoded, sizeof(decoded) - 1, &olen,
+                                   (const unsigned char *)p, strlen(p));
+    if (rc != 0) {
+        return ESP_FAIL;
+    }
+    decoded[olen] = '\0';
+
+    // Split at the FIRST ':' (usernames cannot contain ':', passwords can).
+    char *sep = strchr((char *)decoded, ':');
+    if (sep == NULL) {
+        memset(decoded, 0, sizeof(decoded));
+        return ESP_FAIL;
+    }
+    *sep = '\0';
+    const char *user = (const char *)decoded;
+    const char *pass = sep + 1;
+
+    esp_err_t ret = ESP_OK;
+    if (strlen(user) >= user_len || strlen(pass) >= pass_len) {
+        ret = ESP_ERR_INVALID_SIZE;
+    } else {
+        strlcpy(user_out, user, user_len);
+        strlcpy(pass_out, pass, pass_len);
+    }
+
+    memset(decoded, 0, sizeof(decoded));
+    return ret;
+}
+
+// ---------------------------------------------------------------------------
+// NVS-backed credential storage (with an in-RAM cache for the hot path)
+// ---------------------------------------------------------------------------
+
+static esp_err_t ensure_mutex(void)
+{
+    if (s_mutex == NULL) {
+        s_mutex = xSemaphoreCreateMutex();
+        if (s_mutex == NULL) {
+            return ESP_ERR_NO_MEM;
+        }
+    }
+    return ESP_OK;
+}
+
+// Read a string value from the auth namespace into buf. On any error buf is set
+// to the empty string. Returns ESP_OK when a value was read, ESP_ERR_NOT_FOUND
+// otherwise.
+static esp_err_t nvs_read_str(const char *key, char *buf, size_t buf_len)
+{
+    buf[0] = '\0';
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(AUTH_NVS_NAMESPACE, NVS_READONLY, &h);
+    if (err != ESP_OK) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    size_t len = buf_len;
+    err = nvs_get_str(h, key, buf, &len);
+    nvs_close(h);
+    if (err != ESP_OK) {
+        buf[0] = '\0';
+        return ESP_ERR_NOT_FOUND;
+    }
+    return ESP_OK;
+}
+
+esp_err_t http_auth_init(void)
+{
+    esp_err_t err = ensure_mutex();
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+
+    char user[HTTP_AUTH_USERNAME_MAX + 1];
+    char hash[AUTH_HASH_STR_MAX];
+    if (nvs_read_str(AUTH_NVS_KEY_USER, user, sizeof(user)) != ESP_OK || user[0] == '\0') {
+        strlcpy(user, AUTH_DEFAULT_USER, sizeof(user));
+    }
+    nvs_read_str(AUTH_NVS_KEY_HASH, hash, sizeof(hash));
+
+    strlcpy(s_auth.username, user, sizeof(s_auth.username));
+    strlcpy(s_auth.hash, hash, sizeof(s_auth.hash));
+    s_auth.loaded = true;
+
+    bool enabled = s_auth.hash[0] != '\0';
+    xSemaphoreGive(s_mutex);
+
+    ESP_LOGI(TAG, "Web authentication %s", enabled ? "ENABLED" : "disabled");
+    return ESP_OK;
+}
+
+bool http_auth_is_enabled(void)
+{
+    if (s_mutex == NULL) {
+        return false;
+    }
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    bool enabled = s_auth.loaded && s_auth.hash[0] != '\0';
+    xSemaphoreGive(s_mutex);
+    return enabled;
+}
+
+esp_err_t http_auth_get_username(char *out, size_t out_len)
+{
+    if (out == NULL || out_len == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (s_mutex == NULL) {
+        strlcpy(out, AUTH_DEFAULT_USER, out_len);
+        return ESP_OK;
+    }
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    strlcpy(out, s_auth.username[0] ? s_auth.username : AUTH_DEFAULT_USER, out_len);
+    xSemaphoreGive(s_mutex);
+    return ESP_OK;
+}
+
+esp_err_t http_auth_set_credentials(const char *username, const char *password)
+{
+    esp_err_t err = ensure_mutex();
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    // Validate lengths up-front.
+    if (username != NULL && strlen(username) > HTTP_AUTH_USERNAME_MAX) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (password != NULL && strlen(password) > HTTP_AUTH_PASSWORD_MAX) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    char new_user[HTTP_AUTH_USERNAME_MAX + 1];
+    if (username != NULL && username[0] != '\0') {
+        strlcpy(new_user, username, sizeof(new_user));
+    } else {
+        // Keep the existing username, or fall back to the default.
+        http_auth_get_username(new_user, sizeof(new_user));
+    }
+
+    char new_hash[AUTH_HASH_STR_MAX];
+    new_hash[0] = '\0';
+    bool disabling = (password == NULL || password[0] == '\0');
+    if (!disabling) {
+        uint8_t salt[AUTH_SALT_LEN];
+        esp_fill_random(salt, sizeof(salt));
+        err = http_auth_compute_hash(salt, sizeof(salt), password, new_hash, sizeof(new_hash));
+        memset(salt, 0, sizeof(salt));
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
+
+    // Persist to NVS.
+    nvs_handle_t h;
+    err = nvs_open(AUTH_NVS_NAMESPACE, NVS_READWRITE, &h);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS namespace: %s", esp_err_to_name(err));
+        return err;
+    }
+    esp_err_t e1 = nvs_set_str(h, AUTH_NVS_KEY_USER, new_user);
+    esp_err_t e2 = nvs_set_str(h, AUTH_NVS_KEY_HASH, new_hash);
+    esp_err_t e3 = nvs_commit(h);
+    nvs_close(h);
+    if (e1 != ESP_OK || e2 != ESP_OK || e3 != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to persist credentials");
+        return ESP_FAIL;
+    }
+
+    // Update the cache only after a successful commit.
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    strlcpy(s_auth.username, new_user, sizeof(s_auth.username));
+    strlcpy(s_auth.hash, new_hash, sizeof(s_auth.hash));
+    s_auth.loaded = true;
+    xSemaphoreGive(s_mutex);
+
+    memset(new_hash, 0, sizeof(new_hash));
+    ESP_LOGI(TAG, "Web authentication %s", disabling ? "disabled" : "enabled/updated");
+    return ESP_OK;
+}
+
+esp_err_t http_auth_check_request(httpd_req_t *req)
+{
+    if (req == NULL || s_mutex == NULL) {
+        return ESP_FAIL;
+    }
+
+    size_t hdr_len = httpd_req_get_hdr_value_len(req, "Authorization");
+    if (hdr_len == 0 || hdr_len > 512) {
+        return ESP_FAIL;
+    }
+    char *hdr = malloc(hdr_len + 1);
+    if (hdr == NULL) {
+        return ESP_FAIL;
+    }
+    if (httpd_req_get_hdr_value_str(req, "Authorization", hdr, hdr_len + 1) != ESP_OK) {
+        free(hdr);
+        return ESP_FAIL;
+    }
+
+    char user[HTTP_AUTH_USERNAME_MAX + 1];
+    char pass[HTTP_AUTH_PASSWORD_MAX + 1];
+    esp_err_t parsed = http_auth_parse_basic(hdr, user, sizeof(user), pass, sizeof(pass));
+    free(hdr);
+    if (parsed != ESP_OK) {
+        return ESP_FAIL;
+    }
+
+    // Snapshot the stored credentials under the mutex.
+    char stored_user[HTTP_AUTH_USERNAME_MAX + 1];
+    char stored_hash[AUTH_HASH_STR_MAX];
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    strlcpy(stored_user, s_auth.username, sizeof(stored_user));
+    strlcpy(stored_hash, s_auth.hash, sizeof(stored_hash));
+    xSemaphoreGive(s_mutex);
+
+    esp_err_t result = ESP_FAIL;
+    if (stored_hash[0] != '\0') {
+        bool user_ok = http_auth_ct_equals(user, stored_user);
+        bool pass_ok = http_auth_verify_hash(stored_hash, pass);
+        if (user_ok && pass_ok) {
+            result = ESP_OK;
+        }
+    }
+
+    // Wipe sensitive stack buffers.
+    memset(user, 0, sizeof(user));
+    memset(pass, 0, sizeof(pass));
+    memset(stored_hash, 0, sizeof(stored_hash));
+    return result;
+}

--- a/components/http_auth/http_auth.c
+++ b/components/http_auth/http_auth.c
@@ -25,6 +25,9 @@ static const char *TAG = "http_auth";
 // "<32 hex salt>:<64 hex sha256>" = 97 chars + NUL. Round up for headroom.
 #define AUTH_HASH_STR_MAX  128
 #define AUTH_DEFAULT_USER  "admin"
+// Upper bound for the "Authorization" header we will parse (base64 of user:pass
+// plus the "Basic " prefix stays well under this).
+#define AUTH_HEADER_MAX    512
 
 const char *const HTTP_AUTH_WWW_AUTHENTICATE = "Basic realm=\"AxeOS\", charset=\"UTF-8\"";
 
@@ -372,7 +375,7 @@ esp_err_t http_auth_check_request(httpd_req_t *req)
     }
 
     size_t hdr_len = httpd_req_get_hdr_value_len(req, "Authorization");
-    if (hdr_len == 0 || hdr_len > 512) {
+    if (hdr_len == 0 || hdr_len > AUTH_HEADER_MAX) {
         return ESP_FAIL;
     }
     char *hdr = malloc(hdr_len + 1);

--- a/components/http_auth/http_auth.c
+++ b/components/http_auth/http_auth.c
@@ -249,12 +249,11 @@ static esp_err_t nvs_read_str(const char *key, char *buf, size_t buf_len)
 
 esp_err_t http_auth_init(void)
 {
-    esp_err_t err = ensure_mutex();
-    if (err != ESP_OK) {
-        return err;
-    }
-
-    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    // Best-effort mutex creation. We deliberately continue even if it fails so
+    // that a configured password is still reflected by http_auth_is_enabled():
+    // that makes a mutex failure fail CLOSED (deny, recover via AP mode) rather
+    // than fail open. There is no concurrency during init.
+    ensure_mutex();
 
     char user[HTTP_AUTH_USERNAME_MAX + 1];
     char hash[AUTH_HASH_STR_MAX];
@@ -263,12 +262,12 @@ esp_err_t http_auth_init(void)
     }
     nvs_read_str(AUTH_NVS_KEY_HASH, hash, sizeof(hash));
 
+    if (s_mutex != NULL) xSemaphoreTake(s_mutex, portMAX_DELAY);
     strlcpy(s_auth.username, user, sizeof(s_auth.username));
     strlcpy(s_auth.hash, hash, sizeof(s_auth.hash));
     s_auth.loaded = true;
-
     bool enabled = s_auth.hash[0] != '\0';
-    xSemaphoreGive(s_mutex);
+    if (s_mutex != NULL) xSemaphoreGive(s_mutex);
 
     ESP_LOGI(TAG, "Web authentication %s", enabled ? "ENABLED" : "disabled");
     return ESP_OK;
@@ -276,12 +275,14 @@ esp_err_t http_auth_init(void)
 
 bool http_auth_is_enabled(void)
 {
-    if (s_mutex == NULL) {
-        return false;
-    }
-    xSemaphoreTake(s_mutex, portMAX_DELAY);
-    bool enabled = s_auth.loaded && s_auth.hash[0] != '\0';
-    xSemaphoreGive(s_mutex);
+    // Reflect the stored password even when the mutex is unavailable so a
+    // configured password is never silently ignored. When a password is set
+    // but the mutex failed, http_auth_check_request() denies every request
+    // (fail closed); recovery is still possible through AP setup mode.
+    bool enabled;
+    if (s_mutex != NULL) xSemaphoreTake(s_mutex, portMAX_DELAY);
+    enabled = s_auth.loaded && s_auth.hash[0] != '\0';
+    if (s_mutex != NULL) xSemaphoreGive(s_mutex);
     return enabled;
 }
 

--- a/components/http_auth/include/http_auth.h
+++ b/components/http_auth/include/http_auth.h
@@ -1,0 +1,72 @@
+#ifndef HTTP_AUTH_H
+#define HTTP_AUTH_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include "esp_err.h"
+#include "esp_http_server.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Maximum accepted lengths for the credentials.
+#define HTTP_AUTH_USERNAME_MAX 32
+#define HTTP_AUTH_PASSWORD_MAX 64
+
+// Value for the "WWW-Authenticate" response header. Sending this on a 401 makes
+// the browser show its native login dialog.
+extern const char *const HTTP_AUTH_WWW_AUTHENTICATE;
+
+// Load the stored credentials into the in-memory cache. Must be called once,
+// after NVS has been initialised and before the HTTP server starts serving.
+// Safe to call multiple times.
+esp_err_t http_auth_init(void);
+
+// True when a password has been configured (i.e. authentication is active).
+bool http_auth_is_enabled(void);
+
+// Copy the configured username (default "admin") into out. Returns ESP_OK.
+esp_err_t http_auth_get_username(char *out, size_t out_len);
+
+// Configure the credentials and persist them to NVS.
+//   - A NULL or empty password DISABLES authentication (clears the password).
+//   - username may be NULL/empty to keep the default ("admin").
+// Returns ESP_OK on success or ESP_ERR_INVALID_ARG when the input is too long.
+esp_err_t http_auth_set_credentials(const char *username, const char *password);
+
+// Validate the request's "Authorization: Basic ..." header against the stored
+// credentials. Returns ESP_OK when the credentials are valid, ESP_FAIL otherwise.
+// Always returns ESP_FAIL when authentication is disabled.
+esp_err_t http_auth_check_request(httpd_req_t *req);
+
+// -------------------------------------------------------------------------
+// Pure helpers (no NVS / no global state) - exposed for unit testing.
+// -------------------------------------------------------------------------
+
+// Parse a "Basic <base64(user:pass)>" header into user/pass. The scheme name is
+// matched case-insensitively. The username stops at the first ':' so passwords
+// may themselves contain ':'. Returns ESP_OK on success.
+esp_err_t http_auth_parse_basic(const char *auth_header,
+                                char *user_out, size_t user_len,
+                                char *pass_out, size_t pass_len);
+
+// Compute "<saltHex>:<hashHex>" (hex(salt) ':' hex(sha256(salt || password)))
+// into out. Returns ESP_OK on success.
+esp_err_t http_auth_compute_hash(const uint8_t *salt, size_t salt_len,
+                                 const char *password,
+                                 char *out, size_t out_len);
+
+// Verify a plaintext password against a stored "<saltHex>:<hashHex>" string.
+// Returns true when the password matches.
+bool http_auth_verify_hash(const char *stored, const char *password);
+
+// Constant-time string comparison. Returns true when the strings are equal.
+bool http_auth_ct_equals(const char *a, const char *b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // HTTP_AUTH_H

--- a/components/http_auth/test/CMakeLists.txt
+++ b/components/http_auth/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRC_DIRS "."
+                    INCLUDE_DIRS "."
+                    REQUIRES cmock http_auth)

--- a/components/http_auth/test/test_http_auth.c
+++ b/components/http_auth/test/test_http_auth.c
@@ -1,0 +1,141 @@
+#include <string.h>
+#include "unity.h"
+#include "http_auth.h"
+
+// Fixed salt 0x00..0x0f used for deterministic hashing vectors.
+static const uint8_t TEST_SALT[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+
+// Precomputed with Python: sha256(bytes(range(16)) + b"hunter2").
+#define STORED_HUNTER2 "000102030405060708090a0b0c0d0e0f:" \
+                       "e8d1e18507861757b13674f2e9d0e9149ed6667f432ad5b8220f9c049a29dc54"
+
+// sha256(bytes(range(16)) + b"p@ss:word:with:colons")
+#define STORED_COLONS  "000102030405060708090a0b0c0d0e0f:" \
+                       "449fe551ace188a331dfa9f04d67d281b729a8ef84c818b48b2de40ca82a7e9a"
+
+TEST_CASE("http_auth: constant-time equals", "[http_auth]")
+{
+    TEST_ASSERT_TRUE(http_auth_ct_equals("abc", "abc"));
+    TEST_ASSERT_TRUE(http_auth_ct_equals("", ""));
+    TEST_ASSERT_FALSE(http_auth_ct_equals("abc", "abd"));
+    TEST_ASSERT_FALSE(http_auth_ct_equals("abc", "ab"));   // different length
+    TEST_ASSERT_FALSE(http_auth_ct_equals("ab", "abc"));   // different length
+    TEST_ASSERT_FALSE(http_auth_ct_equals(NULL, "abc"));
+    TEST_ASSERT_FALSE(http_auth_ct_equals("abc", NULL));
+}
+
+TEST_CASE("http_auth: compute_hash produces expected salt:hash", "[http_auth]")
+{
+    char out[128];
+    TEST_ASSERT_EQUAL(ESP_OK, http_auth_compute_hash(TEST_SALT, sizeof(TEST_SALT), "hunter2", out, sizeof(out)));
+    TEST_ASSERT_EQUAL_STRING(STORED_HUNTER2, out);
+}
+
+TEST_CASE("http_auth: compute_hash rejects tiny output buffer", "[http_auth]")
+{
+    char out[8];
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, http_auth_compute_hash(TEST_SALT, sizeof(TEST_SALT), "hunter2", out, sizeof(out)));
+}
+
+TEST_CASE("http_auth: verify_hash accepts the right password", "[http_auth]")
+{
+    TEST_ASSERT_TRUE(http_auth_verify_hash(STORED_HUNTER2, "hunter2"));
+}
+
+TEST_CASE("http_auth: verify_hash rejects the wrong password", "[http_auth]")
+{
+    TEST_ASSERT_FALSE(http_auth_verify_hash(STORED_HUNTER2, "hunter3"));
+    TEST_ASSERT_FALSE(http_auth_verify_hash(STORED_HUNTER2, ""));
+    TEST_ASSERT_FALSE(http_auth_verify_hash(STORED_HUNTER2, "Hunter2"));
+}
+
+TEST_CASE("http_auth: verify_hash rejects malformed stored strings", "[http_auth]")
+{
+    TEST_ASSERT_FALSE(http_auth_verify_hash("", "hunter2"));
+    TEST_ASSERT_FALSE(http_auth_verify_hash("no-colon-here", "hunter2"));
+    TEST_ASSERT_FALSE(http_auth_verify_hash(":onlyhash", "hunter2"));     // empty salt
+    TEST_ASSERT_FALSE(http_auth_verify_hash("zzzz:abcd", "hunter2"));     // non-hex salt
+    TEST_ASSERT_FALSE(http_auth_verify_hash(NULL, "hunter2"));
+    TEST_ASSERT_FALSE(http_auth_verify_hash(STORED_HUNTER2, NULL));
+}
+
+TEST_CASE("http_auth: roundtrip hash then verify", "[http_auth]")
+{
+    // A different salt would be used in production; here we reuse TEST_SALT to
+    // prove compute + verify agree.
+    char out[128];
+    TEST_ASSERT_EQUAL(ESP_OK, http_auth_compute_hash(TEST_SALT, sizeof(TEST_SALT), "s3cr3t!", out, sizeof(out)));
+    TEST_ASSERT_TRUE(http_auth_verify_hash(out, "s3cr3t!"));
+    TEST_ASSERT_FALSE(http_auth_verify_hash(out, "s3cr3t"));
+}
+
+TEST_CASE("http_auth: parse_basic decodes user and pass", "[http_auth]")
+{
+    char user[33];
+    char pass[65];
+    // base64("admin:hunter2")
+    TEST_ASSERT_EQUAL(ESP_OK, http_auth_parse_basic("Basic YWRtaW46aHVudGVyMg==",
+                                                    user, sizeof(user), pass, sizeof(pass)));
+    TEST_ASSERT_EQUAL_STRING("admin", user);
+    TEST_ASSERT_EQUAL_STRING("hunter2", pass);
+}
+
+TEST_CASE("http_auth: parse_basic keeps colons in the password", "[http_auth]")
+{
+    char user[33];
+    char pass[65];
+    // base64("admin:p@ss:word:with:colons")
+    TEST_ASSERT_EQUAL(ESP_OK, http_auth_parse_basic("Basic YWRtaW46cEBzczp3b3JkOndpdGg6Y29sb25z",
+                                                    user, sizeof(user), pass, sizeof(pass)));
+    TEST_ASSERT_EQUAL_STRING("admin", user);
+    TEST_ASSERT_EQUAL_STRING("p@ss:word:with:colons", pass);
+}
+
+TEST_CASE("http_auth: parse_basic is case-insensitive on the scheme", "[http_auth]")
+{
+    char user[33];
+    char pass[65];
+    TEST_ASSERT_EQUAL(ESP_OK, http_auth_parse_basic("basic YWRtaW46aHVudGVyMg==",
+                                                    user, sizeof(user), pass, sizeof(pass)));
+    TEST_ASSERT_EQUAL_STRING("admin", user);
+}
+
+TEST_CASE("http_auth: parse_basic rejects malformed headers", "[http_auth]")
+{
+    char user[33];
+    char pass[65];
+    // Wrong scheme.
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, http_auth_parse_basic("Bearer YWRtaW46aHVudGVyMg==",
+                                                        user, sizeof(user), pass, sizeof(pass)));
+    // No colon inside decoded token: base64("user").
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, http_auth_parse_basic("Basic dXNlcg==",
+                                                        user, sizeof(user), pass, sizeof(pass)));
+    // Empty token.
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, http_auth_parse_basic("Basic ",
+                                                        user, sizeof(user), pass, sizeof(pass)));
+    // Not base64.
+    TEST_ASSERT_NOT_EQUAL(ESP_OK, http_auth_parse_basic("Basic !!!not-base64!!!",
+                                                        user, sizeof(user), pass, sizeof(pass)));
+}
+
+TEST_CASE("http_auth: parse_basic enforces output bounds", "[http_auth]")
+{
+    char user[3];   // too small for "admin"
+    char pass[65];
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_SIZE,
+                      http_auth_parse_basic("Basic YWRtaW46aHVudGVyMg==",
+                                            user, sizeof(user), pass, sizeof(pass)));
+}
+
+TEST_CASE("http_auth: full parse + verify flow", "[http_auth]")
+{
+    char user[33];
+    char pass[65];
+    // A client presenting admin / p@ss:word:with:colons must verify against the
+    // stored hash for that password.
+    TEST_ASSERT_EQUAL(ESP_OK, http_auth_parse_basic("Basic YWRtaW46cEBzczp3b3JkOndpdGg6Y29sb25z",
+                                                    user, sizeof(user), pass, sizeof(pass)));
+    TEST_ASSERT_TRUE(http_auth_ct_equals("admin", user));
+    TEST_ASSERT_TRUE(http_auth_verify_hash(STORED_COLONS, pass));
+    TEST_ASSERT_FALSE(http_auth_verify_hash(STORED_HUNTER2, pass));
+}

--- a/doc/web-authentication.md
+++ b/doc/web-authentication.md
@@ -14,8 +14,9 @@ same Wi-Fi/LAN from reading data or changing settings/firmware without credentia
   calls `http_auth_gate()`; the static-file handler calls it too so the login
   dialog appears on the first page load. When enabled, every `/api/*` route,
   both WebSockets, and OTA are covered.
-- **Recovery.** AP setup mode (hold `BOOT`) bypasses auth so a forgotten password
-  can always be reset from **Settings → Security**. Erasing NVS also clears it
+- **Recovery.** AP setup mode (hold `BOOT`) bypasses auth, and the setup page shows
+  the **Security** panel so a forgotten password can always be cleared there
+  (the normal Settings pages are redirected to the setup page in AP mode). Erasing NVS also clears it
   (a full factory-image flash or `idf.py erase-flash`); a plain app-only re-flash
   keeps the stored hash because it lives in the separate `nvs` partition.
 - **Storage.** Only a salted SHA-256 hash is kept, in its own NVS namespace

--- a/doc/web-authentication.md
+++ b/doc/web-authentication.md
@@ -1,0 +1,96 @@
+# Web Authentication
+
+Optional password protection for the AxeOS web interface. It stops anyone on the
+same Wi-Fi/LAN from reading data or changing settings/firmware without credentials.
+
+## How it works
+
+- **HTTP Basic auth.** The browser shows its native sign-in dialog and re-sends
+  the credentials to every same-origin request (API + WebSockets), so no custom
+  login flow is needed.
+- **Opt-in.** With no password set the gate is a no-op — behaviour is identical
+  to before, so updating never locks anyone out.
+- **Single choke point.** `is_network_allowed()` in `main/http_server/http_server.c`
+  calls `http_auth_gate()`; the static-file handler calls it too so the login
+  dialog appears on the first page load. When enabled, every `/api/*` route,
+  both WebSockets, and OTA are covered.
+- **Recovery.** AP setup mode (hold `BOOT`) bypasses auth so a forgotten password
+  can always be reset from **Settings → Security**. A factory reset (NVS erase)
+  or USB re-flash also clears it.
+- **Storage.** Only a salted SHA-256 hash is kept, in its own NVS namespace
+  (`authcfg`); it is never returned by any API.
+
+Scope: plain HTTP on the LAN — protects against other users on the network, not
+an on-path or physical/RF attacker. See the "Web Authentication" section of the
+root `readme.md` for the user-facing guide and API examples.
+
+## Code layout
+
+| Area | Files |
+|------|-------|
+| Credential logic + storage (own component) | `components/http_auth/` |
+| C unit tests (pure logic) | `components/http_auth/test/test_http_auth.c` |
+| Server gate + `GET`/`POST /api/system/auth` | `main/http_server/http_server.c` |
+| API spec | `main/http_server/openapi.yaml` |
+| Settings → Security panel | `main/http_server/axe-os/src/app/components/security/` |
+| Auth API client | `main/http_server/axe-os/src/app/services/auth.service.ts` |
+
+## Reproducing the tests
+
+### Prerequisites (once)
+
+- **Node.js 22+** for the frontend.
+- **ESP-IDF v5.5.x** + **qemu-xtensa** for the firmware/C tests:
+  ```bash
+  git clone -b v5.5.3 --recursive https://github.com/espressif/esp-idf.git ~/esp/v5.5.3/esp-idf
+  cd ~/esp/v5.5.3/esp-idf
+  ./install.sh esp32s3
+  python tools/idf_tools.py install qemu-xtensa
+  ```
+  > Gotcha: `install.sh` refuses to run if your shell's `python3` is itself a
+  > virtualenv/managed Python (`sys.prefix != sys.base_prefix`). Run it with the
+  > system Python in front, e.g. `env PATH="/usr/bin:$PATH" ./install.sh esp32s3`.
+
+Source the environment in each shell (again, system Python first if yours is a venv):
+```bash
+env PATH="/usr/bin:$PATH" bash -lc '. ~/esp/v5.5.3/esp-idf/export.sh; idf.py --version'
+```
+
+### Frontend unit tests (Angular / Karma)
+
+```bash
+cd main/http_server/axe-os
+npm ci
+CHROME_BIN=$(command -v google-chrome-stable) npm run test:ci
+```
+Covers `AuthService` and the `SecurityComponent` (set / change / disable, password
+match + length validation) alongside the existing suite.
+
+### Firmware C unit tests (`http_auth`)
+
+The tests are registered in `test/CMakeLists.txt` (`TEST_COMPONENTS`), so they build
+with the standard unit-test app (see [unit_testing.md](unit_testing.md)). Run them on a
+device (flash + `idf.py monitor`, per unit_testing.md), or locally in QEMU:
+```bash
+cd test          # or test-ci
+idf.py fullclean # avoids a stale target in the cache
+idf.py qemu      # builds, boots in QEMU, runs every test; Ctrl-] to exit
+```
+CI runs them automatically in QEMU via `.github/workflows/unittest.yml`. Expected output:
+```
+components/http_auth/test/test_http_auth.c:40:http_auth: verify_hash accepts the right password:PASS
+...
+85 Tests 0 Failures 0 Ignored
+```
+(85 = the `http_auth`, `stratum` and `asic` suites combined; the `http_auth` cases are
+the 13 added here. An `abort()` after the summary is just the interactive test menu
+hitting end-of-input under headless QEMU — it does not affect the results.)
+
+### Full firmware build (compile/link check)
+
+Confirms the auth component + server wiring + Angular UI all build into the real
+image for the Bitaxe's chip:
+```bash
+idf.py set-target esp32s3
+idf.py build
+```

--- a/doc/web-authentication.md
+++ b/doc/web-authentication.md
@@ -15,8 +15,9 @@ same Wi-Fi/LAN from reading data or changing settings/firmware without credentia
   dialog appears on the first page load. When enabled, every `/api/*` route,
   both WebSockets, and OTA are covered.
 - **Recovery.** AP setup mode (hold `BOOT`) bypasses auth so a forgotten password
-  can always be reset from **Settings → Security**. A factory reset (NVS erase)
-  or USB re-flash also clears it.
+  can always be reset from **Settings → Security**. Erasing NVS also clears it
+  (a full factory-image flash or `idf.py erase-flash`); a plain app-only re-flash
+  keeps the stored hash because it lives in the separate `nvs` partition.
 - **Storage.** Only a salted SHA-256 hash is kept, in its own NVS namespace
   (`authcfg`); it is never returned by any API.
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -86,6 +86,7 @@ PRIV_REQUIRES
     "tcp_transport"
     "stratum_v2"
     "esp_mm"
+    "http_auth"
 
 EMBED_FILES "http_server/recovery_page.html"
 )

--- a/main/http_server/axe-os/src/app/app.module.ts
+++ b/main/http_server/axe-os/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { SystemComponent } from './components/system/system.component';
 import { UpdateComponent } from './components/update/update.component';
 import { NetworkComponent } from './components/network/network.component';
 import { SettingsComponent } from './components/settings/settings.component';
+import { SecurityComponent } from './components/security/security.component';
 import { SwarmComponent } from './components/swarm/swarm.component';
 import { ScoreboardComponent } from './components/scoreboard/scoreboard.component';
 import { ThemeConfigComponent } from './components/design/theme-config.component';
@@ -90,6 +91,7 @@ const components = [
     AppChartComponent,
     EditComponent,
     SettingsComponent,
+    SecurityComponent,
     ANSIPipe,
     DateAgoPipe,
     HashSuffixPipe,

--- a/main/http_server/axe-os/src/app/components/network/network.component.html
+++ b/main/http_server/axe-os/src/app/components/network/network.component.html
@@ -3,3 +3,7 @@
 
     <app-network-edit></app-network-edit>
 </div>
+
+<!-- AP setup/recovery only: lets a user clear a forgotten password (auth is
+     bypassed in AP mode, so this reset is always reachable without signing in). -->
+<app-security *ngIf="isAPMode"></app-security>

--- a/main/http_server/axe-os/src/app/components/network/network.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/network/network.component.spec.ts
@@ -1,27 +1,49 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
 
 import { NetworkComponent } from './network.component';
 import { NetworkEditComponent } from '../network-edit/network.edit.component';
+import { SecurityComponent } from '../security/security.component';
 import { provideHttpClient } from '@angular/common/http';
 import { provideToastr } from 'ngx-toastr';
+import { provideAnimations } from '@angular/platform-browser/animations';
 import { DialogService } from 'src/app/services/dialog.service';
 
 describe('NetworkComponent', () => {
   let component: NetworkComponent;
   let fixture: ComponentFixture<NetworkComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [NetworkComponent, NetworkEditComponent],
-      providers: [provideHttpClient(), provideToastr(), DialogService]
-    });
+  // Render the component as if the router were at the given URL. isAPMode is
+  // derived from router.url, so stubbing the getter controls AP vs normal mode.
+  function createAt(url: string): void {
+    spyOnProperty(TestBed.inject(Router), 'url', 'get').and.returnValue(url);
     fixture = TestBed.createComponent(NetworkComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [NetworkComponent, NetworkEditComponent],
+      imports: [SecurityComponent],
+      providers: [provideHttpClient(), provideToastr(), provideAnimations(), provideRouter([]), DialogService]
+    });
   });
 
   it('should create', () => {
+    createAt('/network');
     expect(component).toBeTruthy();
   });
-});
 
+  it('does not show the security panel on the normal network page', () => {
+    createAt('/network');
+    expect(component.isAPMode).toBeFalse();
+    expect(fixture.nativeElement.querySelector('app-security')).toBeNull();
+  });
+
+  it('surfaces the security panel in AP (recovery) mode so a forgotten password can be reset', () => {
+    createAt('/ap');
+    expect(component.isAPMode).toBeTrue();
+    expect(fixture.nativeElement.querySelector('app-security')).not.toBeNull();
+  });
+});

--- a/main/http_server/axe-os/src/app/components/network/network.component.ts
+++ b/main/http_server/axe-os/src/app/components/network/network.component.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild, AfterViewInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { Observable } from 'rxjs';
+import { Router } from '@angular/router';
 import { NetworkEditComponent } from '../network-edit/network.edit.component';
 
 @Component({
@@ -14,7 +15,15 @@ export class NetworkComponent implements AfterViewInit {
 
   @ViewChild(NetworkEditComponent) networkEditComponent!: NetworkEditComponent;
 
-  constructor() {}
+  constructor(private router: Router) {}
+
+  // In AP (setup/recovery) mode ApModeGuard redirects every other page to this
+  // one, so the settings-based password reset is unreachable. Surface it here so
+  // a forgotten password can still be cleared. The '/ap' route is only ever used
+  // while the device is in AP mode (mirrors AppLayoutComponent.isAPMode).
+  get isAPMode(): boolean {
+    return this.router.url.startsWith('/ap');
+  }
 
   ngAfterViewInit() {
     this.form$ = this.networkEditComponent.form$;

--- a/main/http_server/axe-os/src/app/components/security/security.component.html
+++ b/main/http_server/axe-os/src/app/components/security/security.component.html
@@ -1,0 +1,68 @@
+<div class="card">
+    <h2>Security</h2>
+
+    <p class="mb-4 text-sm">
+        <ng-container *ngIf="authEnabled">
+            <i class="pi pi-lock text-primary"></i>
+            Web authentication is <strong>enabled</strong>. A username and password are required to access this device.
+        </ng-container>
+        <ng-container *ngIf="!authEnabled">
+            <i class="pi pi-lock-open"></i>
+            Web authentication is <strong>disabled</strong>. Anyone on the network can access and change this device.
+        </ng-container>
+    </p>
+
+    <form [formGroup]="form" (ngSubmit)="save()">
+        <div class="flex flex-col md:flex-row md:items-center mb-4 gap-2">
+            <label for="authUsername" class="w-full md:w-3/12 font-medium">Username</label>
+            <div class="w-full md:w-9/12">
+                <input class="input-text" id="authUsername" formControlName="username" type="text"
+                       autocomplete="username" [maxlength]="usernameMax" />
+            </div>
+        </div>
+
+        <div class="flex flex-col md:flex-row md:items-center mb-4 gap-2">
+            <label for="authNewPassword" class="w-full md:w-3/12 font-medium">
+                {{ authEnabled ? 'New Password' : 'Password' }}
+            </label>
+            <div class="w-full md:w-9/12">
+                <input class="input-text" id="authNewPassword" formControlName="newPassword" type="password"
+                       autocomplete="new-password" [maxlength]="passwordMax" />
+            </div>
+        </div>
+
+        <div class="flex flex-col md:flex-row md:items-center mb-2 gap-2">
+            <label for="authConfirmPassword" class="w-full md:w-3/12 font-medium">Confirm Password</label>
+            <div class="w-full md:w-9/12">
+                <input class="input-text" id="authConfirmPassword" formControlName="confirmPassword" type="password"
+                       autocomplete="new-password" [maxlength]="passwordMax" />
+            </div>
+        </div>
+
+        <div class="mb-4 min-h-[1.25rem]">
+            <small *ngIf="form.get('newPassword')?.touched && form.get('newPassword')?.hasError('minlength')"
+                   class="text-red-500">Password must be at least {{ passwordMin }} characters.</small>
+            <small *ngIf="form.hasError('passwordMismatch') && form.get('confirmPassword')?.touched"
+                   class="text-red-500">Passwords do not match.</small>
+        </div>
+
+        <div class="flex flex-col sm:flex-row gap-2">
+            <button type="submit" class="btn w-full sm:w-auto" [disabled]="saving || loading || form.invalid">
+                {{ authEnabled ? 'Change Password' : 'Enable Authentication' }}
+            </button>
+            <button *ngIf="authEnabled" type="button" class="btn btn-danger w-full sm:w-auto"
+                    [disabled]="saving || loading" (click)="disable()">
+                Disable Authentication
+            </button>
+        </div>
+    </form>
+
+    <div class="mt-4 flex items-start gap-2 p-3 rounded-lg border text-sm bg-[#ffecb3] text-[#614a00] border-[#ffe082]">
+        <i class="pi pi-info-circle mt-0.5"></i>
+        <span>
+            After enabling or changing the password your browser will ask you to sign in again.
+            If you ever forget it, hold the <strong>BOOT</strong> button to start the device in
+            access-point (setup) mode, which bypasses authentication so you can reset it.
+        </span>
+    </div>
+</div>

--- a/main/http_server/axe-os/src/app/components/security/security.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/security/security.component.spec.ts
@@ -1,0 +1,94 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideToastr } from 'ngx-toastr';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { SecurityComponent } from './security.component';
+
+describe('SecurityComponent', () => {
+  let component: SecurityComponent;
+  let fixture: ComponentFixture<SecurityComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [SecurityComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideToastr(), provideAnimations()]
+    });
+    fixture = TestBed.createComponent(SecurityComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  // Trigger ngOnInit and satisfy the initial GET /api/system/auth request.
+  function flushInit(enabled = 0, username = 'admin') {
+    fixture.detectChanges();
+    const req = httpMock.expectOne('/api/system/auth');
+    expect(req.request.method).toBe('GET');
+    req.flush({ enabled, username });
+  }
+
+  it('should create', () => {
+    flushInit();
+    expect(component).toBeTruthy();
+  });
+
+  it('reflects the enabled state returned by the API', () => {
+    flushInit(1, 'operator');
+    expect(component.authEnabled).toBeTrue();
+    expect(component.username).toBe('operator');
+  });
+
+  it('is invalid when the passwords do not match', () => {
+    flushInit();
+    component.form.patchValue({ username: 'admin', newPassword: 'abcd', confirmPassword: 'abce' });
+    expect(component.form.hasError('passwordMismatch')).toBeTrue();
+    expect(component.form.invalid).toBeTrue();
+  });
+
+  it('is invalid when the password is too short', () => {
+    flushInit();
+    component.form.patchValue({ username: 'admin', newPassword: 'ab', confirmPassword: 'ab' });
+    expect(component.form.get('newPassword')?.hasError('minlength')).toBeTrue();
+  });
+
+  it('save() posts the credentials and clears the password fields', () => {
+    flushInit();
+    component.form.patchValue({ username: 'admin', newPassword: 'longenough', confirmPassword: 'longenough' });
+    component.save();
+    const req = httpMock.expectOne('/api/system/auth');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ username: 'admin', newPassword: 'longenough' });
+    req.flush({ enabled: 1, message: 'Authentication enabled' });
+    expect(component.authEnabled).toBeTrue();
+    expect(component.form.get('newPassword')?.value).toBe('');
+    expect(component.form.get('confirmPassword')?.value).toBe('');
+  });
+
+  it('save() issues no request when the form is invalid', () => {
+    flushInit();
+    component.form.patchValue({ username: 'admin', newPassword: 'x', confirmPassword: 'y' });
+    component.save();
+    httpMock.expectNone('/api/system/auth');
+  });
+
+  it('disable() clears the password when confirmed', () => {
+    flushInit(1, 'admin');
+    spyOn(window, 'confirm').and.returnValue(true);
+    component.disable();
+    const req = httpMock.expectOne('/api/system/auth');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.newPassword).toBe('');
+    req.flush({ enabled: 0, message: 'disabled' });
+    expect(component.authEnabled).toBeFalse();
+  });
+
+  it('disable() aborts when the confirmation is declined', () => {
+    flushInit(1, 'admin');
+    spyOn(window, 'confirm').and.returnValue(false);
+    component.disable();
+    httpMock.expectNone('/api/system/auth');
+  });
+});

--- a/main/http_server/axe-os/src/app/components/security/security.component.ts
+++ b/main/http_server/axe-os/src/app/components/security/security.component.ts
@@ -1,0 +1,109 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, AbstractControl, ValidationErrors } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ToastrService } from 'ngx-toastr';
+import { finalize } from 'rxjs';
+import { AuthService } from '../../services/auth.service';
+
+// Keep these in sync with the firmware limits (components/http_auth/http_auth.h).
+const USERNAME_MAX = 32;
+const PASSWORD_MAX = 64;
+const PASSWORD_MIN = 4;
+
+// Cross-field validator: newPassword must equal confirmPassword.
+function passwordsMatch(group: AbstractControl): ValidationErrors | null {
+  const pw = group.get('newPassword')?.value ?? '';
+  const confirm = group.get('confirmPassword')?.value ?? '';
+  return pw === confirm ? null : { passwordMismatch: true };
+}
+
+@Component({
+  selector: 'app-security',
+  templateUrl: './security.component.html',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule]
+})
+export class SecurityComponent implements OnInit {
+  public form: FormGroup;
+  public authEnabled = false;
+  public username = 'admin';
+  public loading = true;
+  public saving = false;
+
+  public readonly usernameMax = USERNAME_MAX;
+  public readonly passwordMax = PASSWORD_MAX;
+  public readonly passwordMin = PASSWORD_MIN;
+
+  constructor(
+    private fb: FormBuilder,
+    private authService: AuthService,
+    private toastr: ToastrService
+  ) {
+    this.form = this.fb.group({
+      username: ['admin', [Validators.required, Validators.maxLength(USERNAME_MAX)]],
+      newPassword: ['', [Validators.required, Validators.minLength(PASSWORD_MIN), Validators.maxLength(PASSWORD_MAX)]],
+      confirmPassword: ['', [Validators.required]]
+    }, { validators: passwordsMatch });
+  }
+
+  ngOnInit(): void {
+    this.authService.getAuthInfo()
+      .pipe(finalize(() => this.loading = false))
+      .subscribe({
+        next: info => {
+          this.authEnabled = info.enabled === 1;
+          this.username = info.username || 'admin';
+          this.form.patchValue({ username: this.username });
+        },
+        error: () => {
+          // Non-fatal: leave defaults. The panel still lets the user set a password.
+        }
+      });
+  }
+
+  public save(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    const { username, newPassword } = this.form.value;
+    this.saving = true;
+    this.authService.setCredentials(username, newPassword)
+      .pipe(finalize(() => this.saving = false))
+      .subscribe({
+        next: res => {
+          this.authEnabled = res.enabled === 1;
+          this.username = username;
+          this.form.patchValue({ newPassword: '', confirmPassword: '' });
+          this.form.markAsPristine();
+          this.toastr.success(res.message || 'Authentication updated', 'Success');
+        },
+        error: (err: HttpErrorResponse) => {
+          this.toastr.error(err?.error?.message || err?.message || 'Failed to update authentication', 'Error');
+        }
+      });
+  }
+
+  public disable(): void {
+    if (!confirm('Disable web authentication? Anyone on the network will be able to access and change this device.')) {
+      return;
+    }
+    const username = this.form.get('username')?.value || this.username || 'admin';
+    this.saving = true;
+    // Empty password clears/disables authentication.
+    this.authService.setCredentials(username, '')
+      .pipe(finalize(() => this.saving = false))
+      .subscribe({
+        next: res => {
+          this.authEnabled = res.enabled === 1;
+          this.form.patchValue({ newPassword: '', confirmPassword: '' });
+          this.form.markAsPristine();
+          this.toastr.success(res.message || 'Authentication disabled', 'Success');
+        },
+        error: (err: HttpErrorResponse) => {
+          this.toastr.error(err?.error?.message || err?.message || 'Failed to disable authentication', 'Error');
+        }
+      });
+  }
+}

--- a/main/http_server/axe-os/src/app/components/settings/settings.component.html
+++ b/main/http_server/axe-os/src/app/components/settings/settings.component.html
@@ -2,3 +2,5 @@
     <h2>Settings</h2>
     <app-edit></app-edit>
 </div>
+
+<app-security></app-security>

--- a/main/http_server/axe-os/src/app/components/settings/settings.component.ts
+++ b/main/http_server/axe-os/src/app/components/settings/settings.component.ts
@@ -3,12 +3,13 @@ import { CommonModule } from '@angular/common';
 import { FormGroup } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { EditComponent } from '../edit/edit.component';
+import { SecurityComponent } from '../security/security.component';
 
 @Component({
     selector: 'app-settings',
     templateUrl: './settings.component.html',
     standalone: true,
-    imports: [CommonModule, EditComponent]
+    imports: [CommonModule, EditComponent, SecurityComponent]
 })
 export class SettingsComponent implements AfterViewInit {
   form$!: Observable<FormGroup | null>;

--- a/main/http_server/axe-os/src/app/services/auth.service.spec.ts
+++ b/main/http_server/axe-os/src/app/services/auth.service.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AuthService, provideHttpClient(), provideHttpClientTesting()]
+    });
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('getAuthInfo() GETs /api/system/auth', () => {
+    let result: any;
+    service.getAuthInfo().subscribe(r => (result = r));
+    const req = httpMock.expectOne('/api/system/auth');
+    expect(req.request.method).toBe('GET');
+    req.flush({ enabled: 1, username: 'admin' });
+    expect(result.enabled).toBe(1);
+    expect(result.username).toBe('admin');
+  });
+
+  it('setCredentials() POSTs username and newPassword', () => {
+    let result: any;
+    service.setCredentials('operator', 's3cret').subscribe(r => (result = r));
+    const req = httpMock.expectOne('/api/system/auth');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ username: 'operator', newPassword: 's3cret' });
+    req.flush({ enabled: 1, message: 'ok' });
+    expect(result.enabled).toBe(1);
+  });
+
+  it('setCredentials() with an empty password disables auth', () => {
+    let result: any;
+    service.setCredentials('admin', '').subscribe(r => (result = r));
+    const req = httpMock.expectOne('/api/system/auth');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ username: 'admin', newPassword: '' });
+    req.flush({ enabled: 0, message: 'disabled' });
+    expect(result.enabled).toBe(0);
+  });
+});

--- a/main/http_server/axe-os/src/app/services/auth.service.ts
+++ b/main/http_server/axe-os/src/app/services/auth.service.ts
@@ -1,0 +1,47 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { delay } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+
+export interface AuthInfo {
+  // 0 = authentication disabled, 1 = enabled. Matches the backend's numeric flag.
+  enabled: number;
+  username: string;
+}
+
+export interface AuthUpdateResponse {
+  enabled: number;
+  message: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+
+  constructor(private httpClient: HttpClient) { }
+
+  /** Report whether web authentication is currently enabled. */
+  public getAuthInfo(uri: string = ''): Observable<AuthInfo> {
+    if (environment.mock) {
+      return of<AuthInfo>({ enabled: 0, username: 'admin' }).pipe(delay(200));
+    }
+    return this.httpClient.get<AuthInfo>(`${uri}/api/system/auth`);
+  }
+
+  /**
+   * Set, change or clear the web authentication password.
+   * An empty newPassword disables authentication.
+   */
+  public setCredentials(username: string, newPassword: string, uri: string = ''): Observable<AuthUpdateResponse> {
+    if (environment.mock) {
+      const enabled = newPassword != null && newPassword.length > 0 ? 1 : 0;
+      return of<AuthUpdateResponse>({
+        enabled,
+        message: enabled ? 'Authentication enabled (mock)' : 'Authentication disabled (mock)'
+      }).pipe(delay(200));
+    }
+    return this.httpClient.post<AuthUpdateResponse>(`${uri}/api/system/auth`, { username, newPassword });
+  }
+}

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -44,6 +44,7 @@
 #include "log_buffer.h"
 #include "cjson_utils.h"
 #include "utils.h"
+#include "http_auth.h"
 
 static const char * TAG = "http_server";
 static const char * CORS_TAG = "CORS";
@@ -306,11 +307,45 @@ static void normalize_hostname(char *hostname, size_t max_len) {
     }
 }
 
+// Optional HTTP Basic authentication gate.
+//
+// Returns ESP_OK when the request may proceed (auth disabled, AP setup mode, a
+// CORS preflight, or valid credentials). Returns ESP_FAIL when the client must
+// authenticate; in that case a "WWW-Authenticate" header is queued so the
+// caller's 401 response makes the browser show its native login dialog.
+//
+// This is intentionally a no-op unless the user has configured a password, so
+// existing devices behave exactly as before after updating. AP mode always
+// bypasses authentication, which keeps the physical-button recovery flow (and
+// therefore the ability to reset a forgotten password) working.
+static esp_err_t http_auth_gate(httpd_req_t * req)
+{
+    if (req->method == HTTP_OPTIONS) {
+        return ESP_OK; // never challenge CORS preflight requests
+    }
+    if (GLOBAL_STATE->SYSTEM_MODULE.ap_enabled == true) {
+        return ESP_OK; // AP setup / recovery: no authentication
+    }
+    if (!http_auth_is_enabled()) {
+        return ESP_OK; // opt-in: no password configured
+    }
+    if (http_auth_check_request(req) == ESP_OK) {
+        return ESP_OK; // valid credentials
+    }
+    httpd_resp_set_hdr(req, "WWW-Authenticate", HTTP_AUTH_WWW_AUTHENTICATE);
+    return ESP_FAIL;
+}
+
 esp_err_t is_network_allowed(httpd_req_t * req)
 {
     if (GLOBAL_STATE->SYSTEM_MODULE.ap_enabled == true) {
         ESP_LOGI(CORS_TAG, "Device in AP mode. Allowing CORS.");
         return ESP_OK;
+    }
+
+    // Enforce HTTP authentication (no-op when no password is configured).
+    if (http_auth_gate(req) != ESP_OK) {
+        return ESP_FAIL;
     }
 
     int sockfd = httpd_req_to_sockfd(req);
@@ -532,6 +567,14 @@ static bool file_exists(const char *path) {
 /* Send HTTP response with the contents of the requested file */
 static esp_err_t rest_common_get_handler(httpd_req_t * req)
 {
+    // Challenge for credentials on the page load itself (when auth is enabled)
+    // so the browser shows its login dialog before the app shell renders. Note:
+    // this only adds the auth check, not the CORS/origin restriction, so serving
+    // the UI is unchanged when authentication is disabled.
+    if (http_auth_gate(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+
     char filepath[FILE_PATH_MAX];
     char gz_file[FILE_PATH_MAX];
     uint8_t filePathLength = sizeof(filepath);
@@ -1035,6 +1078,125 @@ static esp_err_t POST_mining_resume(httpd_req_t * req)
     return res;
 }
 
+/* GET /api/system/auth - report whether web authentication is enabled */
+static esp_err_t GET_auth_info(httpd_req_t * req)
+{
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+
+    httpd_resp_set_type(req, "application/json");
+    if (set_cors_headers(req) != ESP_OK) {
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
+
+    char username[HTTP_AUTH_USERNAME_MAX + 1];
+    http_auth_get_username(username, sizeof(username));
+
+    cJSON * root = cJSON_CreateObject();
+    if (root == NULL) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Memory allocation failed");
+        return ESP_OK;
+    }
+    cJSON_AddNumberToObject(root, "enabled", http_auth_is_enabled() ? 1 : 0);
+    cJSON_AddStringToObject(root, "username", username);
+
+    esp_err_t res = HTTP_send_json(req, root, &api_common_prebuffer_len);
+    cJSON_Delete(root);
+    return res;
+}
+
+/* POST /api/system/auth - set, change, or clear the web authentication password.
+ * Body: { "username": "...", "newPassword": "..." }
+ * An empty newPassword disables authentication. When authentication is already
+ * enabled, the network gate above requires valid current credentials before
+ * this handler runs, so a password can only be changed by an authenticated user. */
+static esp_err_t POST_auth_update(httpd_req_t * req)
+{
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+    if (set_cors_headers(req) != ESP_OK) {
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
+
+    int total_len = req->content_len;
+    if (total_len <= 0 || total_len >= SCRATCH_BUFSIZE) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid content length");
+        return ESP_OK;
+    }
+    char * buf = ((rest_server_context_t *) (req->user_ctx))->scratch;
+    int cur_len = 0;
+    int received = 0;
+    while (cur_len < total_len) {
+        received = httpd_req_recv(req, buf + cur_len, total_len - cur_len);
+        if (received <= 0) {
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to read request");
+            return ESP_OK;
+        }
+        cur_len += received;
+    }
+    buf[total_len] = '\0';
+
+    cJSON * root = cJSON_Parse(buf);
+    // Scrub the raw request body: it contains the plaintext password.
+    memset(buf, 0, total_len);
+    if (root == NULL) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid JSON");
+        return ESP_OK;
+    }
+
+    cJSON * pw_item = cJSON_GetObjectItem(root, "newPassword");
+    cJSON * user_item = cJSON_GetObjectItem(root, "username");
+    if (pw_item != NULL && !cJSON_IsString(pw_item)) {
+        cJSON_Delete(root);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "newPassword must be a string");
+        return ESP_OK;
+    }
+    if (user_item != NULL && !cJSON_IsString(user_item)) {
+        cJSON_Delete(root);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "username must be a string");
+        return ESP_OK;
+    }
+
+    const char * new_password = pw_item ? pw_item->valuestring : NULL;
+    const char * new_username = user_item ? user_item->valuestring : NULL;
+
+    esp_err_t err = http_auth_set_credentials(new_username, new_password);
+
+    // Scrub the parsed plaintext password before freeing.
+    if (pw_item && pw_item->valuestring) {
+        memset(pw_item->valuestring, 0, strlen(pw_item->valuestring));
+    }
+    cJSON_Delete(root);
+
+    if (err == ESP_ERR_INVALID_ARG) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Username or password too long");
+        return ESP_OK;
+    }
+    if (err != ESP_OK) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to store credentials");
+        return ESP_OK;
+    }
+
+    bool enabled = http_auth_is_enabled();
+    httpd_resp_set_type(req, "application/json");
+    cJSON * resp = cJSON_CreateObject();
+    if (resp == NULL) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Memory allocation failed");
+        return ESP_OK;
+    }
+    cJSON_AddNumberToObject(resp, "enabled", enabled ? 1 : 0);
+    cJSON_AddStringToObject(resp, "message",
+        enabled ? "Authentication enabled. You may be asked to sign in again."
+                : "Authentication disabled.");
+    esp_err_t res = HTTP_send_json(req, resp, &api_common_prebuffer_len);
+    cJSON_Delete(resp);
+    return res;
+}
+
 /* Simple handler for getting system handler */
 static esp_err_t GET_system_info(httpd_req_t * req)
 {
@@ -1418,6 +1580,10 @@ esp_err_t start_rest_server(void * pvParameters)
     
     // Initialize the ASIC API with the global state
     asic_api_init(GLOBAL_STATE);
+
+    // Load the (optional) web authentication credentials from NVS.
+    http_auth_init();
+
     const char * base_path = "";
 
     REST_CHECK(base_path, "wrong base path", err);
@@ -1429,7 +1595,7 @@ esp_err_t start_rest_server(void * pvParameters)
     config.uri_match_fn = httpd_uri_match_wildcard;
     config.stack_size = 8192;
     config.max_open_sockets = 20;
-    config.max_uri_handlers = 25;
+    config.max_uri_handlers = 28;
     config.close_fn = websocket_close_fn;
     config.lru_purge_enable = true;
 
@@ -1466,6 +1632,24 @@ esp_err_t start_rest_server(void * pvParameters)
         .user_ctx = rest_context
     };
     httpd_register_uri_handler(server, &system_info_get_uri);
+
+    /* URI handler for reading web authentication status */
+    httpd_uri_t auth_info_get_uri = {
+        .uri = "/api/system/auth",
+        .method = HTTP_GET,
+        .handler = GET_auth_info,
+        .user_ctx = rest_context
+    };
+    httpd_register_uri_handler(server, &auth_info_get_uri);
+
+    /* URI handler for setting/clearing the web authentication password */
+    httpd_uri_t auth_update_post_uri = {
+        .uri = "/api/system/auth",
+        .method = HTTP_POST,
+        .handler = POST_auth_update,
+        .user_ctx = rest_context
+    };
+    httpd_register_uri_handler(server, &auth_update_post_uri);
 
     /* URI handler for fetching system asic values */
     httpd_uri_t system_asic_get_uri = {

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -15,7 +15,22 @@ servers:
         default: "192.168.1.1"
         description: IP address of the ESP-Miner device
 
+# HTTP Basic authentication is optional (disabled by default). When a password is
+# configured via POST /api/system/auth it is required on every endpoint; the empty
+# requirement object below expresses that unauthenticated access is also valid.
+security:
+  - {}
+  - basicAuth: []
+
 components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      description: >-
+        Optional HTTP Basic authentication. Disabled by default; once a password is
+        set (POST /api/system/auth) every endpoint requires the username/password and
+        returns 401 otherwise. AP setup mode bypasses it for recovery.
   schemas:
     GenericResponse:
       type: object
@@ -896,7 +911,7 @@ paths:
                     items:
                       $ref: '#/components/schemas/WifiNetwork'
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -915,7 +930,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SystemInfo'
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -964,9 +979,11 @@ paths:
               properties:
                 username:
                   type: string
+                  maxLength: 32
                   description: Username to store (optional; keeps the current value when omitted)
                 newPassword:
                   type: string
+                  maxLength: 64
                   description: New password; an empty string disables authentication
       responses:
         '200':
@@ -1004,7 +1021,7 @@ paths:
                 type: string
                 format: binary
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -1023,7 +1040,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SystemASIC'
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -1054,7 +1071,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SystemStatistics'
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -1090,7 +1107,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericResponse'
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -1109,7 +1126,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericResponse'
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -1128,7 +1145,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericResponse'
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -1147,7 +1164,7 @@ paths:
               schema:
                 '$ref': '#/components/schemas/GenericResponse'
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -1175,7 +1192,7 @@ paths:
                   message:
                     type: string
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -1202,7 +1219,7 @@ paths:
         '400':
           description: Invalid settings provided
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -1230,7 +1247,7 @@ paths:
         '400':
           description: Invalid firmware file
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error
 
@@ -1258,6 +1275,6 @@ paths:
         '400':
           description: Invalid web interface file
         '401':
-          description: Unauthorized - Client not in allowed network range
+          description: Unauthorized - Client not in allowed network range, or invalid credentials when authentication is enabled
         '500':
           description: Internal server error

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -919,6 +919,75 @@ paths:
         '500':
           description: Internal server error
 
+  /api/system/auth:
+    get:
+      summary: Get web authentication status
+      description: >-
+        Reports whether HTTP Basic authentication is currently required to
+        access the web interface, and the configured username.
+      operationId: getAuthStatus
+      tags:
+        - system
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled:
+                    type: integer
+                    description: 1 when authentication is enabled, 0 when disabled
+                  username:
+                    type: string
+                    description: The configured username (default "admin")
+        '401':
+          description: Unauthorized - Client not in allowed network range or invalid credentials
+        '500':
+          description: Internal server error
+    post:
+      summary: Set or clear the web authentication password
+      description: >-
+        Sets, changes or clears the web interface password. Sending an empty
+        newPassword disables authentication. When authentication is already
+        enabled, valid current credentials are required to call this endpoint.
+      operationId: updateAuth
+      tags:
+        - system
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                  description: Username to store (optional; keeps the current value when omitted)
+                newPassword:
+                  type: string
+                  description: New password; an empty string disables authentication
+      responses:
+        '200':
+          description: Authentication settings updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled:
+                    type: integer
+                    description: 1 when authentication is enabled, 0 when disabled
+                  message:
+                    type: string
+        '400':
+          description: Invalid input (username or password too long, or malformed body)
+        '401':
+          description: Unauthorized - Client not in allowed network range or invalid credentials
+        '500':
+          description: Internal server error
+
   /api/system/logs:
     get:
       summary: Download system logs

--- a/readme.md
+++ b/readme.md
@@ -236,7 +236,7 @@ By default the web interface is open to anyone on the local network. You can opt
 > Notes / scope:
 > - The connection is plain HTTP, so this protects against access on a shared/local network but does not encrypt traffic. Do not expose the device directly to the internet.
 > - The **setup access point** (shown during first-time setup, or after the device loses Wi-Fi, or on a `BOOT`-button press) is intentionally *not* password protected — that is what makes password recovery possible. Protecting the setup AP is out of scope for the LAN threat model above, since joining it requires being in radio range of the device rather than simply being on your Wi-Fi.
-> - If the device's display is non-functional the `BOOT`-button shortcut may be unavailable; in that case recover with a USB re-flash / NVS erase (see [Recovery](#recovery)).
+> - If the device's display is non-functional the `BOOT`-button shortcut may be unavailable; in that case erase NVS to recover — a full factory-image flash or `idf.py erase-flash` (a plain app-only firmware update keeps the password). See [Recovery](#recovery).
 
 ## Development using esp-miner/devcontainer
 

--- a/readme.md
+++ b/readme.md
@@ -238,7 +238,7 @@ By default the web interface is open to anyone on the local network. You can opt
 > Notes / scope:
 > - The connection is plain HTTP, so this protects against access on a shared/local network but does not encrypt traffic. Do not expose the device directly to the internet.
 > - The **setup access point** (shown during first-time setup, or after the device loses Wi-Fi, or on a `BOOT`-button press) is intentionally *not* password protected — that is what makes password recovery possible. Protecting the setup AP is out of scope for the LAN threat model above, since joining it requires being in radio range of the device rather than simply being on your Wi-Fi.
-> - If the device's display is non-functional the `BOOT`-button shortcut may be unavailable; in that case erase NVS to recover — a full factory-image flash or `idf.py erase-flash` (a plain app-only firmware update keeps the password). See [Recovery](#recovery).
+> - If the device's display is non-functional the `BOOT`-button shortcut may be unavailable; in that case erase NVS to recover — a full factory-image flash or `idf.py erase-flash` (a plain app-only firmware update keeps the password).
 
 ## Development using esp-miner/devcontainer
 

--- a/readme.md
+++ b/readme.md
@@ -230,10 +230,13 @@ By default the web interface is open to anyone on the local network. You can opt
 
 - Authentication uses standard HTTP Basic auth, so your browser shows its native sign-in dialog and remembers the credentials for the session. The password is never stored in clear text — only a salted SHA-256 hash is kept on the device.
 - It is **opt-in**: until you set a password nothing changes, so existing setups keep working after updating.
-- Once enabled, all API access (reading data, changing settings, OTA updates) requires the username and password.
-- **Forgot the password?** Hold the `BOOT` button to start the device in access-point (setup) mode, which bypasses authentication. From there you can open **Settings → Security** and set a new password or disable authentication. A full factory reset (erasing NVS) also clears it.
+- Once enabled, everyone on your Wi-Fi/LAN must supply the username and password before they can read data, change any setting, or flash firmware (OTA). This is the case it is designed to protect.
+- **Forgot the password?** Hold the `BOOT` button to start the device in access-point (setup) mode, which bypasses authentication so you can reconnect and open **Settings → Security** to set a new password or disable it. A full factory reset (erasing NVS) also clears it.
 
-> Note: the connection is plain HTTP, so this protects against casual access on a shared/local network but does not encrypt traffic. Do not expose the device directly to the internet.
+> Notes / scope:
+> - The connection is plain HTTP, so this protects against access on a shared/local network but does not encrypt traffic. Do not expose the device directly to the internet.
+> - The **setup access point** (shown during first-time setup, or after the device loses Wi-Fi, or on a `BOOT`-button press) is intentionally *not* password protected — that is what makes password recovery possible. Protecting the setup AP is out of scope for the LAN threat model above, since joining it requires being in radio range of the device rather than simply being on your Wi-Fi.
+> - If the device's display is non-functional the `BOOT`-button shortcut may be unavailable; in that case recover with a USB re-flash / NVS erase (see [Recovery](#recovery)).
 
 ## Development using esp-miner/devcontainer
 

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ Available API endpoints:
 * `/api/system/scoreboard` Get top 20 highest difficulty shares
 * `/api/system/wifi/scan` Scan for available Wi-Fi networks
 * `/api/system/logs` Download system logs
+* `/api/system/auth` Get web authentication status
 
 **POST**
 
@@ -72,6 +73,7 @@ Available API endpoints:
 * `/api/system/identify` Identify the device
 * `/api/system/OTA` Update system firmware
 * `/api/system/OTAWWW` Update AxeOS
+* `/api/system/auth` Set or clear the web authentication password
 
 **PATCH**
 

--- a/readme.md
+++ b/readme.md
@@ -233,7 +233,7 @@ By default the web interface is open to anyone on the local network. You can opt
 - Authentication uses standard HTTP Basic auth, so your browser shows its native sign-in dialog and remembers the credentials for the session. The password is never stored in clear text — only a salted SHA-256 hash is kept on the device.
 - It is **opt-in**: until you set a password nothing changes, so existing setups keep working after updating.
 - Once enabled, everyone on your Wi-Fi/LAN must supply the username and password before they can read data, change any setting, or flash firmware (OTA). This is the case it is designed to protect.
-- **Forgot the password?** Hold the `BOOT` button to start the device in access-point (setup) mode, which bypasses authentication so you can reconnect and open **Settings → Security** to set a new password or disable it. A full factory reset (erasing NVS) also clears it.
+- **Forgot the password?** Hold the `BOOT` button to start the device in access-point (setup) mode. It bypasses authentication, and the setup page includes the **Security** panel where you can set a new password or disable it. A full factory reset (erasing NVS) also clears it.
 
 > Notes / scope:
 > - The connection is plain HTTP, so this protects against access on a shared/local network but does not encrypt traffic. Do not expose the device directly to the internet.

--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,17 @@ curl -X PATCH http://YOUR-BITAXE-IP/api/system \
      -H "Content-Type: application/json" \
      -d '{"fanspeed": "desired_speed_value"}'
 
+# Get web authentication status
+curl http://YOUR-BITAXE-IP/api/system/auth
+
+# Enable/change the web password (empty newPassword disables it)
+curl -X POST http://YOUR-BITAXE-IP/api/system/auth \
+     -H "Content-Type: application/json" \
+     -d '{"username": "admin", "newPassword": "your_password"}'
+
+# When authentication is enabled, pass credentials on every request
+curl -u admin:your_password http://YOUR-BITAXE-IP/api/system/info
+
 # Stream logs
 websocat ws://YOUR-BITAXE-IP/api/ws
 
@@ -212,6 +223,17 @@ In the event that the admin web front end is inaccessible, for example because o
 ### Unlock Settings
 
 In order to unlock the Input fields for ASIC Frequency and ASIC Core Voltage you need to append `?oc` to the end of the settings tab URL in your browser. Be aware that without additional cooling overclocking can overheat and/or damage your Bitaxe.
+
+### Web Authentication
+
+By default the web interface is open to anyone on the local network. You can optionally protect it with a password from **Settings → Security**.
+
+- Authentication uses standard HTTP Basic auth, so your browser shows its native sign-in dialog and remembers the credentials for the session. The password is never stored in clear text — only a salted SHA-256 hash is kept on the device.
+- It is **opt-in**: until you set a password nothing changes, so existing setups keep working after updating.
+- Once enabled, all API access (reading data, changing settings, OTA updates) requires the username and password.
+- **Forgot the password?** Hold the `BOOT` button to start the device in access-point (setup) mode, which bypasses authentication. From there you can open **Settings → Security** and set a new password or disable authentication. A full factory reset (erasing NVS) also clears it.
+
+> Note: the connection is plain HTTP, so this protects against casual access on a shared/local network but does not encrypt traffic. Do not expose the device directly to the internet.
 
 ## Development using esp-miner/devcontainer
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ set(EXTRA_COMPONENT_DIRS "../components")
 # - when invoking CMake directly: cmake -D TEST_COMPONENTS="xxxxx" ..
 # - when using idf.py: idf.py -T xxxxx build
 #
-set(TEST_COMPONENTS "stratum asic" CACHE STRING "List of components to test")
+set(TEST_COMPONENTS "stratum asic http_auth" CACHE STRING "List of components to test")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 


### PR DESCRIPTION
Right now anyone on the same Wi-Fi as a Bitaxe can open AxeOS and read the pool/Wi-Fi details, change any setting, or even flash new firmware — there's no authentication at all. This PR adds an optional password so you can lock that down on a shared or untrusted network.

It's completely opt-in. If you don't set a password nothing changes and the device behaves exactly as it does today, so updating to this is safe even for people who don't want it. Once you do set a password (under Settings → Security), the browser asks you to sign in before you can read data, change settings, or run an OTA update.

How it works

I tried to keep the change small and contained. There's a new `components/http_auth/` component that stores and checks the credential, and a single gate function (`http_auth_gate()`) that hooks into the existing `is_network_allowed()` check in `http_server.c`, plus the static-file handler so the login prompt appears on first load. That one choke point covers every `/api/*` route, both WebSockets, and OTA when auth is on. The password is only ever stored as a salted SHA-256 hash in its own NVS namespace (`authcfg`), it's never returned by any endpoint, and the comparison is constant-time. If reading the config ever fails, the gate fails closed. There are two new endpoints, `GET` and `POST /api/system/auth`, to report status and to set/change/clear the password (sending an empty password turns auth back off). It's all in `openapi.yaml`, and there's a small Settings → Security panel on the frontend.

Recovery — you can't get locked out or brick the device

This is the part I was most careful about. AP setup mode (hold the BOOT button) already bypasses auth, and I surface the Security panel right on that setup screen, so if you forget the password you just drop into AP mode and clear it from the browser. Erasing NVS (a factory image or `idf.py erase-flash`) also clears it. There are no changes to the partition table, the bootloader, or the flash layout, so a USB reflash always works as a last resort. The setup AP stays unauthenticated on purpose — that's what makes recovery possible.

Testing

I added C unit tests for the auth logic (hashing against known vectors, right/wrong/edge-case passwords, parsing the Basic header including odd and malformed input, the constant-time compare) that run under QEMU, plus Angular specs for the auth service, the Security panel, and the AP-mode reset. The full esp32s3 build and the production web build both pass, and I've been running it on a real Bitaxe 601 Gamma.

Why you might want to merge it

- It closes a real gap: today there's zero protection against anyone on your LAN changing settings or flashing firmware.
- No risk for people who don't want it — it does nothing at all until a password is set.
- It's small and isolated: one new component, one gate function, a couple of endpoints and a settings panel. No flash-layout, partition, or bootloader changes.
- Reasonable crypto choices: salted SHA-256, constant-time compare, the hash never leaves the device, and the gate fails closed.
- Recovery is safe, so it shouldn't generate "I locked myself out" support reports.

Things to weigh (the honest trade-offs)

- It's Basic auth over plain HTTP. It keeps out casual LAN access but doesn't encrypt traffic, so it won't stop someone who can sniff the network or sit on-path — the device has no TLS.
- The setup AP is intentionally left open so recovery works, which means anyone within Wi-Fi range of the device can still get in. Physical/RF access is out of scope here.
- It's a single shared admin credential — no multiple users or roles.
- There's no rate limiting or lockout on failed attempts. Since it's LAN-scoped I judged that acceptable, but it's worth noting.
- The UX is the browser's native Basic-auth dialog rather than a custom login page, and "logging out" means clearing the browser's saved credentials.
- It does add a bit of ongoing surface to maintain (the new component, endpoints and frontend panel).
