### PR TITLE
BM1370 ASIC Driver Timing & Initialization Fixes

### DIFF
--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -171,16 +171,16 @@ void ASIC_read_registers(GlobalState * GLOBAL_STATE)
 {
     switch (GLOBAL_STATE->DEVICE_CONFIG.family.asic.id) {
         case BM1397:
-            BM1397_read_registers();
+            BM1397_read_registers(GLOBAL_STATE);
             break;
         case BM1366:
-            BM1366_read_registers();
+            BM1366_read_registers(GLOBAL_STATE);
             break;
         case BM1368:
-            BM1368_read_registers();
+            BM1368_read_registers(GLOBAL_STATE);
             break;
         case BM1370:
-            BM1370_read_registers();
+            BM1370_read_registers(GLOBAL_STATE);
             break;
         default:
             ESP_LOGE(TAG, "Unknown ASIC id %d — cannot read registers", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -401,13 +401,22 @@ task_result * BM1366_process_work(void * pvParameters)
     return &result;
 }
 
-void BM1366_read_registers(void)
+void BM1366_read_registers(void * pvParameters)
 {
+    GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
+    uint16_t asic_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
+    if (asic_count == 0 || address_interval <= 0) {
+        return;
+    }
+
     int size = sizeof(REGISTER_MAP) / sizeof(REGISTER_MAP[0]);
-    for (int reg = 0; reg < size; reg++) {
-        if (REGISTER_MAP[reg] != REGISTER_INVALID) {
-            _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_READ), (uint8_t[]){0x00, reg}, 2, BM1366_SERIALTX_DEBUG);
-            vTaskDelay(pdMS_TO_TICKS(1));
+    for (uint8_t chip = 0; chip < asic_count; chip++) {
+        uint8_t chip_addr = chip * address_interval;
+        for (int reg = 0; reg < size; reg++) {
+            if (REGISTER_MAP[reg] != REGISTER_INVALID) {
+                _send_BM1366((TYPE_CMD | GROUP_SINGLE | CMD_READ), (uint8_t[]){chip_addr, reg}, 2, BM1366_SERIALTX_DEBUG);
+                vTaskDelay(pdMS_TO_TICKS(1));
+            }
         }
     }
 }

--- a/components/asic/bm1366.c
+++ b/components/asic/bm1366.c
@@ -87,7 +87,12 @@ static void _send_BM1366(uint8_t header, uint8_t * data, uint8_t data_len, bool 
     packet_type_t packet_type = (header & TYPE_JOB) ? JOB_PACKET : CMD_PACKET;
     uint8_t total_length = (packet_type == JOB_PACKET) ? (data_len + 6) : (data_len + 5);
 
-    uint8_t buf[total_length];
+    if (total_length > 128) {
+        ESP_LOGE(TAG, "Packet length %d exceeds maximum buffer size", total_length);
+        return;
+    }
+
+    uint8_t buf[128];
 
     // add the preamble
     buf[0] = 0x55;
@@ -117,7 +122,12 @@ static void _send_BM1366(uint8_t header, uint8_t * data, uint8_t data_len, bool 
 
 static void _send_simple(uint8_t * data, uint8_t total_length)
 {
-    uint8_t buf[total_length];
+    if (total_length > 128) {
+        ESP_LOGE(TAG, "Packet length %d exceeds maximum buffer size", total_length);
+        return;
+    }
+
+    uint8_t buf[128];
     memcpy(buf, data, total_length);
     SERIAL_send(buf, total_length, BM1366_SERIALTX_DEBUG);
 }
@@ -397,7 +407,7 @@ void BM1366_read_registers(void)
     for (int reg = 0; reg < size; reg++) {
         if (REGISTER_MAP[reg] != REGISTER_INVALID) {
             _send_BM1366((TYPE_CMD | GROUP_ALL | CMD_READ), (uint8_t[]){0x00, reg}, 2, BM1366_SERIALTX_DEBUG);
-            vTaskDelay(1 / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(1));
         }
     }
 }

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -83,7 +83,12 @@ static void _send_BM1368(uint8_t header, uint8_t * data, uint8_t data_len, bool 
     packet_type_t packet_type = (header & TYPE_JOB) ? JOB_PACKET : CMD_PACKET;
     uint8_t total_length = (packet_type == JOB_PACKET) ? (data_len + 6) : (data_len + 5);
 
-    uint8_t buf[total_length];
+    if (total_length > 128) {
+        ESP_LOGE(TAG, "Packet length %d exceeds maximum buffer size", total_length);
+        return;
+    }
+
+    uint8_t buf[128];
 
     buf[0] = 0x55;
     buf[1] = 0xAA;
@@ -346,7 +351,7 @@ void BM1368_read_registers(void)
     for (int reg = 0; reg < size; reg++) {
         if (REGISTER_MAP[reg] != REGISTER_INVALID) {
             _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_READ), (uint8_t[]){0x00, reg}, 2, BM1368_SERIALTX_DEBUG);
-            vTaskDelay(1 / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(1));
         }
     }
 }

--- a/components/asic/bm1368.c
+++ b/components/asic/bm1368.c
@@ -345,13 +345,22 @@ task_result * BM1368_process_work(void * pvParameters)
     return &result;
 }
 
