### PR TITLE
CMake build improvements

### DIFF
--- a/components/libsecp256k1/CMakeLists.txt
+++ b/components/libsecp256k1/CMakeLists.txt
@@ -12,4 +12,4 @@ target_compile_definitions(${COMPONENT_LIB} PRIVATE
     ENABLE_MODULE_SCHNORRSIG=1
     ENABLE_MODULE_EXTRAKEYS=1
 )
-target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-unused-parameter)
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-unused-parameter -Wno-unused-function)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -121,10 +121,11 @@ else()
         USES_TERMINAL
     )
 
-    # Collect all frontend source files to track dependencies
+    # Collect all frontend source files to track dependencies (excluding auto-generated code)
     file(GLOB_RECURSE WEB_UI_SOURCES
         "${WEB_SRC_DIR}/src/*.*"
     )
+    list(FILTER WEB_UI_SOURCES EXCLUDE REGEX "/generated/")
 
     # Also track build configuration files
     list(APPEND WEB_UI_SOURCES


### PR DESCRIPTION
 * Suppres libsecp256k1 compiler warnings
 * Excluded generated files from build tracking

The latter one sometimes prevented a re-build and forced the user to do a full clean