### PR TITLE
Fix crash due to missing GLOBAL_STATE setter

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -1828,8 +1828,9 @@ esp_err_t http_404_error_handler(httpd_req_t * req, httpd_err_code_t err)
     return ESP_OK;
 }
 
-esp_err_t start_rest_server(GlobalState * GLOBAL_STATE)
+esp_err_t start_rest_server(GlobalState * global_state)
 {
+    GLOBAL_STATE = global_state;
     // Initialize the ASIC API with the global state
     asic_api_init(GLOBAL_STATE);
     const char * base_path = "";

--- a/main/screen.c
+++ b/main/screen.c
@@ -688,8 +688,9 @@ static void uptime_update_cb(lv_timer_t * timer)
     }
 }
 
-esp_err_t screen_start(GlobalState * GLOBAL_STATE)
+esp_err_t screen_start(GlobalState * global_state)
 {
+    GLOBAL_STATE = global_state;
     if (lvgl_port_lock(0)) {
         // screen_chars = lv_display_get_horizontal_resolution(NULL) / 6;
         screen_lines = lv_display_get_vertical_resolution(NULL) / 8;


### PR DESCRIPTION
Bamboozled by #1826 being only a compile time change. It was not.