-void BM1368_read_registers(void)
+void BM1368_read_registers(void * pvParameters)
 {
+    GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
+    uint16_t asic_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
+    if (asic_count == 0 || address_interval <= 0) {
+        return;
+    }
+
     int size = sizeof(REGISTER_MAP) / sizeof(REGISTER_MAP[0]);
-    for (int reg = 0; reg < size; reg++) {
-        if (REGISTER_MAP[reg] != REGISTER_INVALID) {
-            _send_BM1368((TYPE_CMD | GROUP_ALL | CMD_READ), (uint8_t[]){0x00, reg}, 2, BM1368_SERIALTX_DEBUG);
-            vTaskDelay(pdMS_TO_TICKS(1));
+    for (uint8_t chip = 0; chip < asic_count; chip++) {
+        uint8_t chip_addr = chip * address_interval;
+        for (int reg = 0; reg < size; reg++) {
+            if (REGISTER_MAP[reg] != REGISTER_INVALID) {
+                _send_BM1368((TYPE_CMD | GROUP_SINGLE | CMD_READ), (uint8_t[]){chip_addr, reg}, 2, BM1368_SERIALTX_DEBUG);
+                vTaskDelay(pdMS_TO_TICKS(1));
+            }
         }
     }
 }

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -32,6 +32,8 @@
 #define BM_CHIP_ID 0x00
 #define MISC_CONTROL 0x18
 #define FAST_UART_CONFIGURATION 0x28
+#define BM1370_INIT_CORE_REGISTER_DELAY_MS 10
+#define BM1370_CLOCK_DELAY_CTRL_VALUE 0x10
 
 static const register_type_t REGISTER_MAP[] = {
     [0x4C] = REGISTER_ERROR_COUNT,
@@ -75,6 +77,30 @@ static const char * TAG = "bm1370";
 static task_result result;
 
 static int address_interval;
+static int chip_count;
+
+static void _send_BM1370(uint8_t header, const uint8_t * data, uint8_t data_len, bool debug);
+
+static void BM1370_init_core_register_delay(void)
+{
+    vTaskDelay(pdMS_TO_TICKS(BM1370_INIT_CORE_REGISTER_DELAY_MS));
+}
+
+static void BM1370_write_clock_delay_ctrl(uint8_t chip_addr, uint8_t header)
+{
+    _send_BM1370(header,
+                 (uint8_t[]){chip_addr, 0x3C, 0x80, 0x00, 0x80, BM1370_CLOCK_DELAY_CTRL_VALUE},
+                 6,
+                 BM1370_SERIALTX_DEBUG);
+}
+
+static void BM1370_write_io_driver_strength(uint8_t chip_addr, uint8_t header, uint8_t value2)
+{
+    _send_BM1370(header,
+                 (uint8_t[]){chip_addr, 0x58, 0x00, 0x01, value2, 0x11},
+                 6,
+                 BM1370_SERIALTX_DEBUG);
+}
 
 /// @brief
 /// @param ftdi
@@ -202,6 +228,7 @@ uint8_t BM1370_init(void * pvParameters)
         return 0;
     }
 
+    chip_count = chip_counter;
 
     // set version mask
     BM1370_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
@@ -231,11 +258,15 @@ uint8_t BM1370_init(void * pvParameters)
     //Core Register Control
     //unsigned char init9[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0x3C, 0x80, 0x00, 0x8B, 0x00, 0x12};
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x3C, 0x80, 0x00, 0x8B, 0x00}, 6, BM1370_SERIALTX_DEBUG);
+    BM1370_init_core_register_delay();
 
