### PR TITLE
feat: prompt before restart in topbar

### DIFF
--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -371,6 +371,9 @@ private isIpAddress(value: string): boolean {
   }
 
   public postAction(device: any, action: string) {
+    if (action === 'restart' && !confirm('Are you sure you want to restart the device?')) {
+      return;
+    }
     this.httpClient.post(`http://${device.connectionAddress}/api/system/${action}`, {}, { responseType: 'text' }).pipe(
       timeout(800),
       catchError(error => {

--- a/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.topbar.component.ts
@@ -74,9 +74,11 @@ export class AppTopBarComponent implements OnInit, OnDestroy {
   }
 
   public restart() {
-    this.systemService.restart().subscribe({
-      next: () => this.toastr.success('Device restarted'),
-      error: () => this.toastr.error('Restart failed')
-    });
+    if (confirm('Are you sure you want to restart the device?')) {
+      this.systemService.restart().subscribe({
+        next: () => this.toastr.success('Device restarted'),
+        error: () => this.toastr.error('Restart failed')
+      });
+    }
   }
 }


### PR DESCRIPTION
closes: #1633 

copies the reset prompt from the partition reboot button, i wanted to do a panel but angular is eughhhhh  
future things