### PR TITLE
TPS546 PMBus Telemetry & Active-High ASIC Enable

### DIFF
--- a/main/device_config.h
+++ b/main/device_config.h
@@ -62,6 +62,7 @@ typedef struct {
     FamilyConfig family;
     bool plug_sense;
     bool asic_enable;
+    bool asic_enable_active_high;
     bool EMC2101 : 1;
     bool EMC2103 : 1;
     bool EMC2302 : 1;

--- a/main/power/TPS546.c
+++ b/main/power/TPS546.c
@@ -5,6 +5,8 @@
 #include "esp_log.h"
 #include "esp_err.h"
 #include "esp_check.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #include "pmbus_commands.h"
 
@@ -23,6 +25,8 @@
 #define ACK_VALUE      0x0
 #define NACK_VALUE     0x1
 #define MAX_BLOCK_LEN  32
+#define TPS546_POWER_GOOD_GRACE_MS 250
+#define TPS546_I2C_TIMEOUT_MS 500
 
 static const char *TAG = "TPS546";
 
@@ -34,6 +38,8 @@ static uint8_t DEVICE_ID_TPS546D24S[] = {0x54, 0x49, 0x54, 0x6D, 0x24, 0x62};
 static i2c_master_dev_handle_t tps546_i2c_handle;
 
 static TPS546_CONFIG tps546_config;
+static TickType_t tps546_power_good_grace_until = 0;
+static i2c_master_dev_handle_t tps546_alert_i2c_handle;
 
 // Cached values to handle I2C failures robustly
 static float last_vin = 0.0f;
@@ -43,6 +49,14 @@ static int last_temp = 0;
 
 
 static esp_err_t TPS546_parse_status(uint16_t);
+
+static esp_err_t TPS546_read_alert_response(uint8_t *alert_response)
+{
+    ESP_RETURN_ON_ERROR(i2c_bitaxe_add_device(TPS546_I2CADDR_ALERT, &tps546_alert_i2c_handle, "TPS546_ALERT"),
+                        TAG, "Failed to add TPS546 SMBus alert address");
+
+    return i2c_master_receive(tps546_alert_i2c_handle, alert_response, 1, TPS546_I2C_TIMEOUT_MS);
+}
 
 /**
  * @brief SMBus read byte
@@ -331,6 +345,41 @@ static uint16_t float_2_ulinear16(float value)
     return result;
 }
 
+static esp_err_t TPS546_write_vout_limit_ratios(float vout_command)
+{
+    ESP_LOGI(TAG, "Setting VOUT_OV_FAULT_LIMIT: %.2fx (%.2fV)", TPS546_INIT_VOUT_OV_FAULT_LIMIT,
+             vout_command * TPS546_INIT_VOUT_OV_FAULT_LIMIT);
+    ESP_RETURN_ON_ERROR(smb_write_word(PMBUS_VOUT_OV_FAULT_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_OV_FAULT_LIMIT)),
+                        TAG, "Failed to write VOUT_OV_FAULT_LIMIT");
+
+    ESP_LOGI(TAG, "Setting VOUT_OV_WARN_LIMIT: %.2fx (%.2fV)", TPS546_INIT_VOUT_OV_WARN_LIMIT,
+             vout_command * TPS546_INIT_VOUT_OV_WARN_LIMIT);
+    ESP_RETURN_ON_ERROR(smb_write_word(PMBUS_VOUT_OV_WARN_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_OV_WARN_LIMIT)),
+                        TAG, "Failed to write VOUT_OV_WARN_LIMIT");
+
+    ESP_LOGI(TAG, "Setting VOUT_MARGIN_HIGH: %.2fx (%.2fV)", TPS546_INIT_VOUT_MARGIN_HIGH,
+             vout_command * TPS546_INIT_VOUT_MARGIN_HIGH);
+    ESP_RETURN_ON_ERROR(smb_write_word(PMBUS_VOUT_MARGIN_HIGH, float_2_ulinear16(TPS546_INIT_VOUT_MARGIN_HIGH)),
+                        TAG, "Failed to write VOUT_MARGIN_HIGH");
+
+    ESP_LOGI(TAG, "Setting VOUT_MARGIN_LOW: %.2fx (%.2fV)", TPS546_INIT_VOUT_MARGIN_LOW,
+             vout_command * TPS546_INIT_VOUT_MARGIN_LOW);
+    ESP_RETURN_ON_ERROR(smb_write_word(PMBUS_VOUT_MARGIN_LOW, float_2_ulinear16(TPS546_INIT_VOUT_MARGIN_LOW)),
+                        TAG, "Failed to write VOUT_MARGIN_LOW");
+
+    ESP_LOGI(TAG, "Setting VOUT_UV_WARN_LIMIT: %.2fx (%.2fV)", TPS546_INIT_VOUT_UV_WARN_LIMIT,
+             vout_command * TPS546_INIT_VOUT_UV_WARN_LIMIT);
+    ESP_RETURN_ON_ERROR(smb_write_word(PMBUS_VOUT_UV_WARN_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_UV_WARN_LIMIT)),
+                        TAG, "Failed to write VOUT_UV_WARN_LIMIT");
+
+    ESP_LOGI(TAG, "Setting VOUT_UV_FAULT_LIMIT: %.2fx (%.2fV)", TPS546_INIT_VOUT_UV_FAULT_LIMIT,
+             vout_command * TPS546_INIT_VOUT_UV_FAULT_LIMIT);
+    ESP_RETURN_ON_ERROR(smb_write_word(PMBUS_VOUT_UV_FAULT_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_UV_FAULT_LIMIT)),
+                        TAG, "Failed to write VOUT_UV_FAULT_LIMIT");
+
+    return ESP_OK;
+}
+
 /*--- Public TPS546 functions ---*/
 
 /**
@@ -348,6 +397,15 @@ esp_err_t TPS546_init(TPS546_CONFIG config)
     tps546_config = config;
 
     ESP_LOGI(TAG, "Initializing the core voltage regulator");
+
+    uint8_t alert_response = 0;
+    esp_err_t alert_err = TPS546_read_alert_response(&alert_response);
+    if (alert_err == ESP_OK) {
+        ESP_LOGW(TAG, "SMBus alert response raw=0x%02X decoded 7-bit address=0x%02X", alert_response, alert_response >> 1);
+    } else {
+        ESP_LOGI(TAG, "No SMBus alert response read: %s", esp_err_to_name(alert_err));
+    }
+
     ESP_RETURN_ON_ERROR(i2c_bitaxe_add_device(TPS546_I2CADDR, &tps546_i2c_handle, TAG), TAG, "Failed to add TPS546 I2C");
 
     // 1) Power-up guard (PMBus ready after AVIN UVLO + ~8 ms)
@@ -563,7 +621,23 @@ void TPS546_write_entire_config(void)
             tps546_config.TPS546_INIT_COMPENSATION_CONFIG[0], tps546_config.TPS546_INIT_COMPENSATION_CONFIG[1],
             tps546_config.TPS546_INIT_COMPENSATION_CONFIG[2], tps546_config.TPS546_INIT_COMPENSATION_CONFIG[3],
             tps546_config.TPS546_INIT_COMPENSATION_CONFIG[4]);
-        smb_write_block(PMBUS_COMPENSATION_CONFIG, tps546_config.TPS546_INIT_COMPENSATION_CONFIG, 5);
+        esp_err_t comp_err = smb_write_block(PMBUS_COMPENSATION_CONFIG,
+                                             tps546_config.TPS546_INIT_COMPENSATION_CONFIG,
+                                             5);
+        if (comp_err != ESP_OK) {
+            uint8_t status_cml = 0;
+            uint16_t status_word = 0;
+
+            if (smb_read_byte(PMBUS_STATUS_CML, &status_cml) == ESP_OK) {
+                ESP_LOGE(TAG, "COMPENSATION_CONFIG write failed; STATUS_CML=%02X", status_cml);
+            }
+
+            if (smb_read_word(PMBUS_STATUS_WORD, &status_word) == ESP_OK) {
+                ESP_LOGE(TAG, "COMPENSATION_CONFIG write failed; STATUS_WORD=%04X", status_word);
+            }
+        } else {
+            ESP_LOGI(TAG, "COMPENSATION_CONFIG write accepted");
+        }
 
     }
 
@@ -600,23 +674,9 @@ void TPS546_write_entire_config(void)
     ESP_LOGI(TAG, "Setting VOUT_MIN: %.2fV", tps546_config.TPS546_INIT_VOUT_MIN);
     smb_write_word(PMBUS_VOUT_MIN, float_2_ulinear16(tps546_config.TPS546_INIT_VOUT_MIN));
 
-    ESP_LOGI(TAG, "Setting VOUT_OV_FAULT_LIMIT: %.2f", TPS546_INIT_VOUT_OV_FAULT_LIMIT);
-    smb_write_word(PMBUS_VOUT_OV_FAULT_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_OV_FAULT_LIMIT));
-
-    ESP_LOGI(TAG, "Setting VOUT_OV_WARN_LIMIT: %.2f", TPS546_INIT_VOUT_OV_WARN_LIMIT);
-    smb_write_word(PMBUS_VOUT_OV_WARN_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_OV_WARN_LIMIT));
-
-    ESP_LOGI(TAG, "Setting VOUT_MARGIN_HIGH: %.2f", TPS546_INIT_VOUT_MARGIN_HIGH);
-    smb_write_word(PMBUS_VOUT_MARGIN_HIGH, float_2_ulinear16(TPS546_INIT_VOUT_MARGIN_HIGH));
-
-    ESP_LOGI(TAG, "Setting VOUT_MARGIN_LOW: %.2f", TPS546_INIT_VOUT_MARGIN_LOW);
-    smb_write_word(PMBUS_VOUT_MARGIN_LOW, float_2_ulinear16(TPS546_INIT_VOUT_MARGIN_LOW));
-
-    ESP_LOGI(TAG, "Setting VOUT_UV_WARN_LIMIT: %.2f", TPS546_INIT_VOUT_UV_WARN_LIMIT);
-    smb_write_word(PMBUS_VOUT_UV_WARN_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_UV_WARN_LIMIT));
-
-    ESP_LOGI(TAG, "Setting VOUT_UV_FAULT_LIMIT: %.2f", TPS546_INIT_VOUT_UV_FAULT_LIMIT);
-    smb_write_word(PMBUS_VOUT_UV_FAULT_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_UV_FAULT_LIMIT));
+    if (TPS546_write_vout_limit_ratios(tps546_config.TPS546_INIT_VOUT_COMMAND) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to write VOUT limit ratios");
+    }
 
     /* iout current */
     ESP_LOGI(TAG, "----- IOUT");
@@ -658,7 +718,7 @@ void TPS546_write_entire_config(void)
     //smb_write_block(PMBUS_COMPENSATION_CONFIG, COMPENSATION_CONFIG, 5);
 
     /* configure the bootup behavior regarding pin detect values vs NVM values */
-    ESP_LOGI(TAG, "Setting PIN_DETECT_OVERRIDE");
+    ESP_LOGI(TAG, "Setting PIN_DETECT_OVERRIDE: %04X", INIT_PIN_DETECT_OVERRIDE);
     smb_write_word(PMBUS_PIN_DETECT_OVERRIDE, INIT_PIN_DETECT_OVERRIDE);
 
     /* TODO write new MFR_REVISION number to reflect these parameters */
@@ -779,15 +839,84 @@ float TPS546_get_vout(void)
     }
 }
 