-    //Core Register Control
-    //TX: 55 AA 51 09 [00 3C 80 00 80 0C] 11  //command all chips, write chip address 00, register 3C, data 80 00 80 0C - Core Register Control
-    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x3C, 0x80, 0x00, 0x80, 0x0C}, 6, BM1370_SERIALTX_DEBUG); //from S21Pro dump
-    //_send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x3C, 0x80, 0x00, 0x80, 0x18}, 6, BM1370_SERIALTX_DEBUG); //from S21 dump
+    // Core Register Control, internal ClockDelayCtrlV2.
+    BM1370_write_clock_delay_ctrl(0x00, (TYPE_CMD | GROUP_ALL | CMD_WRITE));
+    BM1370_init_core_register_delay();
+
+    // Present in the S21 XP init between core register control and analog mux.
+    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x14, 0x00, 0x00, 0x00, 0xFF}, 6, BM1370_SERIALTX_DEBUG);
+    BM1370_init_core_register_delay();
 
     uint16_t difficulty = GLOBAL_STATE->DEVICE_CONFIG.family.asic.difficulty;
     
@@ -243,16 +274,17 @@ uint8_t BM1370_init(void * pvParameters)
     uint8_t difficulty_mask[6];
     get_difficulty_mask(difficulty, difficulty_mask);
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), difficulty_mask, 6, BM1370_SERIALTX_DEBUG);    
+    BM1370_init_core_register_delay();
 
-    //Analog Mux Control -- not sent on S21 Pro?
-    // unsigned char init12[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0x54, 0x00, 0x00, 0x00, 0x03, 0x1D};
-    // _send_simple(init12, 11);
+    //Analog Mux Control
+    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x54, 0x00, 0x00, 0x00, 0x03}, 6, BM1370_SERIALTX_DEBUG);
 
-    //Set the IO Driver Strength on chip 00
-    //TX: 55 AA 51 09 [00 58 00 01 11 11] 0D  //command all chips, write chip address 00, register 58, data 01 11 11 11 - Set the IO Driver Strength on chip 00
-    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x58, 0x00, 0x01, 0x11, 0x11}, 6, BM1370_SERIALTX_DEBUG); //from S21Pro dump
-    //_send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x58, 0x02, 0x11, 0x11, 0x11}, 6, BM1370_SERIALTX_DEBUG); //from S21Pro dump
-    
+    //Set the IO Driver Strength
+    BM1370_write_io_driver_strength(0x00, (TYPE_CMD | GROUP_ALL | CMD_WRITE), 0x11);
+
+    // Present in the older BM1370 C++ init path. Keep this before per-chip core
+    // register setup so all chips share the same internal counter/mux state.
+    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x68, 0x5A, 0xA5, 0x5A, 0xA5}, 6, BM1370_SERIALTX_DEBUG);
 
     for (uint8_t i = 0; i < chip_counter; i++) {
         //TX: 55 AA 41 09 00 [A8 00 07 01 F0] 15    // Reg_A8
@@ -264,12 +296,14 @@ uint8_t BM1370_init(void * pvParameters)
         //TX: 55 AA 41 09 00 [3C 80 00 8B 00] 1A    // Core Register Control
         unsigned char set_3c_register_first[6] = {i * address_interval, 0x3C, 0x80, 0x00, 0x8B, 0x00};
         _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_first, 6, BM1370_SERIALTX_DEBUG);
-        //TX: 55 AA 41 09 00 [3C 80 00 80 0C] 19    // Core Register Control
-        unsigned char set_3c_register_second[6] = {i * address_interval, 0x3C, 0x80, 0x00, 0x80, 0x0C};
-        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_second, 6, BM1370_SERIALTX_DEBUG);
+        BM1370_init_core_register_delay();
+        //TX: 55 AA 41 09 00 [3C 80 00 80 XX] 09    // Core Register Control
+        BM1370_write_clock_delay_ctrl(i * address_interval, (TYPE_CMD | GROUP_SINGLE | CMD_WRITE));
+        BM1370_init_core_register_delay();
         //TX: 55 AA 41 09 00 [3C 80 00 82 AA] 05    // Core Register Control
         unsigned char set_3c_register_third[6] = {i * address_interval, 0x3C, 0x80, 0x00, 0x82, 0xAA};
         _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_third, 6, BM1370_SERIALTX_DEBUG);
+        BM1370_init_core_register_delay();
     }
 
     //Some misc settings?
