### PR TITLE
GPIO pin abstraction

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -18,6 +18,7 @@ SRCS
     "./bap/bap_uart.c"
     "./bap/bap_handlers.c"
     "./bap/bap_subscription.c"
+    "device_pins.c"
     "device_config.c"
     "task_monitor.c"
     "./http_server/http_server.c"

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -27,26 +27,34 @@ menu "Bitaxe Configuration"
                 GPIO pin for DC barrel (PLUG_SENSE), sense pin of DC power jack socket.
 
         config GPIO_I2C_SDA
-            int "I2C SDA Pin"
-            default 47
+            int "I2C SDA Pin Override (-1 to use board default)"
+            default -1
             help
-                GPIO pin for I2C clock line (SDA).
+                GPIO pin override for I2C SDA line. Set to -1 to use board default.
             
         config GPIO_I2C_SCL
-            int "I2C SCL Pin"
-            default 48
+            int "I2C SCL Pin Override (-1 to use board default)"
+            default -1
             help
-                GPIO pin for I2C clock line (SCL).
+                GPIO pin override for I2C SCL line. Set to -1 to use board default.
+
+        config ENABLE_BAP
+            bool "Enable BAP (Bitaxe Accessory Protocol)"
+            default y
+            help
+                Enable or disable Bitaxe Accessory Protocol (BAP) UART communication.
+
         config GPIO_BAP_RX
-            int "I2C BAP Pin"
-            default 40
+            int "BAP RX Pin Override (-1 to use board default)"
+            default -1
             help
-                GPIO pin for BAP receiving line.
+                GPIO pin override for BAP receiving line. Set to -1 to use board default.
+
         config GPIO_BAP_TX
-            int "I2C BAP Pin"
-            default 39
+            int "BAP TX Pin Override (-1 to use board default)"
+            default -1
             help
-                GPIO pin for BAP transmitting line.
+                GPIO pin override for BAP transmitting line. Set to -1 to use board default.
             
     endmenu
     

--- a/main/bap/bap.c
+++ b/main/bap/bap.c
@@ -27,6 +27,11 @@ esp_err_t BAP_init(GlobalState *state) {
         ESP_LOGE(TAG, "Invalid global state pointer");
         return ESP_ERR_INVALID_ARG;
     }
+
+    if (state->DEVICE_CONFIG.bap_pins == NULL) {
+        ESP_LOGW(TAG, "BAP UART disabled on %s", state->DEVICE_CONFIG.family.name);
+        return ESP_OK;
+    }
     
     bap_global_state = state;
     

--- a/main/bap/bap.c
+++ b/main/bap/bap.c
@@ -28,7 +28,7 @@ esp_err_t BAP_init(GlobalState *state) {
         return ESP_ERR_INVALID_ARG;
     }
 