+esp_err_t TPS546_check_phase_currents(uint8_t phase_count, float minimum_current_a)
+{
+    uint8_t original_phase = 0;
+    esp_err_t result = smb_read_byte(PMBUS_PHASE, &original_phase);
+    if (result != ESP_OK) {
+        ESP_LOGE(TAG, "Could not read PHASE before buck participation test");
+        return result;
+    }
+
+    for (uint8_t phase = 0; phase < phase_count; phase++) {
+        uint16_t raw_iout = 0;
+
+        result = smb_write_byte(PMBUS_PHASE, phase);
+        if (result == ESP_OK) {
+            result = smb_read_word(PMBUS_READ_IOUT, &raw_iout);
+        }
+        if (result != ESP_OK) {
+            ESP_LOGE(TAG, "Buck phase %u current read failed: %s", phase, esp_err_to_name(result));
+            break;
+        }
+
+        float current_a = slinear11_2_float(raw_iout);
+        ESP_LOGI(TAG, "Buck phase %u current: %.3f A", phase, current_a);
+        if (current_a < minimum_current_a) {
+            ESP_LOGE(TAG, "Buck phase %u is not participating (%.3f A, minimum %.3f A)",
+                     phase, current_a, minimum_current_a);
+            result = ESP_FAIL;
+            break;
+        }
+    }
+
+    esp_err_t restore_result = smb_write_byte(PMBUS_PHASE, original_phase);
+    if (restore_result != ESP_OK) {
+        ESP_LOGE(TAG, "Could not restore PHASE=0x%02X after buck participation test: %s",
+                 original_phase, esp_err_to_name(restore_result));
+        return restore_result;
+    }
+
+    return result;
+}
+
+uint8_t TPS546_get_phase_count(void)
+{
+    uint16_t stack_config = 0;
+    if (smb_read_word(PMBUS_STACK_CONFIG, &stack_config) == ESP_OK) {
+        return (stack_config & 0x07) + 1;
+    }
+    return (tps546_config.TPS546_INIT_STACK_CONFIG & 0x07) + 1;
+}
+
 esp_err_t TPS546_check_status(GlobalState * GLOBAL_STATE) {
 
     SystemModule * SYSTEM_MODULE = &GLOBAL_STATE->SYSTEM_MODULE;
     uint16_t status;
 
     ESP_RETURN_ON_ERROR(smb_read_word(PMBUS_STATUS_WORD, &status), TAG, "Failed to read STATUS_WORD");
+
+    if ((status & TPS546_STATUS_OFF) && xTaskGetTickCount() < tps546_power_good_grace_until) {
+        uint8_t operation = 0;
+        const uint16_t hard_faults = TPS546_STATUS_VOUT_OV | TPS546_STATUS_IOUT_OC | TPS546_STATUS_VIN_UV |
+                                     TPS546_STATUS_TEMP | TPS546_STATUS_CML;
+        if (!(status & hard_faults) && smb_read_byte(PMBUS_OPERATION, &operation) == ESP_OK &&
+            operation == OPERATION_ON) {
+            ESP_LOGI(TAG, "Waiting for TPS546 power-good after enable, STATUS_WORD: 0x%04X", status);
+            return ESP_OK;
+        }
+    }
+
     //determine if this is a fault we care about
     if (status & (TPS546_STATUS_OFF | TPS546_STATUS_VOUT_OV | TPS546_STATUS_IOUT_OC | TPS546_STATUS_VIN_UV | TPS546_STATUS_TEMP)) {
         if (SYSTEM_MODULE->power_fault == 0) {
+            TPS546_StatusSnapshot snapshot = {0};
+            esp_err_t snapshot_err = TPS546_snapshot_status(&snapshot);
+            if (snapshot_err == ESP_OK) {
+                TPS546_log_snapshot(&snapshot);
+            } else {
+                ESP_LOGE(TAG, "Failed to snapshot TPS546 status: %s", esp_err_to_name(snapshot_err));
+            }
             ESP_RETURN_ON_ERROR(TPS546_parse_status(status), TAG, "Failed to parse STATUS_WORD");
             SYSTEM_MODULE->power_fault = 1;
         }
@@ -883,8 +1012,6 @@ static esp_err_t TPS546_parse_status(uint16_t status) {
     if (status & TPS546_STATUS_NONE) {
         //ESP_LOGI(TAG, "TPS546 Status Word Error");
         //The host should check the STATUS_WORD for more information.
-    } else {
-        return ESP_OK;
     }
 
     //STATUS_WORD bits
@@ -1021,6 +1148,7 @@ esp_err_t TPS546_set_vout(float volts) {
             ESP_LOGE(TAG, "Could not turn off Vout");
             return ESP_FAIL;
         }
+        tps546_power_good_grace_until = 0;
     } else {
         /* make sure we're in range */
         if ((volts < tps546_config.TPS546_INIT_VOUT_MIN) || (volts > tps546_config.TPS546_INIT_VOUT_MAX)) {
@@ -1036,11 +1164,14 @@ esp_err_t TPS546_set_vout(float volts) {
 
             ESP_LOGI(TAG, "Vout changed to %1.2f V", volts);
 
+            ESP_RETURN_ON_ERROR(TPS546_write_vout_limit_ratios(volts), TAG, "Could not update Vout limit ratios");
+
             /* turn on output */
-           if (smb_write_byte(PMBUS_OPERATION, OPERATION_ON) != ESP_OK) {
+            if (smb_write_byte(PMBUS_OPERATION, OPERATION_ON) != ESP_OK) {
                 ESP_LOGE(TAG, "Could not turn on Vout");
                 return ESP_FAIL;
             }
+            tps546_power_good_grace_until = xTaskGetTickCount() + pdMS_TO_TICKS(TPS546_POWER_GOOD_GRACE_MS);
 
             //make sure operation was written correctly
             if (smb_read_byte(PMBUS_OPERATION, &value8) != ESP_OK) {
@@ -1096,17 +1227,17 @@ void TPS546_show_voltage_settings(void)
     /* VOUT_OV_FAULT_LIMIT */
     smb_read_word(PMBUS_VOUT_OV_FAULT_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "read VOUT_OV_FAULT_LIMIT: %.2fV", f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
+    ESP_LOGI(TAG, "read VOUT_OV_FAULT_LIMIT: %.2fx (%.2fV)", f_value, f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
 
     /* VOUT_OV_WARN_LIMIT */
     smb_read_word(PMBUS_VOUT_OV_WARN_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "read VOUT_OV_WARN_LIMIT: %.2fV", f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
+    ESP_LOGI(TAG, "read VOUT_OV_WARN_LIMIT: %.2fx (%.2fV)", f_value, f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
 
     /* VOUT_MARGIN_HIGH */
     smb_read_word(PMBUS_VOUT_MARGIN_HIGH, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "read VOUT_MARGIN_HIGH: %.2fV", f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
+    ESP_LOGI(TAG, "read VOUT_MARGIN_HIGH: %.2fx (%.2fV)", f_value, f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
 
     /* --- VOUT_COMMAND --- */
     smb_read_word(PMBUS_VOUT_COMMAND, &u16_value);
@@ -1116,17 +1247,17 @@ void TPS546_show_voltage_settings(void)
     /* VOUT_MARGIN_LOW */
     smb_read_word(PMBUS_VOUT_MARGIN_LOW, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "read VOUT_MARGIN_LOW: %.2fV", f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
+    ESP_LOGI(TAG, "read VOUT_MARGIN_LOW: %.2fx (%.2fV)", f_value, f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
 
     /* VOUT_UV_WARN_LIMIT */
     smb_read_word(PMBUS_VOUT_UV_WARN_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "read VOUT_UV_WARN_LIMIT: %.2fV", f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
+    ESP_LOGI(TAG, "read VOUT_UV_WARN_LIMIT: %.2fx (%.2fV)", f_value, f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
 
     /* VOUT_UV_FAULT_LIMIT */
     smb_read_word(PMBUS_VOUT_UV_FAULT_LIMIT, &u16_value);
     f_value = ulinear16_2_float(u16_value);
-    ESP_LOGI(TAG, "read VOUT_UV_FAULT_LIMIT: %.2fV", f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
+    ESP_LOGI(TAG, "read VOUT_UV_FAULT_LIMIT: %.2fx (%.2fV)", f_value, f_value * tps546_config.TPS546_INIT_VOUT_COMMAND);
 
     /* VOUT_MIN */
     smb_read_word(PMBUS_VOUT_MIN, &u16_value);
@@ -1181,9 +1312,37 @@ esp_err_t TPS546_snapshot_status(TPS546_StatusSnapshot *s) {
     if (err != ESP_OK) { return err; }
     s->on_off_config = u8;
 
+    err = smb_read_byte(PMBUS_PHASE, &u8);
+    if (err != ESP_OK) { return err; }
+    s->phase = u8;
+
+    err = smb_read_word(PMBUS_STACK_CONFIG, &u16);
+    if (err != ESP_OK) { return err; }
+    s->stack_config = u16;
+
+    err = smb_read_byte(PMBUS_SYNC_CONFIG, &u8);
+    if (err != ESP_OK) { return err; }
+    s->sync_config = u8;
+
+    err = smb_read_word(PMBUS_INTERLEAVE, &u16);
+    if (err != ESP_OK) { return err; }
+    s->interleave = u16;
+
     err = smb_read_word(PMBUS_VOUT_COMMAND, &u16);
     if (err != ESP_OK) { return err; }
     s->vout_command = ulinear16_2_float(u16);
+
+    err = smb_read_word(PMBUS_VOUT_MIN, &u16);
+    if (err != ESP_OK) { return err; }
+    s->vout_min = ulinear16_2_float(u16);
+
+    err = smb_read_word(PMBUS_VOUT_MAX, &u16);
+    if (err != ESP_OK) { return err; }
+    s->vout_max = ulinear16_2_float(u16);
+
+    err = smb_read_word(PMBUS_VOUT_SCALE_LOOP, &u16);
+    if (err != ESP_OK) { return err; }
+    s->vout_scale_loop = slinear11_2_float(u16);
 
     err = smb_read_word(PMBUS_READ_VOUT, &u16);
     if (err != ESP_OK) { return err; }
@@ -1226,7 +1385,13 @@ esp_err_t TPS546_snapshot_status(TPS546_StatusSnapshot *s) {
     // Context (always useful)
     ESP_LOGE(TAG, "OPERATION: 0x%02X  (ON bit: %d)", s->operation, !!(s->operation & 0x80));
     ESP_LOGE(TAG, "ON_OFF_CONFIG: 0x%02X", s->on_off_config);
+    ESP_LOGE(TAG, "PHASE: 0x%02X", s->phase);
+    ESP_LOGE(TAG, "STACK_CONFIG: 0x%04X", s->stack_config);
+    ESP_LOGE(TAG, "SYNC_CONFIG: 0x%02X", s->sync_config);
+    ESP_LOGE(TAG, "INTERLEAVE: 0x%04X", s->interleave);
     ESP_LOGE(TAG, "VOUT_COMMAND: %.3f V", s->vout_command);
+    ESP_LOGE(TAG, "VOUT_MIN/MAX: %.3f V / %.3f V", s->vout_min, s->vout_max);
+    ESP_LOGE(TAG, "VOUT_SCALE_LOOP: %.3f", s->vout_scale_loop);
     ESP_LOGE(TAG, "READ_VOUT:    %.3f V", s->read_vout);
     ESP_LOGE(TAG, "READ_VIN:     %.3f V", s->read_vin);
     ESP_LOGE(TAG, "READ_IOUT:    %.3f A", s->read_iout);

--- a/main/power/TPS546.h
+++ b/main/power/TPS546.h
@@ -30,10 +30,11 @@
 typedef struct {
   uint16_t status_word;
   uint8_t  st_vout, st_input, st_iout, st_temp, st_cml, st_mfr, st_other;
-  uint8_t  operation, on_off_config;
+  uint8_t  operation, on_off_config, phase, sync_config;
+  uint16_t stack_config, interleave;
   float    read_vout, read_vin, read_iout;
   int      read_temp1;
-  float    vout_command;
+  float    vout_command, vout_min, vout_max, vout_scale_loop;
 } TPS546_StatusSnapshot;
 
 typedef struct
@@ -77,13 +78,13 @@ typedef struct
   /* vout voltage */
 //#define TPS546_INIT_SCALE_LOOP 0.25  /* Voltage Scale factor */
 //#define TPS546_INIT_VOUT_MAX 3 /* V */
-#define TPS546_INIT_VOUT_OV_FAULT_LIMIT 1.25 /* %/100 above VOUT_COMMAND */
-#define TPS546_INIT_VOUT_OV_WARN_LIMIT  1.16 /* %/100 above VOUT_COMMAND */
-#define TPS546_INIT_VOUT_MARGIN_HIGH 1.1 /* %/100 above VOUT */
+#define TPS546_INIT_VOUT_OV_FAULT_LIMIT 1.25 /* multiplier of VOUT_COMMAND */
+#define TPS546_INIT_VOUT_OV_WARN_LIMIT  1.16 /* multiplier of VOUT_COMMAND */
+#define TPS546_INIT_VOUT_MARGIN_HIGH 1.1 /* multiplier of VOUT_COMMAND */
 //#define TPS546_INIT_VOUT_COMMAND 1.2  /* V absolute value */
-#define TPS546_INIT_VOUT_MARGIN_LOW 0.90 /* %/100 below VOUT */
-#define TPS546_INIT_VOUT_UV_WARN_LIMIT 0.90  /* %/100 below VOUT_COMMAND */
-#define TPS546_INIT_VOUT_UV_FAULT_LIMIT 0.75 /* %/100 below VOUT_COMMAND */
+#define TPS546_INIT_VOUT_MARGIN_LOW 0.90 /* multiplier of VOUT_COMMAND */
+#define TPS546_INIT_VOUT_UV_WARN_LIMIT 0.90  /* multiplier of VOUT_COMMAND */
+#define TPS546_INIT_VOUT_UV_FAULT_LIMIT 0.75 /* multiplier of VOUT_COMMAND */
 //#define TPS546_INIT_VOUT_MIN 1 /* v */
 
   /* iout current */
@@ -201,6 +202,8 @@ float TPS546_get_vout(void);
 esp_err_t TPS546_set_vout(float volts);
 void TPS546_show_voltage_settings(void);
 void TPS546_print_status(void);
+esp_err_t TPS546_check_phase_currents(uint8_t phase_count, float minimum_current_a);
+uint8_t TPS546_get_phase_count(void);
 
 esp_err_t TPS546_check_status(GlobalState * GLOBAL_STATE);
 esp_err_t TPS546_clear_faults(void);

--- a/main/power/vcore.c
+++ b/main/power/vcore.c
@@ -1,6 +1,8 @@
 #include "esp_log.h"
 #include <math.h>
 #include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #include "DS4432U.h"
 #include "INA260.h"
@@ -13,6 +15,34 @@
 #define GPIO_PLUG_SENSE CONFIG_GPIO_PLUG_SENSE
 
 static const char *TAG = "vcore";
+
+static void log_tps546_config(const FamilyConfig *family, const TPS546_CONFIG *config)
+{
+    ESP_LOGI(TAG, "Selected TPS546 config for family=%s id=%d voltage_domains=%u",
+             family->name, (int)family->id, (unsigned)family->voltage_domains);
+    ESP_LOGI(TAG, "TPS546 init core: phase=0x%02X stack=0x%04X sync=0x%02X scale=%.3f vout=%.2f min=%.2f max=%.2f",
+             config->TPS546_INIT_PHASE,
+             config->TPS546_INIT_STACK_CONFIG,
+             config->TPS546_INIT_SYNC_CONFIG,
+             config->TPS546_INIT_SCALE_LOOP,
+             config->TPS546_INIT_VOUT_COMMAND,
+             config->TPS546_INIT_VOUT_MIN,
+             config->TPS546_INIT_VOUT_MAX);
+    ESP_LOGI(TAG, "TPS546 init VIN: on=%.2f off=%.2f uv_warn=%.2f ov_fault=%.2f",
+             config->TPS546_INIT_VIN_ON,
+             config->TPS546_INIT_VIN_OFF,
+             config->TPS546_INIT_VIN_UV_WARN_LIMIT,
+             config->TPS546_INIT_VIN_OV_FAULT_LIMIT);
+    ESP_LOGI(TAG, "TPS546 init IOUT: warn=%.2f fault=%.2f",
+             config->TPS546_INIT_IOUT_OC_WARN_LIMIT,
+             config->TPS546_INIT_IOUT_OC_FAULT_LIMIT);
+    ESP_LOGI(TAG, "TPS546 init COMPENSATION_CONFIG: %02X %02X %02X %02X %02X",
+             config->TPS546_INIT_COMPENSATION_CONFIG[0],
+             config->TPS546_INIT_COMPENSATION_CONFIG[1],
+             config->TPS546_INIT_COMPENSATION_CONFIG[2],
+             config->TPS546_INIT_COMPENSATION_CONFIG[3],
+             config->TPS546_INIT_COMPENSATION_CONFIG[4]);
+}
 
 static TPS546_CONFIG get_tps546_config(const FamilyConfig * family)
 {
@@ -78,12 +108,46 @@ static TPS546_CONFIG get_tps546_config(const FamilyConfig * family)
         break;
     }
 
+    log_tps546_config(family, &config);
     return config;
+}
+
+static void configure_asic_power_enable(GlobalState * GLOBAL_STATE)
+{
+    if (!(GLOBAL_STATE->DEVICE_CONFIG.plug_sense || GLOBAL_STATE->DEVICE_CONFIG.asic_enable)) {
+        return;
+    }
+
+    bool enable_power = GLOBAL_STATE->DEVICE_CONFIG.asic_enable;
+
+    if (GLOBAL_STATE->DEVICE_CONFIG.plug_sense) {
+        gpio_config_t barrel_jack_conf = {
+            .pin_bit_mask = (1ULL << GPIO_PLUG_SENSE),
+            .mode = GPIO_MODE_INPUT,
+        };
+        gpio_config(&barrel_jack_conf);
+        enable_power = gpio_get_level(GPIO_PLUG_SENSE) == 1 || enable_power;
+    }
+
+    gpio_config_t asic_enable_conf = {
+        .pin_bit_mask = (1ULL << GPIO_ASIC_ENABLE),
+        .mode = GPIO_MODE_OUTPUT,
+    };
+    gpio_config(&asic_enable_conf);
+
+    bool active_high = GLOBAL_STATE->DEVICE_CONFIG.asic_enable_active_high;
+    gpio_set_level(GPIO_ASIC_ENABLE, enable_power ? active_high : !active_high);
+
+    if (enable_power) {
+        vTaskDelay(pdMS_TO_TICKS(20));
+    }
 }
 
 esp_err_t VCORE_init(GlobalState * GLOBAL_STATE)
 {
     ESP_RETURN_ON_FALSE(GLOBAL_STATE->DEVICE_CONFIG.family.voltage_domains != 0, ESP_FAIL, TAG, "voltage_domains not defined");
+
+    configure_asic_power_enable(GLOBAL_STATE);
 
     if (GLOBAL_STATE->DEVICE_CONFIG.DS4432U) {
         ESP_RETURN_ON_ERROR(DS4432U_init(), TAG, "DS4432 init failed!");
@@ -96,23 +160,6 @@ esp_err_t VCORE_init(GlobalState * GLOBAL_STATE)
         ESP_RETURN_ON_ERROR(TPS546_init(tps_config), TAG, "TPS546 init failed!");
     }
 
-    if (GLOBAL_STATE->DEVICE_CONFIG.plug_sense) {
-        gpio_config_t barrel_jack_conf = {
-            .pin_bit_mask = (1ULL << GPIO_PLUG_SENSE),
-            .mode = GPIO_MODE_INPUT,
-        };
-        gpio_config(&barrel_jack_conf);
-        int barrel_jack_plugged_in = gpio_get_level(GPIO_PLUG_SENSE);
-
-        gpio_set_direction(GPIO_ASIC_ENABLE, GPIO_MODE_OUTPUT);
-        if (barrel_jack_plugged_in == 1 || GLOBAL_STATE->DEVICE_CONFIG.asic_enable) {
-            gpio_set_level(GPIO_ASIC_ENABLE, 0);
-        } else {
-            // turn ASIC off
-            gpio_set_level(GPIO_ASIC_ENABLE, 1);
-        }
-    }
-
     return ESP_OK;
 }
 
@@ -122,7 +169,13 @@ esp_err_t VCORE_set_voltage(GlobalState * GLOBAL_STATE, float core_voltage)
 
     // Enable/disable the ASIC power enable GPIO before touching the regulator
     if (GLOBAL_STATE->DEVICE_CONFIG.asic_enable) {
-        gpio_set_level(GPIO_ASIC_ENABLE, core_voltage == 0.0f ? 1 : 0);
+        bool active_high = GLOBAL_STATE->DEVICE_CONFIG.asic_enable_active_high;
+        bool enable_power = core_voltage != 0.0f;
+        gpio_set_level(GPIO_ASIC_ENABLE, enable_power ? active_high : !active_high);
+
+        if (enable_power) {
+            vTaskDelay(pdMS_TO_TICKS(20));
+        }
     }
 
     if (GLOBAL_STATE->DEVICE_CONFIG.DS4432U) {
@@ -160,4 +213,12 @@ const char * VCORE_get_fault_string(GlobalState * GLOBAL_STATE)
         return TPS546_get_error_message();
     }
     return NULL;
+}
+
+uint8_t VCORE_get_phase_count(GlobalState * GLOBAL_STATE)
+{
+    if (GLOBAL_STATE->DEVICE_CONFIG.TPS546) {
+        return TPS546_get_phase_count();
+    }
+    return 1;
 }

--- a/main/power/vcore.h
+++ b/main/power/vcore.h
@@ -8,5 +8,6 @@ esp_err_t VCORE_set_voltage(GlobalState * GLOBAL_STATE, float core_voltage);
 int16_t VCORE_get_voltage_mv(GlobalState * GLOBAL_STATE);
 esp_err_t VCORE_check_fault(GlobalState * GLOBAL_STATE);
 const char* VCORE_get_fault_string(GlobalState * GLOBAL_STATE);
+uint8_t VCORE_get_phase_count(GlobalState * GLOBAL_STATE);
 
 #endif /* VCORE_H_ */

--- a/main/self_test/self_test.c
+++ b/main/self_test/self_test.c
@@ -11,6 +11,7 @@
 #include "thermal.h"
 #include "vcore.h"
 #include "power.h"
+#include "TPS546.h"
 #include "nvs_config.h"
 #include "global_state.h"
 #include "asic_reset.h"
@@ -39,6 +40,8 @@
 
 // Test Input Voltage
 #define INPUT_VOLTAGE_MARGIN 0.10f // +/- 10%
+
+#define MULTIPHASE_BUCK_MIN_CURRENT_A 1.0f
 
 // Test Difficulty
 #define DIFFICULTY 16
@@ -373,7 +376,15 @@ static esp_err_t test_power_consumption(GlobalState * GLOBAL_STATE)
 
     float power = 0;
     float current = 0;
-    
+
+    uint8_t phase_count = VCORE_get_phase_count(GLOBAL_STATE);
+    if (phase_count > 1 &&
+        TPS546_check_phase_currents(phase_count, MULTIPHASE_BUCK_MIN_CURRENT_A) != ESP_OK) {
+        ESP_LOGE(TAG, "MULTIPHASE BUCK test failed!");
+        self_test_show_message(GLOBAL_STATE, "BUCK:FAIL");
+        return ESP_FAIL;
+    }
+
     Power_get_output(GLOBAL_STATE, &power, &current);
     ESP_LOGI(TAG, "Power: %.2f W", power);
 


### PR DESCRIPTION
 * TPS546 regulator & PMBus telemetry;
 * Add support for asic_enable_active_high and setup delays;
 * Add generic multi-phase support to power consumption self test.

Extracted from #1807 