@@ -281,6 +315,7 @@ uint8_t BM1370_init(void * pvParameters)
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0xB9, 0x00, 0x00, 0x44, 0x80}, 6, BM1370_SERIALTX_DEBUG);
     // TX: 55 AA 51 09 [00 3C 80 00 8D EE] 1B    //command all chips, write chip address 00, register 3C, data 80 00 8D EE
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x3C, 0x80, 0x00, 0x8D, 0xEE}, 6, BM1370_SERIALTX_DEBUG);
+    BM1370_init_core_register_delay();
 
     //ramp up the hash frequency
     do_frequency_transition(GLOBAL_STATE, BM1370_send_hash_frequency);
@@ -411,11 +446,18 @@ task_result * BM1370_process_work(void * pvParameters)
 
 void BM1370_read_registers(void)
 {
+    if (chip_count <= 0 || address_interval <= 0) {
+        return;
+    }
+
     int size = sizeof(REGISTER_MAP) / sizeof(REGISTER_MAP[0]);
-    for (int reg = 0; reg < size; reg++) {
-        if (REGISTER_MAP[reg] != REGISTER_INVALID) {
-            _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_READ), (uint8_t[]){0x00, reg}, 2, BM1370_SERIALTX_DEBUG);
-            vTaskDelay(1 / portTICK_PERIOD_MS);
+    for (int chip = 0; chip < chip_count; chip++) {
+        uint8_t chip_addr = (uint8_t)(chip * address_interval);
+        for (int reg = 0; reg < size; reg++) {
+            if (REGISTER_MAP[reg] != REGISTER_INVALID) {
+                _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_READ), (uint8_t[]){chip_addr, reg}, 2, BM1370_SERIALTX_DEBUG);
+                vTaskDelay(1 / portTICK_PERIOD_MS);
+            }
         }
     }
 }

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -32,7 +32,10 @@
 #define BM_CHIP_ID 0x00
 #define MISC_CONTROL 0x18
 #define FAST_UART_CONFIGURATION 0x28
-#define BM1370_INIT_CORE_REGISTER_DELAY_MS 10
+#define CORE_REGISTER_CONTROL 0x3C
+#define ANALOG_MUX_CONTROL 0x54
+#define IO_DRIVER_STRENGTH 0x58
+#define PLL3_PARAMETER 0x68
 #define BM1370_CLOCK_DELAY_CTRL_VALUE 0x10
 
 static const register_type_t REGISTER_MAP[] = {
@@ -80,15 +83,10 @@ static int address_interval;
 
 static void _send_BM1370(uint8_t header, const uint8_t * data, uint8_t data_len, bool debug);
 
-static void BM1370_init_core_register_delay(void)
-{
-    vTaskDelay(pdMS_TO_TICKS(BM1370_INIT_CORE_REGISTER_DELAY_MS));
-}
-
 static void BM1370_write_clock_delay_ctrl(uint8_t chip_addr, uint8_t header)
 {
     _send_BM1370(header,
-                 (uint8_t[]){chip_addr, 0x3C, 0x80, 0x00, 0x80, BM1370_CLOCK_DELAY_CTRL_VALUE},
+                 (uint8_t[]){chip_addr, CORE_REGISTER_CONTROL, 0x80, 0x00, 0x80, BM1370_CLOCK_DELAY_CTRL_VALUE},
                  6,
                  BM1370_SERIALTX_DEBUG);
 }
@@ -96,7 +94,7 @@ static void BM1370_write_clock_delay_ctrl(uint8_t chip_addr, uint8_t header)
 static void BM1370_write_io_driver_strength(uint8_t chip_addr, uint8_t header, uint8_t value2)
 {
     _send_BM1370(header,
-                 (uint8_t[]){chip_addr, 0x58, 0x00, 0x01, value2, 0x11},
+                 (uint8_t[]){chip_addr, IO_DRIVER_STRENGTH, 0x00, 0x01, value2, 0x11},
                  6,
                  BM1370_SERIALTX_DEBUG);
 }
@@ -232,8 +230,6 @@ uint8_t BM1370_init(void * pvParameters)
         return 0;
     }
 
-    chip_count = chip_counter;
-
     // set version mask
     BM1370_set_version_mask(STRATUM_DEFAULT_VERSION_MASK);
 
@@ -261,16 +257,16 @@ uint8_t BM1370_init(void * pvParameters)
 
     //Core Register Control
     //unsigned char init9[11] = {0x55, 0xAA, 0x51, 0x09, 0x00, 0x3C, 0x80, 0x00, 0x8B, 0x00, 0x12};