-    if (state->DEVICE_CONFIG.bap_pins == NULL) {
+    if (state->DEVICE_CONFIG.pins.bap == NULL) {
         ESP_LOGW(TAG, "BAP UART disabled on %s", state->DEVICE_CONFIG.family.name);
         return ESP_OK;
     }

--- a/main/bap/bap_readme.md
+++ b/main/bap/bap_readme.md
@@ -153,11 +153,11 @@ Device: $BAP,STA,status,restarting*5E\r\n
 
 ## Configuration
 
-BAP UART pin assignments are defined per board revision in `DeviceConfig.bap_pins`:
+BAP UART pin assignments are defined per board revision in `DeviceConfig.pins.bap`:
 - **Default Pins**: RX (GPIO 40), TX (GPIO 39)
 - **Kconfig Enable/Disable**: Configurable via `CONFIG_ENABLE_BAP` (default `y`). Setting to `n` disables BAP.
 - **Kconfig Pin Overrides**: Optionally configurable via `CONFIG_GPIO_BAP_RX` and `CONFIG_GPIO_BAP_TX` (set to `-1` to use board defaults).
-- **Board Support**: If `bap_pins` is set to `NULL` for a board configuration or via `CONFIG_ENABLE_BAP=n`, BAP UART is automatically disabled.
+- **Board Support**: If `pins.bap` is set to `NULL` for a board configuration or via `CONFIG_ENABLE_BAP=n`, BAP UART is automatically disabled.
 
 UART settings:
 - Baud rate: 115200

--- a/main/bap/bap_readme.md
+++ b/main/bap/bap_readme.md
@@ -153,9 +153,11 @@ Device: $BAP,STA,status,restarting*5E\r\n
 
 ## Configuration
 
-BAP uses the following GPIO pins for UART communication:
-- **RX**: Configurable via `CONFIG_GPIO_BAP_RX`
-- **TX**: Configurable via `CONFIG_GPIO_BAP_TX`
+BAP UART pin assignments are defined per board revision in `DeviceConfig.bap_pins`:
+- **Default Pins**: RX (GPIO 40), TX (GPIO 39)
+- **Kconfig Enable/Disable**: Configurable via `CONFIG_ENABLE_BAP` (default `y`). Setting to `n` disables BAP.
+- **Kconfig Pin Overrides**: Optionally configurable via `CONFIG_GPIO_BAP_RX` and `CONFIG_GPIO_BAP_TX` (set to `-1` to use board defaults).
+- **Board Support**: If `bap_pins` is set to `NULL` for a board configuration or via `CONFIG_ENABLE_BAP=n`, BAP UART is automatically disabled.
 
 UART settings:
 - Baud rate: 115200

--- a/main/bap/bap_uart.c
+++ b/main/bap/bap_uart.c
@@ -240,8 +240,8 @@ esp_err_t BAP_uart_init(void) {
         return ret;
     }
     
-    gpio_num_t bap_tx = bap_global_state->DEVICE_CONFIG.bap_pins->tx;
-    gpio_num_t bap_rx = bap_global_state->DEVICE_CONFIG.bap_pins->rx;
+    gpio_num_t bap_tx = bap_global_state->DEVICE_CONFIG.pins.bap->tx;
+    gpio_num_t bap_rx = bap_global_state->DEVICE_CONFIG.pins.bap->rx;
 
     ret = uart_set_pin(BAP_UART_NUM, bap_tx, bap_rx, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
     if (ret != ESP_OK) {

--- a/main/bap/bap_uart.c
+++ b/main/bap/bap_uart.c
@@ -14,6 +14,7 @@
 #include "esp_log.h"
 #include "esp_err.h"
 #include "device_config.h"
+#include "global_state.h"
 #include "bap_uart.h"
 #include "bap_protocol.h"
 #include "bap.h"
@@ -24,9 +25,6 @@
 #define UART_SEND_QUEUE_ITEM_SIZE sizeof(bap_message_t)
 #define UART_SEND_TIMEOUT_MS 1000
 #define UART_BUFFER_THRESHOLD (BAP_BUF_SIZE / 2)
-
-#define GPIO_BAP_RX CONFIG_GPIO_BAP_RX
-#define GPIO_BAP_TX CONFIG_GPIO_BAP_TX
 
 static const char *TAG = "BAP_UART";
 
@@ -227,11 +225,6 @@ esp_err_t BAP_start_uart_receive_task(void) {
 esp_err_t BAP_uart_init(void) {
     //ESP_LOGI(TAG, "Initializing BAP UART interface");
     
-    if (GPIO_BAP_TX > 47 || GPIO_BAP_RX > 47) {
-        ESP_LOGE(TAG, "Invalid GPIO pins: TX=%d, RX=%d", GPIO_BAP_TX, GPIO_BAP_RX);
-        return ESP_ERR_INVALID_ARG;
-    }
-    
     uart_config_t uart_config = {
         .baud_rate = 115200,
         .data_bits = UART_DATA_8_BITS,
@@ -247,7 +240,10 @@ esp_err_t BAP_uart_init(void) {
         return ret;
     }
     
-    ret = uart_set_pin(BAP_UART_NUM, GPIO_BAP_TX, GPIO_BAP_RX, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    gpio_num_t bap_tx = bap_global_state->DEVICE_CONFIG.bap_pins->tx;
+    gpio_num_t bap_rx = bap_global_state->DEVICE_CONFIG.bap_pins->rx;
+
+    ret = uart_set_pin(BAP_UART_NUM, bap_tx, bap_rx, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Failed to set UART pins: %d", ret);
         return ret;

--- a/main/device_config.c
+++ b/main/device_config.c
@@ -9,80 +9,6 @@
 
 static const char * TAG = "device_config";
 
-static inline esp_err_t check_pin(gpio_num_t gpio, const char * name, uint64_t * allocated_pins_mask)
-{
-    if (gpio == GPIO_NUM_NC) {
-        return ESP_OK;
-    }
-    if (!GPIO_IS_VALID_GPIO(gpio)) {
-        ESP_LOGE(TAG, "INVALID GPIO: %d for %s is out of range (0-%d)!", gpio, name, GPIO_NUM_MAX - 1);
-        return ESP_ERR_INVALID_ARG;
-    }
-    if (*allocated_pins_mask & (1ULL << gpio)) {
-        ESP_LOGE(TAG, "PIN CONFLICT: GPIO %d (%s) is already in use by another interface!", gpio, name);
-        return ESP_ERR_INVALID_STATE;
-    }
-    *allocated_pins_mask |= (1ULL << gpio);
-    return ESP_OK;
-}
-
-static esp_err_t device_config_validate_pins(const DeviceConfig * cfg)
-{
-    uint64_t allocated_pins_mask = 0;
-    esp_err_t status = ESP_OK;
-
-    if (cfg->bap_pins) {
-        if (check_pin(cfg->bap_pins->tx, "BAP TX", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-        if (check_pin(cfg->bap_pins->rx, "BAP RX", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-    }
-
-    if (cfg->i2c_pins) {
-        if (check_pin(cfg->i2c_pins->sda, "I2C SDA", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-        if (check_pin(cfg->i2c_pins->scl, "I2C SCL", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-    }
-
-    if (cfg->i80_pins) {
-        for (int i = 0; i < 8; i++) {
-            if (check_pin(cfg->i80_pins->data[i], "LCD Data", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-        }
-        if (check_pin(cfg->i80_pins->rd, "LCD RD", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-        if (check_pin(cfg->i80_pins->wr, "LCD WR", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-        if (check_pin(cfg->i80_pins->cs, "LCD CS", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-        if (check_pin(cfg->i80_pins->dc, "LCD DC", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-        if (check_pin(cfg->i80_pins->rst, "LCD RST", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-        if (check_pin(cfg->i80_pins->pwr, "LCD PWR", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-        if (check_pin(cfg->i80_pins->bk_light, "LCD BK_LIGHT", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
-    }
-
-    return status;
-}
-
-static void apply_kconfig_pin_overrides(DeviceConfig * cfg)
-{
-#if defined(CONFIG_ENABLE_BAP) && !CONFIG_ENABLE_BAP
-    cfg->bap_pins = NULL;
-    ESP_LOGI(TAG, "BAP disabled via Kconfig (CONFIG_ENABLE_BAP=n)");
-#elif defined(CONFIG_GPIO_BAP_TX) && defined(CONFIG_GPIO_BAP_RX)
-    if (CONFIG_GPIO_BAP_TX >= 0 && CONFIG_GPIO_BAP_RX >= 0) {
-        static BapPins kconfig_bap_pins;
-        kconfig_bap_pins.tx = CONFIG_GPIO_BAP_TX;
-        kconfig_bap_pins.rx = CONFIG_GPIO_BAP_RX;
-        cfg->bap_pins = &kconfig_bap_pins;
-        ESP_LOGI(TAG, "Kconfig override applied for BAP pins: TX=%d RX=%d", CONFIG_GPIO_BAP_TX, CONFIG_GPIO_BAP_RX);
-    }
-#endif
-
-#if defined(CONFIG_GPIO_I2C_SDA) && defined(CONFIG_GPIO_I2C_SCL)
-    if (CONFIG_GPIO_I2C_SDA >= 0 && CONFIG_GPIO_I2C_SCL >= 0) {
-        static I2cPins kconfig_i2c_pins;
-        kconfig_i2c_pins.sda = CONFIG_GPIO_I2C_SDA;
-        kconfig_i2c_pins.scl = CONFIG_GPIO_I2C_SCL;
-        cfg->i2c_pins = &kconfig_i2c_pins;
-        ESP_LOGI(TAG, "Kconfig override applied for I2C pins: SDA=%d SCL=%d", CONFIG_GPIO_I2C_SDA, CONFIG_GPIO_I2C_SCL);
-    }
-#endif
-}
-
 esp_err_t device_config_init(void * pvParameters)
 {
     GlobalState * GLOBAL_STATE = (GlobalState *) pvParameters;
@@ -100,8 +26,7 @@ esp_err_t device_config_init(void * pvParameters)
             ESP_LOGI(TAG, "ASIC: %dx %s (%d cores)", GLOBAL_STATE->DEVICE_CONFIG.family.asic_count, GLOBAL_STATE->DEVICE_CONFIG.family.asic.name, GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count);
 
             free(board_version);
-            apply_kconfig_pin_overrides(&GLOBAL_STATE->DEVICE_CONFIG);
-            return device_config_validate_pins(&GLOBAL_STATE->DEVICE_CONFIG);
+            return device_pins_init(&GLOBAL_STATE->DEVICE_CONFIG.pins);
         }
     }
 
@@ -154,6 +79,5 @@ esp_err_t device_config_init(void * pvParameters)
     free(device_model);
     free(asic_model);
 
-    apply_kconfig_pin_overrides(&GLOBAL_STATE->DEVICE_CONFIG);
-    return device_config_validate_pins(&GLOBAL_STATE->DEVICE_CONFIG);
+    return device_pins_init(&GLOBAL_STATE->DEVICE_CONFIG.pins);
 }

--- a/main/device_config.c
+++ b/main/device_config.c
@@ -2,7 +2,6 @@
 #include "device_config.h"
 #include "nvs_config.h"
 #include "global_state.h"
-#include "driver/gpio.h"
 #include "esp_log.h"
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))

--- a/main/device_config.c
+++ b/main/device_config.c
@@ -2,11 +2,86 @@
 #include "device_config.h"
 #include "nvs_config.h"
 #include "global_state.h"
+#include "driver/gpio.h"
 #include "esp_log.h"
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
 static const char * TAG = "device_config";
+
+static inline esp_err_t check_pin(gpio_num_t gpio, const char * name, uint64_t * allocated_pins_mask)
+{
+    if (gpio == GPIO_NUM_NC) {
+        return ESP_OK;
+    }
+    if (!GPIO_IS_VALID_GPIO(gpio)) {
+        ESP_LOGE(TAG, "INVALID GPIO: %d for %s is out of range (0-%d)!", gpio, name, GPIO_NUM_MAX - 1);
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (*allocated_pins_mask & (1ULL << gpio)) {
+        ESP_LOGE(TAG, "PIN CONFLICT: GPIO %d (%s) is already in use by another interface!", gpio, name);
+        return ESP_ERR_INVALID_STATE;
+    }
+    *allocated_pins_mask |= (1ULL << gpio);
+    return ESP_OK;
+}
+
+static esp_err_t device_config_validate_pins(const DeviceConfig * cfg)
+{
+    uint64_t allocated_pins_mask = 0;
+    esp_err_t status = ESP_OK;
+
+    if (cfg->bap_pins) {
+        if (check_pin(cfg->bap_pins->tx, "BAP TX", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(cfg->bap_pins->rx, "BAP RX", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+    }
+
+    if (cfg->i2c_pins) {
+        if (check_pin(cfg->i2c_pins->sda, "I2C SDA", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(cfg->i2c_pins->scl, "I2C SCL", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+    }
+
+    if (cfg->i80_pins) {
+        for (int i = 0; i < 8; i++) {
+            if (check_pin(cfg->i80_pins->data[i], "LCD Data", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        }
+        if (check_pin(cfg->i80_pins->rd, "LCD RD", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(cfg->i80_pins->wr, "LCD WR", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(cfg->i80_pins->cs, "LCD CS", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(cfg->i80_pins->dc, "LCD DC", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(cfg->i80_pins->rst, "LCD RST", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(cfg->i80_pins->pwr, "LCD PWR", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(cfg->i80_pins->bk_light, "LCD BK_LIGHT", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+    }
+
+    return status;
+}
+
+static void apply_kconfig_pin_overrides(DeviceConfig * cfg)
+{
+#if defined(CONFIG_ENABLE_BAP) && !CONFIG_ENABLE_BAP
+    cfg->bap_pins = NULL;
+    ESP_LOGI(TAG, "BAP disabled via Kconfig (CONFIG_ENABLE_BAP=n)");
+#elif defined(CONFIG_GPIO_BAP_TX) && defined(CONFIG_GPIO_BAP_RX)
+    if (CONFIG_GPIO_BAP_TX >= 0 && CONFIG_GPIO_BAP_RX >= 0) {
+        static BapPins kconfig_bap_pins;
+        kconfig_bap_pins.tx = CONFIG_GPIO_BAP_TX;
+        kconfig_bap_pins.rx = CONFIG_GPIO_BAP_RX;
+        cfg->bap_pins = &kconfig_bap_pins;
+        ESP_LOGI(TAG, "Kconfig override applied for BAP pins: TX=%d RX=%d", CONFIG_GPIO_BAP_TX, CONFIG_GPIO_BAP_RX);
+    }
+#endif
+
+#if defined(CONFIG_GPIO_I2C_SDA) && defined(CONFIG_GPIO_I2C_SCL)
+    if (CONFIG_GPIO_I2C_SDA >= 0 && CONFIG_GPIO_I2C_SCL >= 0) {
+        static I2cPins kconfig_i2c_pins;
+        kconfig_i2c_pins.sda = CONFIG_GPIO_I2C_SDA;
+        kconfig_i2c_pins.scl = CONFIG_GPIO_I2C_SCL;
+        cfg->i2c_pins = &kconfig_i2c_pins;
+        ESP_LOGI(TAG, "Kconfig override applied for I2C pins: SDA=%d SCL=%d", CONFIG_GPIO_I2C_SDA, CONFIG_GPIO_I2C_SCL);
+    }
+#endif
+}
 
 esp_err_t device_config_init(void * pvParameters)
 {
@@ -25,7 +100,8 @@ esp_err_t device_config_init(void * pvParameters)
             ESP_LOGI(TAG, "ASIC: %dx %s (%d cores)", GLOBAL_STATE->DEVICE_CONFIG.family.asic_count, GLOBAL_STATE->DEVICE_CONFIG.family.asic.name, GLOBAL_STATE->DEVICE_CONFIG.family.asic.core_count);
 
             free(board_version);
-            return ESP_OK;
+            apply_kconfig_pin_overrides(&GLOBAL_STATE->DEVICE_CONFIG);
+            return device_config_validate_pins(&GLOBAL_STATE->DEVICE_CONFIG);
         }
     }
 
@@ -78,5 +154,6 @@ esp_err_t device_config_init(void * pvParameters)
     free(device_model);
     free(asic_model);
 
-    return ESP_OK;
+    apply_kconfig_pin_overrides(&GLOBAL_STATE->DEVICE_CONFIG);
+    return device_config_validate_pins(&GLOBAL_STATE->DEVICE_CONFIG);
 }

--- a/main/device_config.h
+++ b/main/device_config.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "esp_err.h"
-#include "soc/gpio_num.h"
+#include "device_pins.h"
 
 #define THERMAL_MAX_SENSORS 2
 
@@ -59,34 +59,11 @@ typedef struct {
 } FamilyConfig;
 
 typedef struct {
-    gpio_num_t tx;
-    gpio_num_t rx;
-} BapPins;
-
-typedef struct {
-    gpio_num_t sda;
-    gpio_num_t scl;
-} I2cPins;
-
-typedef struct {
-    gpio_num_t data[8];
-    gpio_num_t rd;
-    gpio_num_t pwr;
-    gpio_num_t wr;
-    gpio_num_t cs;
-    gpio_num_t dc;
-    gpio_num_t rst;
-    gpio_num_t bk_light;
-} I80Pins;
-
-typedef struct {
     const char * board_version;
     FamilyConfig family;
     bool plug_sense;
     bool asic_enable;
-    const BapPins * bap_pins;
-    const I2cPins * i2c_pins;
-    const I80Pins * i80_pins;
+    DevicePins pins;
     bool EMC2101 : 1;
     bool EMC2103 : 1;
     bool EMC2302 : 1;
@@ -102,16 +79,6 @@ typedef struct {
     // test values
     uint16_t power_consumption_target;
 } DeviceConfig;
-
-static const BapPins DEFAULT_BAP_PINS = {
-    .tx = GPIO_NUM_39,
-    .rx = GPIO_NUM_40,
-};
-
-static const I2cPins DEFAULT_I2C_PINS = {
-    .sda = GPIO_NUM_47,
-    .scl = GPIO_NUM_48,
-};
 
 static const uint16_t BM1397_FREQUENCY_OPTIONS[]   = {400, 425, 450, 475, 485, 500, 525, 550, 575, 600, 0};
 static const uint16_t BM1366_FREQUENCY_OPTIONS[]   = {400, 425, 450, 475, 485, 500, 525, 550, 575,      0};
@@ -158,29 +125,29 @@ static const FamilyConfig default_families[] = {
 };
 
 static const DeviceConfig default_configs[] = {
-    { .board_version = "2.2",  .family = FAMILY_MAX,         .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true,                                                                                 .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "102",  .family = FAMILY_MAX,         .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true,                                                                                 .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "0.11", .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "201",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "202",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "203",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "204",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true,                      .power_consumption_target = 12, },
-    { .board_version = "205",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "207",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 12, },
-    { .board_version = "302",  .family = FAMILY_HEX,         .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 40, },
-    { .board_version = "303",  .family = FAMILY_HEX,         .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 40, },
-    { .board_version = "400",  .family = FAMILY_SUPRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "401",  .family = FAMILY_SUPRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "402",  .family = FAMILY_SUPRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 8,  },
-    { .board_version = "403",  .family = FAMILY_SUPRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 8,  },
-    { .board_version = "600",  .family = FAMILY_GAMMA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 19, },
-    { .board_version = "601",  .family = FAMILY_GAMMA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 19, },
-    { .board_version = "602",  .family = FAMILY_GAMMA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 22, },
-    { .board_version = "603",  .family = FAMILY_GAMMA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 22, },
-    { .board_version = "650",  .family = FAMILY_GAMMA_DUO,   .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 35, },
-    { .board_version = "701",  .family = FAMILY_SUPRA_HEX,   .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 90, },
-    { .board_version = "702",  .family = FAMILY_SUPRA_HEX,   .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 90, },
-    { .board_version = "801",  .family = FAMILY_GAMMA_TURBO, .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2103 = true,                                          .temp_flip = true, .temp_offset = 0,   .TPS546 = true,                                                           .power_consumption_target = 36, },
+    { .board_version = "2.2",  .family = FAMILY_MAX,         .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true,                                                                                 .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "102",  .family = FAMILY_MAX,         .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true,                                                                                 .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "0.11", .family = FAMILY_ULTRA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "201",  .family = FAMILY_ULTRA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "202",  .family = FAMILY_ULTRA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "203",  .family = FAMILY_ULTRA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "204",  .family = FAMILY_ULTRA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true,                      .power_consumption_target = 12, },
+    { .board_version = "205",  .family = FAMILY_ULTRA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "207",  .family = FAMILY_ULTRA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 12, },
+    { .board_version = "302",  .family = FAMILY_HEX,         .pins = DEFAULT_DEVICE_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 40, },
+    { .board_version = "303",  .family = FAMILY_HEX,         .pins = DEFAULT_DEVICE_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 40, },
+    { .board_version = "400",  .family = FAMILY_SUPRA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "401",  .family = FAMILY_SUPRA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "402",  .family = FAMILY_SUPRA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 8,  },
+    { .board_version = "403",  .family = FAMILY_SUPRA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 8,  },
+    { .board_version = "600",  .family = FAMILY_GAMMA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 19, },
+    { .board_version = "601",  .family = FAMILY_GAMMA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 19, },
+    { .board_version = "602",  .family = FAMILY_GAMMA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 22, },
+    { .board_version = "603",  .family = FAMILY_GAMMA,       .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 22, },
+    { .board_version = "650",  .family = FAMILY_GAMMA_DUO,   .pins = DEFAULT_DEVICE_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 35, },
+    { .board_version = "701",  .family = FAMILY_SUPRA_HEX,   .pins = DEFAULT_DEVICE_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 90, },
+    { .board_version = "702",  .family = FAMILY_SUPRA_HEX,   .pins = DEFAULT_DEVICE_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 90, },
+    { .board_version = "801",  .family = FAMILY_GAMMA_TURBO, .pins = DEFAULT_DEVICE_PINS, .EMC2103 = true,                                          .temp_flip = true, .temp_offset = 0,   .TPS546 = true,                                                           .power_consumption_target = 36, },
 };
 
 esp_err_t device_config_init(void * pvParameters);

--- a/main/device_config.h
+++ b/main/device_config.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "esp_err.h"
+#include "soc/gpio_num.h"
 
 #define THERMAL_MAX_SENSORS 2
 
@@ -58,10 +59,34 @@ typedef struct {
 } FamilyConfig;
 
 typedef struct {
+    gpio_num_t tx;
+    gpio_num_t rx;
+} BapPins;
+
+typedef struct {
+    gpio_num_t sda;
+    gpio_num_t scl;
+} I2cPins;
+
+typedef struct {
+    gpio_num_t data[8];
+    gpio_num_t rd;
+    gpio_num_t pwr;
+    gpio_num_t wr;
+    gpio_num_t cs;
+    gpio_num_t dc;
+    gpio_num_t rst;
+    gpio_num_t bk_light;
+} I80Pins;
+
+typedef struct {
     const char * board_version;
     FamilyConfig family;
     bool plug_sense;
     bool asic_enable;
+    const BapPins * bap_pins;
+    const I2cPins * i2c_pins;
+    const I80Pins * i80_pins;
     bool EMC2101 : 1;
     bool EMC2103 : 1;
     bool EMC2302 : 1;
@@ -77,6 +102,16 @@ typedef struct {
     // test values
     uint16_t power_consumption_target;
 } DeviceConfig;
+
+static const BapPins DEFAULT_BAP_PINS = {
+    .tx = GPIO_NUM_39,
+    .rx = GPIO_NUM_40,
+};
+
+static const I2cPins DEFAULT_I2C_PINS = {
+    .sda = GPIO_NUM_47,
+    .scl = GPIO_NUM_48,
+};
 
 static const uint16_t BM1397_FREQUENCY_OPTIONS[]   = {400, 425, 450, 475, 485, 500, 525, 550, 575, 600, 0};
 static const uint16_t BM1366_FREQUENCY_OPTIONS[]   = {400, 425, 450, 475, 485, 500, 525, 550, 575,      0};
@@ -123,29 +158,29 @@ static const FamilyConfig default_families[] = {
 };
 
 static const DeviceConfig default_configs[] = {
-    { .board_version = "2.2",  .family = FAMILY_MAX,         .EMC2101 = true,                                                                                 .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "102",  .family = FAMILY_MAX,         .EMC2101 = true,                                                                                 .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "0.11", .family = FAMILY_ULTRA,       .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "201",  .family = FAMILY_ULTRA,       .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "202",  .family = FAMILY_ULTRA,       .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "203",  .family = FAMILY_ULTRA,       .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "204",  .family = FAMILY_ULTRA,       .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true,                      .power_consumption_target = 12, },
-    { .board_version = "205",  .family = FAMILY_ULTRA,       .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "207",  .family = FAMILY_ULTRA,       .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 12, },
-    { .board_version = "302",  .family = FAMILY_HEX,         .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 40, },
-    { .board_version = "303",  .family = FAMILY_HEX,         .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 40, },
-    { .board_version = "400",  .family = FAMILY_SUPRA,       .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "401",  .family = FAMILY_SUPRA,       .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
-    { .board_version = "402",  .family = FAMILY_SUPRA,       .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 8,  },
-    { .board_version = "403",  .family = FAMILY_SUPRA,       .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 8,  },
-    { .board_version = "600",  .family = FAMILY_GAMMA,       .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 19, },
-    { .board_version = "601",  .family = FAMILY_GAMMA,       .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 19, },
-    { .board_version = "602",  .family = FAMILY_GAMMA,       .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 22, },
-    { .board_version = "603",  .family = FAMILY_GAMMA,       .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 22, },
-    { .board_version = "650",  .family = FAMILY_GAMMA_DUO,   .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 35, },
-    { .board_version = "701",  .family = FAMILY_SUPRA_HEX,   .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 90, },
-    { .board_version = "702",  .family = FAMILY_SUPRA_HEX,   .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 90, },
-    { .board_version = "801",  .family = FAMILY_GAMMA_TURBO, .EMC2103 = true,                                          .temp_flip = true, .temp_offset = 0,   .TPS546 = true,                                                           .power_consumption_target = 36, },
+    { .board_version = "2.2",  .family = FAMILY_MAX,         .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true,                                                                                 .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "102",  .family = FAMILY_MAX,         .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true,                                                                                 .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "0.11", .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "201",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "202",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "203",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "204",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true,                      .power_consumption_target = 12, },
+    { .board_version = "205",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "207",  .family = FAMILY_ULTRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 12, },
+    { .board_version = "302",  .family = FAMILY_HEX,         .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 40, },
+    { .board_version = "303",  .family = FAMILY_HEX,         .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 40, },
+    { .board_version = "400",  .family = FAMILY_SUPRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "401",  .family = FAMILY_SUPRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_internal_temp = true,                                  .temp_offset = 5,   .DS4432U = true, .INA260 = true, .plug_sense = true, .asic_enable = true, .power_consumption_target = 12, },
+    { .board_version = "402",  .family = FAMILY_SUPRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 8,  },
+    { .board_version = "403",  .family = FAMILY_SUPRA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true,                                                                                 .TPS546 = true,                                                           .power_consumption_target = 8,  },
+    { .board_version = "600",  .family = FAMILY_GAMMA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 19, },
+    { .board_version = "601",  .family = FAMILY_GAMMA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 19, },
+    { .board_version = "602",  .family = FAMILY_GAMMA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 22, },
+    { .board_version = "603",  .family = FAMILY_GAMMA,       .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 22, },
+    { .board_version = "650",  .family = FAMILY_GAMMA_DUO,   .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2101 = true, .emc_ideality_factor = 0x24, .emc_beta_compensation = 0x00,                     .TPS546 = true,                                                           .power_consumption_target = 35, },
+    { .board_version = "701",  .family = FAMILY_SUPRA_HEX,   .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 90, },
+    { .board_version = "702",  .family = FAMILY_SUPRA_HEX,   .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2302 = true, .TMP1075 = true,                                            .temp_offset = 10,  .TPS546 = true,                                                           .power_consumption_target = 90, },
+    { .board_version = "801",  .family = FAMILY_GAMMA_TURBO, .bap_pins = &DEFAULT_BAP_PINS, .i2c_pins = &DEFAULT_I2C_PINS, .EMC2103 = true,                                          .temp_flip = true, .temp_offset = 0,   .TPS546 = true,                                                           .power_consumption_target = 36, },
 };
 
 esp_err_t device_config_init(void * pvParameters);

--- a/main/device_pins.c
+++ b/main/device_pins.c
@@ -1,0 +1,99 @@
+#include "device_pins.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "sdkconfig.h"
+
+static const char * TAG = "device_pins";
+
+const BapPins DEFAULT_BAP_PINS = {
+    .tx = GPIO_NUM_39,
+    .rx = GPIO_NUM_40,
+};
+
+const I2cPins DEFAULT_I2C_PINS = {
+    .sda = GPIO_NUM_47,
+    .scl = GPIO_NUM_48,
+};
+
+static inline esp_err_t check_pin(gpio_num_t gpio, const char * name, uint64_t * allocated_pins_mask)
+{
+    if (gpio == GPIO_NUM_NC) {
+        return ESP_OK;
+    }
+    if (!GPIO_IS_VALID_GPIO(gpio)) {
+        ESP_LOGE(TAG, "INVALID GPIO: %d for %s is out of range (0-%d)!", gpio, name, GPIO_NUM_MAX - 1);
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (*allocated_pins_mask & (1ULL << gpio)) {
+        ESP_LOGE(TAG, "PIN CONFLICT: GPIO %d (%s) is already in use by another interface!", gpio, name);
+        return ESP_ERR_INVALID_STATE;
+    }
+    *allocated_pins_mask |= (1ULL << gpio);
+    return ESP_OK;
+}
+
+static esp_err_t device_pins_validate(const DevicePins * pins)
+{
+    uint64_t allocated_pins_mask = 0;
+    esp_err_t status = ESP_OK;
+
+    if (pins->bap) {
+        if (check_pin(pins->bap->tx, "BAP TX", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(pins->bap->rx, "BAP RX", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+    }
+
+    if (pins->i2c) {
+        if (check_pin(pins->i2c->sda, "I2C SDA", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(pins->i2c->scl, "I2C SCL", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+    }
+
+    if (pins->i80) {
+        for (int i = 0; i < 8; i++) {
+            if (check_pin(pins->i80->data[i], "LCD Data", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        }
+        if (check_pin(pins->i80->rd, "LCD RD", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(pins->i80->wr, "LCD WR", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(pins->i80->cs, "LCD CS", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(pins->i80->dc, "LCD DC", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(pins->i80->rst, "LCD RST", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(pins->i80->pwr, "LCD PWR", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+        if (check_pin(pins->i80->bk_light, "LCD BK_LIGHT", &allocated_pins_mask) != ESP_OK) status = ESP_ERR_INVALID_STATE;
+    }
+
+    return status;
+}
+
+static void apply_kconfig_pin_overrides(DevicePins * pins)
+{
+#if defined(CONFIG_ENABLE_BAP) && !CONFIG_ENABLE_BAP
+    pins->bap = NULL;
+    ESP_LOGI(TAG, "BAP disabled via Kconfig (CONFIG_ENABLE_BAP=n)");
+#elif defined(CONFIG_GPIO_BAP_TX) && defined(CONFIG_GPIO_BAP_RX)
+    if (CONFIG_GPIO_BAP_TX >= 0 && CONFIG_GPIO_BAP_RX >= 0) {
+        static BapPins kconfig_bap_pins;
+        kconfig_bap_pins.tx = CONFIG_GPIO_BAP_TX;
+        kconfig_bap_pins.rx = CONFIG_GPIO_BAP_RX;
+        pins->bap = &kconfig_bap_pins;
+        ESP_LOGI(TAG, "Kconfig override applied for BAP pins: TX=%d RX=%d", CONFIG_GPIO_BAP_TX, CONFIG_GPIO_BAP_RX);
+    }
+#endif
+
+#if defined(CONFIG_GPIO_I2C_SDA) && defined(CONFIG_GPIO_I2C_SCL)
+    if (CONFIG_GPIO_I2C_SDA >= 0 && CONFIG_GPIO_I2C_SCL >= 0) {
+        static I2cPins kconfig_i2c_pins;
+        kconfig_i2c_pins.sda = CONFIG_GPIO_I2C_SDA;
+        kconfig_i2c_pins.scl = CONFIG_GPIO_I2C_SCL;
+        pins->i2c = &kconfig_i2c_pins;
+        ESP_LOGI(TAG, "Kconfig override applied for I2C pins: SDA=%d SCL=%d", CONFIG_GPIO_I2C_SDA, CONFIG_GPIO_I2C_SCL);
+    }
+#endif
+}
+
+esp_err_t device_pins_init(DevicePins * pins)
+{
+    if (!pins) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    apply_kconfig_pin_overrides(pins);
+    return device_pins_validate(pins);
+}

--- a/main/device_pins.h
+++ b/main/device_pins.h
@@ -1,0 +1,43 @@
+#ifndef DEVICE_PINS_H_
+#define DEVICE_PINS_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "esp_err.h"
+#include "soc/gpio_num.h"
+
+typedef struct {
+    gpio_num_t tx;
+    gpio_num_t rx;
+} BapPins;
+
+typedef struct {
+    gpio_num_t sda;
+    gpio_num_t scl;
+} I2cPins;
+
+typedef struct {
+    gpio_num_t data[8];
+    gpio_num_t rd;
+    gpio_num_t pwr;
+    gpio_num_t wr;
+    gpio_num_t cs;
+    gpio_num_t dc;
+    gpio_num_t rst;
+    gpio_num_t bk_light;
+} I80Pins;
+
+typedef struct {
+    const BapPins * bap;
+    const I2cPins * i2c;
+    const I80Pins * i80;
+} DevicePins;
+
+extern const BapPins DEFAULT_BAP_PINS;
+extern const I2cPins DEFAULT_I2C_PINS;
+
+#define DEFAULT_DEVICE_PINS { .bap = &DEFAULT_BAP_PINS, .i2c = &DEFAULT_I2C_PINS, .i80 = NULL }
+
+esp_err_t device_pins_init(DevicePins * pins);
+
+#endif /* DEVICE_PINS_H_ */

--- a/main/i2c_bitaxe.c
+++ b/main/i2c_bitaxe.c
@@ -7,9 +7,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
-#define GPIO_I2C_SDA CONFIG_GPIO_I2C_SDA
-#define GPIO_I2C_SCL CONFIG_GPIO_I2C_SCL
-
 #define I2C_MASTER_FREQ_HZ 100000
 
 #define I2C_MASTER_NUM 0
@@ -63,16 +60,18 @@ static esp_err_t i2c_transfer_with_retries(i2c_master_dev_handle_t dev_handle,
 /**
  * @brief i2c master initialization
  */
-esp_err_t i2c_bitaxe_init(void)
+esp_err_t i2c_bitaxe_init(gpio_num_t sda_gpio, gpio_num_t scl_gpio)
 {
     i2c_master_bus_config_t i2c_bus_config = {
         .clk_source = I2C_CLK_SRC_DEFAULT,
         .i2c_port = I2C_MASTER_NUM,
-        .scl_io_num = GPIO_I2C_SCL,
-        .sda_io_num = GPIO_I2C_SDA,
+        .scl_io_num = scl_gpio,
+        .sda_io_num = sda_gpio,
         .glitch_ignore_cnt = 7,
         .flags.enable_internal_pullup = true,
     };
+
+    ESP_LOGI(TAG, "Initializing I2C bus on SDA=%d SCL=%d", sda_gpio, scl_gpio);
 
     return i2c_new_master_bus(&i2c_bus_config, &i2c_bus_handle);
 }

--- a/main/i2c_bitaxe.h
+++ b/main/i2c_bitaxe.h
@@ -5,7 +5,7 @@
 
 #define I2C_BUS_SPEED_HZ 400000   /*!< I2C master clock frequency */
 
-esp_err_t i2c_bitaxe_init(void);
+esp_err_t i2c_bitaxe_init(gpio_num_t sda_gpio, gpio_num_t scl_gpio);
 esp_err_t i2c_bitaxe_add_device(uint8_t device_address, i2c_master_dev_handle_t * dev_handle, const char *device_tag);
 esp_err_t i2c_bitaxe_get_master_bus_handle(i2c_master_bus_handle_t * dev_handle);
 

--- a/main/main.c
+++ b/main/main.c
@@ -123,8 +123,8 @@ void app_main(void)
     }
 
     // Init I2C
-    if (GLOBAL_STATE.DEVICE_CONFIG.i2c_pins != NULL) {
-        ESP_ERROR_CHECK(i2c_bitaxe_init(GLOBAL_STATE.DEVICE_CONFIG.i2c_pins->sda, GLOBAL_STATE.DEVICE_CONFIG.i2c_pins->scl));
+    if (GLOBAL_STATE.DEVICE_CONFIG.pins.i2c != NULL) {
+        ESP_ERROR_CHECK(i2c_bitaxe_init(GLOBAL_STATE.DEVICE_CONFIG.pins.i2c->sda, GLOBAL_STATE.DEVICE_CONFIG.pins.i2c->scl));
         ESP_LOGI(TAG, "I2C initialized successfully");
     } else {
         ESP_LOGI(TAG, "I2C pins not configured for board; skipping I2C initialization");

--- a/main/main.c
+++ b/main/main.c
@@ -83,16 +83,9 @@ void app_main(void)
     }
 #endif
   
-    // Init I2C
-    ESP_ERROR_CHECK(i2c_bitaxe_init());
-    ESP_LOGI(TAG, "I2C initialized successfully");
-
     // Initialize RST pin to low early to minimize ASIC power consumption
     ESP_ERROR_CHECK(asic_hold_reset_low());
     ESP_LOGI(TAG, "RST pin initialized to low");
-
-    // wait for I2C to init
-    vTaskDelay(100 / portTICK_PERIOD_MS);
 
     // Init ADC
     ADC_init();
@@ -128,6 +121,17 @@ void app_main(void)
         ESP_LOGE(TAG, "Failed to init device config");
         return;
     }
+
+    // Init I2C
+    if (GLOBAL_STATE.DEVICE_CONFIG.i2c_pins != NULL) {
+        ESP_ERROR_CHECK(i2c_bitaxe_init(GLOBAL_STATE.DEVICE_CONFIG.i2c_pins->sda, GLOBAL_STATE.DEVICE_CONFIG.i2c_pins->scl));
+        ESP_LOGI(TAG, "I2C initialized successfully");
+    } else {
+        ESP_LOGI(TAG, "I2C pins not configured for board; skipping I2C initialization");
+    }
+
+    // wait for I2C to init
+    vTaskDelay(100 / portTICK_PERIOD_MS);
 
     if (self_test_init(&GLOBAL_STATE) != ESP_OK) {
         ESP_LOGE(TAG, "Failed to init self test");


### PR DESCRIPTION
Extracts pin configuration for I2C, BAP and I80 connections.

Extracted from #1807 