-    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x3C, 0x80, 0x00, 0x8B, 0x00}, 6, BM1370_SERIALTX_DEBUG);
-    BM1370_init_core_register_delay();
+    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, CORE_REGISTER_CONTROL, 0x80, 0x00, 0x8B, 0x00}, 6, BM1370_SERIALTX_DEBUG);
+    asic_init_core_register_delay();
 
     // Core Register Control, internal ClockDelayCtrlV2.
     BM1370_write_clock_delay_ctrl(0x00, (TYPE_CMD | GROUP_ALL | CMD_WRITE));
-    BM1370_init_core_register_delay();
+    asic_init_core_register_delay();
 
     // Present in the S21 XP init between core register control and analog mux.
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x14, 0x00, 0x00, 0x00, 0xFF}, 6, BM1370_SERIALTX_DEBUG);
-    BM1370_init_core_register_delay();
+    asic_init_core_register_delay();
 
     uint16_t difficulty = GLOBAL_STATE->DEVICE_CONFIG.family.asic.difficulty;
     
@@ -278,45 +274,45 @@ uint8_t BM1370_init(void * pvParameters)
     uint8_t difficulty_mask[6];
     get_difficulty_mask(difficulty, difficulty_mask);
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), difficulty_mask, 6, BM1370_SERIALTX_DEBUG);    
-    BM1370_init_core_register_delay();
+    asic_init_core_register_delay();
 
     //Analog Mux Control
-    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x54, 0x00, 0x00, 0x00, 0x03}, 6, BM1370_SERIALTX_DEBUG);
+    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, ANALOG_MUX_CONTROL, 0x00, 0x00, 0x00, 0x03}, 6, BM1370_SERIALTX_DEBUG);
 
     //Set the IO Driver Strength
     BM1370_write_io_driver_strength(0x00, (TYPE_CMD | GROUP_ALL | CMD_WRITE), 0x11);
 
     // Present in the older BM1370 C++ init path. Keep this before per-chip core
     // register setup so all chips share the same internal counter/mux state.
-    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x68, 0x5A, 0xA5, 0x5A, 0xA5}, 6, BM1370_SERIALTX_DEBUG);
+    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, PLL3_PARAMETER, 0x5A, 0xA5, 0x5A, 0xA5}, 6, BM1370_SERIALTX_DEBUG);
 
     for (uint8_t i = 0; i < chip_counter; i++) {
         uint8_t chip_addr = i * address_interval;
         //TX: 55 AA 41 09 00 [A8 00 07 01 F0] 15    // Reg_A8
         _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), (uint8_t[]){chip_addr, 0xA8, 0x00, 0x07, 0x01, 0xF0}, 6, BM1370_SERIALTX_DEBUG);
         //TX: 55 AA 41 09 00 [18 F0 00 C1 00] 0C    // Misc Control
-        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), (uint8_t[]){chip_addr, 0x18, 0xF0, 0x00, 0xC1, 0x00}, 6, BM1370_SERIALTX_DEBUG);
+        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), (uint8_t[]){chip_addr, MISC_CONTROL, 0xF0, 0x00, 0xC1, 0x00}, 6, BM1370_SERIALTX_DEBUG);
         //TX: 55 AA 41 09 00 [3C 80 00 8B 00] 1A    // Core Register Control
-        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), (uint8_t[]){chip_addr, 0x3C, 0x80, 0x00, 0x8B, 0x00}, 6, BM1370_SERIALTX_DEBUG);
-        BM1370_init_core_register_delay();
+        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), (uint8_t[]){chip_addr, CORE_REGISTER_CONTROL, 0x80, 0x00, 0x8B, 0x00}, 6, BM1370_SERIALTX_DEBUG);
+        asic_init_core_register_delay();
         //TX: 55 AA 41 09 00 [3C 80 00 80 XX] 09    // Core Register Control
         BM1370_write_clock_delay_ctrl(chip_addr, (TYPE_CMD | GROUP_SINGLE | CMD_WRITE));
-        BM1370_init_core_register_delay();
+        asic_init_core_register_delay();
         //TX: 55 AA 41 09 00 [3C 80 00 82 AA] 05    // Core Register Control
-        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), (uint8_t[]){chip_addr, 0x3C, 0x80, 0x00, 0x82, 0xAA}, 6, BM1370_SERIALTX_DEBUG);
-        BM1370_init_core_register_delay();
+        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), (uint8_t[]){chip_addr, CORE_REGISTER_CONTROL, 0x80, 0x00, 0x82, 0xAA}, 6, BM1370_SERIALTX_DEBUG);
+        asic_init_core_register_delay();
     }
 
     //Some misc settings?
     // TX: 55 AA 51 09 [00 B9 00 00 44 80] 0D    //command all chips, write chip address 00, register B9, data 00 00 44 80
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0xB9, 0x00, 0x00, 0x44, 0x80}, 6, BM1370_SERIALTX_DEBUG);
     // TX: 55 AA 51 09 [00 54 00 00 00 02] 18    //command all chips, write chip address 00, register 54, data 00 00 00 02 - Analog Mux Control - rumored to control the temp diode
-    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x54, 0x00, 0x00, 0x00, 0x02}, 6, BM1370_SERIALTX_DEBUG);
+    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, ANALOG_MUX_CONTROL, 0x00, 0x00, 0x00, 0x02}, 6, BM1370_SERIALTX_DEBUG);
     // TX: 55 AA 51 09 [00 B9 00 00 44 80] 0D    //command all chips, write chip address 00, register B9, data 00 00 44 80 -- duplicate of first command in series
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0xB9, 0x00, 0x00, 0x44, 0x80}, 6, BM1370_SERIALTX_DEBUG);
     // TX: 55 AA 51 09 [00 3C 80 00 8D EE] 1B    //command all chips, write chip address 00, register 3C, data 80 00 8D EE
-    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x3C, 0x80, 0x00, 0x8D, 0xEE}, 6, BM1370_SERIALTX_DEBUG);
-    BM1370_init_core_register_delay();
+    _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, CORE_REGISTER_CONTROL, 0x80, 0x00, 0x8D, 0xEE}, 6, BM1370_SERIALTX_DEBUG);
+    asic_init_core_register_delay();
 
     //ramp up the hash frequency
     do_frequency_transition(GLOBAL_STATE, BM1370_send_hash_frequency);

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -458,7 +458,7 @@ void BM1370_read_registers(void)
         for (int reg = 0; reg < size; reg++) {
             if (REGISTER_MAP[reg] != REGISTER_INVALID) {
                 _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_READ), (uint8_t[]){chip_addr, reg}, 2, BM1370_SERIALTX_DEBUG);
-                BM1370_init_core_register_delay();
+                vTaskDelay(pdMS_TO_TICKS(1));
             }
         }
     }

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -77,7 +77,6 @@ static const char * TAG = "bm1370";
 static task_result result;
 
 static int address_interval;
-static int chip_count;
 
 static void _send_BM1370(uint8_t header, const uint8_t * data, uint8_t data_len, bool debug);
 
@@ -446,15 +445,17 @@ task_result * BM1370_process_work(void * pvParameters)
     return &result;
 }
 
-void BM1370_read_registers(void)
+void BM1370_read_registers(void * pvParameters)
 {
-    if (chip_count <= 0 || address_interval <= 0) {
+    GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
+    uint16_t asic_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
+    if (asic_count == 0 || address_interval <= 0) {
         return;
     }
 
     int size = sizeof(REGISTER_MAP) / sizeof(REGISTER_MAP[0]);
-    for (int chip = 0; chip < chip_count; chip++) {
-        uint8_t chip_addr = (uint8_t)(chip * address_interval);
+    for (uint8_t chip = 0; chip < asic_count; chip++) {
+        uint8_t chip_addr = chip * address_interval;
         for (int reg = 0; reg < size; reg++) {
             if (REGISTER_MAP[reg] != REGISTER_INVALID) {
                 _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_READ), (uint8_t[]){chip_addr, reg}, 2, BM1370_SERIALTX_DEBUG);

--- a/components/asic/bm1370.c
+++ b/components/asic/bm1370.c
@@ -112,7 +112,12 @@ static void _send_BM1370(uint8_t header, const uint8_t * data, uint8_t data_len,
     packet_type_t packet_type = (header & TYPE_JOB) ? JOB_PACKET : CMD_PACKET;
     const uint8_t total_length = (packet_type == JOB_PACKET) ? (data_len + 6) : (data_len + 5);
 
-    uint8_t buf[total_length];
+    if (total_length > 128) {
+        ESP_LOGE(TAG, "Packet length %d exceeds maximum buffer size", total_length);
+        return;
+    }
+
+    uint8_t buf[128];
 
     // add the preamble
     buf[0] = 0x55;
@@ -287,22 +292,19 @@ uint8_t BM1370_init(void * pvParameters)
     _send_BM1370((TYPE_CMD | GROUP_ALL | CMD_WRITE), (uint8_t[]){0x00, 0x68, 0x5A, 0xA5, 0x5A, 0xA5}, 6, BM1370_SERIALTX_DEBUG);
 
     for (uint8_t i = 0; i < chip_counter; i++) {
+        uint8_t chip_addr = i * address_interval;
         //TX: 55 AA 41 09 00 [A8 00 07 01 F0] 15    // Reg_A8
-        unsigned char set_a8_register[6] = {i * address_interval, 0xA8, 0x00, 0x07, 0x01, 0xF0};
-        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_a8_register, 6, BM1370_SERIALTX_DEBUG);
+        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), (uint8_t[]){chip_addr, 0xA8, 0x00, 0x07, 0x01, 0xF0}, 6, BM1370_SERIALTX_DEBUG);
         //TX: 55 AA 41 09 00 [18 F0 00 C1 00] 0C    // Misc Control
-        unsigned char set_18_register[6] = {i * address_interval, 0x18, 0xF0, 0x00, 0xC1, 0x00};
-        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_18_register, 6, BM1370_SERIALTX_DEBUG);
+        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), (uint8_t[]){chip_addr, 0x18, 0xF0, 0x00, 0xC1, 0x00}, 6, BM1370_SERIALTX_DEBUG);
         //TX: 55 AA 41 09 00 [3C 80 00 8B 00] 1A    // Core Register Control
-        unsigned char set_3c_register_first[6] = {i * address_interval, 0x3C, 0x80, 0x00, 0x8B, 0x00};
-        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_first, 6, BM1370_SERIALTX_DEBUG);
+        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), (uint8_t[]){chip_addr, 0x3C, 0x80, 0x00, 0x8B, 0x00}, 6, BM1370_SERIALTX_DEBUG);
         BM1370_init_core_register_delay();
         //TX: 55 AA 41 09 00 [3C 80 00 80 XX] 09    // Core Register Control
-        BM1370_write_clock_delay_ctrl(i * address_interval, (TYPE_CMD | GROUP_SINGLE | CMD_WRITE));
+        BM1370_write_clock_delay_ctrl(chip_addr, (TYPE_CMD | GROUP_SINGLE | CMD_WRITE));
         BM1370_init_core_register_delay();
         //TX: 55 AA 41 09 00 [3C 80 00 82 AA] 05    // Core Register Control
-        unsigned char set_3c_register_third[6] = {i * address_interval, 0x3C, 0x80, 0x00, 0x82, 0xAA};
-        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), set_3c_register_third, 6, BM1370_SERIALTX_DEBUG);
+        _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_WRITE), (uint8_t[]){chip_addr, 0x3C, 0x80, 0x00, 0x82, 0xAA}, 6, BM1370_SERIALTX_DEBUG);
         BM1370_init_core_register_delay();
     }
 
@@ -456,7 +458,7 @@ void BM1370_read_registers(void)
         for (int reg = 0; reg < size; reg++) {
             if (REGISTER_MAP[reg] != REGISTER_INVALID) {
                 _send_BM1370((TYPE_CMD | GROUP_SINGLE | CMD_READ), (uint8_t[]){chip_addr, reg}, 2, BM1370_SERIALTX_DEBUG);
-                vTaskDelay(1 / portTICK_PERIOD_MS);
+                BM1370_init_core_register_delay();
             }
         }
     }

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -91,7 +91,12 @@ static void _send_BM1397(uint8_t header, uint8_t *data, uint8_t data_len, bool d
     packet_type_t packet_type = (header & TYPE_JOB) ? JOB_PACKET : CMD_PACKET;
     uint8_t total_length = (packet_type == JOB_PACKET) ? (data_len + 6) : (data_len + 5);
 
-    uint8_t buf[total_length];
+    if (total_length > 128) {
+        ESP_LOGE(TAG, "Packet length %d exceeds maximum buffer size", total_length);
+        return;
+    }
+
+    uint8_t buf[128];
 
     // add the preamble
     buf[0] = 0x55;
@@ -396,7 +401,7 @@ void BM1397_read_registers(void)
     for (int reg = 0; reg < size; reg++) {
         if (REGISTER_MAP[reg] != REGISTER_INVALID) {
             _send_BM1397((TYPE_CMD | GROUP_ALL | CMD_READ), (uint8_t[]){0x00, reg}, 2, BM1397_SERIALTX_DEBUG);
-            vTaskDelay(1 / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(1));
         }
     }
 }

--- a/components/asic/bm1397.c
+++ b/components/asic/bm1397.c
@@ -395,13 +395,22 @@ task_result *BM1397_process_work(void *pvParameters)
     return &result;
 }
 
-void BM1397_read_registers(void)
+void BM1397_read_registers(void * pvParameters)
 {
+    GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
+    uint16_t asic_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
+    if (asic_count == 0 || address_interval <= 0) {
+        return;
+    }
+
     int size = sizeof(REGISTER_MAP) / sizeof(REGISTER_MAP[0]);
-    for (int reg = 0; reg < size; reg++) {
-        if (REGISTER_MAP[reg] != REGISTER_INVALID) {
-            _send_BM1397((TYPE_CMD | GROUP_ALL | CMD_READ), (uint8_t[]){0x00, reg}, 2, BM1397_SERIALTX_DEBUG);
-            vTaskDelay(pdMS_TO_TICKS(1));
+    for (uint8_t chip = 0; chip < asic_count; chip++) {
+        uint8_t chip_addr = chip * address_interval;
+        for (int reg = 0; reg < size; reg++) {
+            if (REGISTER_MAP[reg] != REGISTER_INVALID) {
+                _send_BM1397((TYPE_CMD | GROUP_SINGLE | CMD_READ), (uint8_t[]){chip_addr, reg}, 2, BM1397_SERIALTX_DEBUG);
+                vTaskDelay(pdMS_TO_TICKS(1));
+            }
         }
     }
 }

--- a/components/asic/include/asic_common.h
+++ b/components/asic/include/asic_common.h
@@ -4,6 +4,15 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "esp_err.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#define ASIC_INIT_CORE_REGISTER_DELAY_MS 10
+
+static inline void asic_init_core_register_delay(void)
+{
+    vTaskDelay(pdMS_TO_TICKS(ASIC_INIT_CORE_REGISTER_DELAY_MS));
+}
 
 static const double NONCE_SPACE = 4294967296.0; //  2^32
 

--- a/components/asic/include/bm1366.h
+++ b/components/asic/include/bm1366.h
@@ -28,7 +28,7 @@ int BM1366_set_max_baud(void);
 int BM1366_set_default_baud(void);
 float BM1366_send_hash_frequency(float frequency);
 task_result * BM1366_process_work(void * GLOBAL_STATE);
-void BM1366_read_registers(void);
+void BM1366_read_registers(void * GLOBAL_STATE);
 void BM1366_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores);
 
 #endif /* BM1366_H_ */

--- a/components/asic/include/bm1368.h
+++ b/components/asic/include/bm1368.h
@@ -28,7 +28,7 @@ int BM1368_set_max_baud(void);
 int BM1368_set_default_baud(void);
 float BM1368_send_hash_frequency(float frequency);
 task_result * BM1368_process_work(void * GLOBAL_STATE);
-void BM1368_read_registers(void);
+void BM1368_read_registers(void * GLOBAL_STATE);
 void BM1368_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores);
 
 #endif /* BM1368_H_ */

--- a/components/asic/include/bm1370.h
+++ b/components/asic/include/bm1370.h
@@ -28,7 +28,7 @@ int BM1370_set_max_baud(void);
 int BM1370_set_default_baud(void);
 float BM1370_send_hash_frequency(float frequency);
 task_result * BM1370_process_work(void * GLOBAL_STATE);
-void BM1370_read_registers(void);
+void BM1370_read_registers(void * GLOBAL_STATE);
 void BM1370_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores);
 
 #endif /* BM1370_H_ */

--- a/components/asic/include/bm1397.h
+++ b/components/asic/include/bm1397.h
@@ -30,6 +30,6 @@ int BM1397_set_max_baud(void);
 int BM1397_set_default_baud(void);
 float BM1397_send_hash_frequency(float frequency);
 task_result * BM1397_process_work(void * GLOBAL_STATE);
-void BM1397_read_registers(void);
+void BM1397_read_registers(void * GLOBAL_STATE);
 
 #endif /* BM1397_H_ */


### PR DESCRIPTION
Adds ASIC init delays and per-chip register read loops. Also refactors VLA to a fixed buffer to eliminate stack overflow risks. 

Extracted from #1807.