### PR TITLE
Harden Stratum V1 network input validation

### DIFF
--- a/components/stratum/coinbase_decoder.c
+++ b/components/stratum/coinbase_decoder.c
@@ -24,29 +24,33 @@ static void ensure_base58_init(void) {
     }
 }
 
-uint64_t coinbase_decode_varint(const uint8_t *data, int *offset) {
-    uint8_t first_byte = data[*offset];
-    (*offset)++;
-    
-    if (first_byte < 0xFD) {
-        return first_byte;
-    } else if (first_byte == 0xFD) {
-        uint64_t value = data[*offset] | (data[*offset + 1] << 8);
-        *offset += 2;
-        return value;
-    } else if (first_byte == 0xFE) {
-        uint64_t value = data[*offset] | (data[*offset + 1] << 8) | 
-                        (data[*offset + 2] << 16) | (data[*offset + 3] << 24);
-        *offset += 4;
-        return value;
-    } else { // 0xFF
-        uint64_t value = 0;
-        for (int i = 0; i < 8; i++) {
-            value |= ((uint64_t)data[*offset + i]) << (i * 8);
-        }
-        *offset += 8;
-        return value;
+bool coinbase_decode_varint(const uint8_t *data, size_t data_len, size_t *offset, uint64_t *value)
+{
+    if (data == NULL || offset == NULL || value == NULL || *offset >= data_len) {
+        return false;
     }
+
+    size_t next = *offset;
+    uint8_t first_byte = data[next++];
+    if (first_byte < 0xFD) {
+        *offset = next;
+        *value = first_byte;
+        return true;
+    }
+
+    size_t payload_len = first_byte == 0xFD ? 2 : first_byte == 0xFE ? 4 : 8;
+    if (payload_len > data_len - next) {
+        return false;
+    }
+
+    uint64_t decoded = 0;
+    for (size_t i = 0; i < payload_len; i++) {
+        decoded |= ((uint64_t)data[next + i]) << (i * 8);
+    }
+
+    *offset = next + payload_len;
+    *value = decoded;
+    return true;
 }
 
 void coinbase_decode_address_from_scriptpubkey(const uint8_t *script, size_t script_len, 
@@ -268,7 +272,7 @@ esp_err_t coinbase_process_notification(const mining_notify *notification,
     
     hex2bin(notification->coinbase_2, coinbase_2_bin, coinbase_2_len);
     
-    int offset = coinbase_2_offset;
+    size_t offset = (size_t)coinbase_2_offset;
     
     // Read sequence (4 bytes) for BIP-54 detection
     if (offset + 4 > coinbase_2_len) {
@@ -287,13 +291,20 @@ esp_err_t coinbase_process_notification(const mining_notify *notification,
         return ESP_ERR_INVALID_ARG;
     }
     
-    uint64_t num_outputs = coinbase_decode_varint(coinbase_2_bin, &offset);
+    uint64_t num_outputs;
+    if (!coinbase_decode_varint(coinbase_2_bin, (size_t)coinbase_2_len, &offset, &num_outputs)) {
+        free(coinbase_2_bin);
+        return ESP_ERR_INVALID_ARG;
+    }
     result->output_count = 0;
     
     // Parse each output
-    for (uint64_t i = 0; i < num_outputs && offset < coinbase_2_len; i++) {
+    for (uint64_t i = 0; i < num_outputs; i++) {
         // Read value (8 bytes, little-endian)
-        if (offset + 8 > coinbase_2_len) break;
+        if ((size_t)coinbase_2_len - offset < 8) {
+            free(coinbase_2_bin);
+            return ESP_ERR_INVALID_ARG;
+        }
 
         uint64_t value_satoshis = 0;
         for (int i = 0; i < 8; i++) {
@@ -305,10 +316,12 @@ esp_err_t coinbase_process_notification(const mining_notify *notification,
         result->total_value_satoshis += value_satoshis;
 
         // Read scriptPubKey length
-        if (offset >= coinbase_2_len) break;
-        uint64_t script_len = coinbase_decode_varint(coinbase_2_bin, &offset);
-
-        if (offset + script_len > coinbase_2_len) break;
+        uint64_t script_len;
+        if (!coinbase_decode_varint(coinbase_2_bin, (size_t)coinbase_2_len, &offset, &script_len) ||
+            script_len > (uint64_t)((size_t)coinbase_2_len - offset)) {
+            free(coinbase_2_bin);
+            return ESP_ERR_INVALID_ARG;
+        }
 
         if (decode_coinbase_tx) {
             if (value_satoshis > 0) {            

--- a/components/stratum/include/coinbase_decoder.h
+++ b/components/stratum/include/coinbase_decoder.h
@@ -27,10 +27,12 @@ typedef struct mining_notify mining_notify;
  * @brief Decode Bitcoin varint from binary data
  * 
  * @param data Binary data containing the varint
- * @param offset Pointer to current offset, will be updated after reading
- * @return Decoded varint value
+ * @param data_len Length of the binary data
+ * @param offset Pointer to current offset, updated after a successful read
+ * @param value Pointer to the decoded varint value
+ * @return true when a complete varint was decoded
  */
-uint64_t coinbase_decode_varint(const uint8_t *data, int *offset);
+bool coinbase_decode_varint(const uint8_t *data, size_t data_len, size_t *offset, uint64_t *value);
 
 /**
  * @brief Decode Bitcoin address from scriptPubKey

--- a/components/stratum/include/mining.h
+++ b/components/stratum/include/mining.h
@@ -1,7 +1,11 @@
 #ifndef MINING_H_
 #define MINING_H_
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+
+#define MAX_COINBASE_TX_BYTES 8192
 
 typedef struct mining_notify mining_notify;
 
@@ -27,7 +31,7 @@ typedef struct bm_job
 
 void free_bm_job(bm_job *job);
 
-void calculate_coinbase_tx_hash(const char *coinbase_1, const char *coinbase_2,
+bool calculate_coinbase_tx_hash(const char *coinbase_1, const char *coinbase_2,
                                 const char *extranonce, const char *extranonce_2, uint8_t dest[32]);
 
 void calculate_coinbase_tx_hash_bin(const uint8_t *prefix, size_t prefix_len,

--- a/components/stratum/include/stratum_api.h
+++ b/components/stratum/include/stratum_api.h
@@ -82,9 +82,13 @@ typedef struct RequestTiming
 
 esp_transport_handle_t STRATUM_V1_transport_init(tls_mode tls, char * cert);
 
+bool STRATUM_V1_initialize(void);
+
 bool STRATUM_V1_initialize_buffer(void);
 
 void STRATUM_V1_cleanup_buffer(void);
+
+void STRATUM_V1_reset_buffer(void);
 
 char *STRATUM_V1_receive_jsonrpc_line(esp_transport_handle_t transport);
 

--- a/components/stratum/include/stratum_api.h
+++ b/components/stratum/include/stratum_api.h
@@ -13,6 +13,7 @@
 #define MAX_REQUEST_IDS 1024
 #define MAX_EXTRANONCE_2_LEN 32
 #define MAX_POOL_MESSAGE_LEN 256
+#define STRATUM_V1_MAX_JSON_LINE_SIZE 8192
 
 typedef enum
 {
@@ -81,7 +82,9 @@ typedef struct RequestTiming
 
 esp_transport_handle_t STRATUM_V1_transport_init(tls_mode tls, char * cert);
 
-void STRATUM_V1_initialize_buffer();
+bool STRATUM_V1_initialize_buffer(void);
+
+void STRATUM_V1_cleanup_buffer(void);
 
 char *STRATUM_V1_receive_jsonrpc_line(esp_transport_handle_t transport);
 

--- a/components/stratum/mining.c
+++ b/components/stratum/mining.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <limits.h>
+#include <stdlib.h>
 #include "mining.h"
 #include "stratum_api.h"
 #include "utils.h"
@@ -12,16 +13,57 @@ void free_bm_job(bm_job *job)
     free(job);
 }
 
-void calculate_coinbase_tx_hash(const char *coinbase_1, const char *coinbase_2, const char *extranonce, const char *extranonce_2, uint8_t dest[32])
+__attribute__((weak)) void *stratum_mining_malloc(size_t size)
 {
+    return malloc(size);
+}
+
+static bool is_even_hex(const char *value)
+{
+    if (value == NULL) return false;
+
+    size_t length = strlen(value);
+    if ((length & 1U) != 0) return false;
+
+    for (size_t i = 0; i < length; i++) {
+        char digit = value[i];
+        if (!((digit >= '0' && digit <= '9') ||
+              (digit >= 'a' && digit <= 'f') ||
+              (digit >= 'A' && digit <= 'F'))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool calculate_coinbase_tx_hash(const char *coinbase_1, const char *coinbase_2,
+                                const char *extranonce, const char *extranonce_2,
+                                uint8_t dest[32])
+{
+    if (dest == NULL || !is_even_hex(coinbase_1) || !is_even_hex(coinbase_2) ||
+        !is_even_hex(extranonce) || !is_even_hex(extranonce_2)) {
+        return false;
+    }
+
     size_t len1 = strlen(coinbase_1);
     size_t len2 = strlen(extranonce);
     size_t len3 = strlen(extranonce_2);
     size_t len4 = strlen(coinbase_2);
 
-    size_t coinbase_tx_bin_len = (len1 + len2 + len3 + len4) / 2;
+    if (len1 > SIZE_MAX - len2 || len1 + len2 > SIZE_MAX - len3 ||
+        len1 + len2 + len3 > SIZE_MAX - len4) {
+        return false;
+    }
 
-    uint8_t coinbase_tx_bin[coinbase_tx_bin_len];
+    size_t coinbase_tx_bin_len = (len1 + len2 + len3 + len4) / 2;
+    if (coinbase_tx_bin_len == 0 || coinbase_tx_bin_len > MAX_COINBASE_TX_BYTES) {
+        return false;
+    }
+
+    uint8_t *coinbase_tx_bin = stratum_mining_malloc(coinbase_tx_bin_len);
+    if (coinbase_tx_bin == NULL) {
+        return false;
+    }
 
     size_t bin_offset = 0;
     bin_offset += hex2bin(coinbase_1, coinbase_tx_bin + bin_offset, coinbase_tx_bin_len - bin_offset);
@@ -29,7 +71,12 @@ void calculate_coinbase_tx_hash(const char *coinbase_1, const char *coinbase_2, 
     bin_offset += hex2bin(extranonce_2, coinbase_tx_bin + bin_offset, coinbase_tx_bin_len - bin_offset);
     bin_offset += hex2bin(coinbase_2, coinbase_tx_bin + bin_offset, coinbase_tx_bin_len - bin_offset);
 
-    double_sha256_bin(coinbase_tx_bin, coinbase_tx_bin_len, dest);
+    bool complete = bin_offset == coinbase_tx_bin_len;
+    if (complete) {
+        double_sha256_bin(coinbase_tx_bin, coinbase_tx_bin_len, dest);
+    }
+    free(coinbase_tx_bin);
+    return complete;
 }
 
 void calculate_coinbase_tx_hash_bin(const uint8_t *prefix, size_t prefix_len,

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -28,11 +28,12 @@ static const char * TAG = "stratum_api";
 
 static char * json_rpc_buffer = NULL;
 static size_t json_rpc_buffer_size = 0;
+static size_t json_rpc_buffer_used = 0;
 
 static RequestTiming *request_timings = NULL;
 
 static RequestTiming* get_request_timing(int request_id) {
-    if (request_id < 0) return NULL;
+    if (request_id < 0 || request_timings == NULL) return NULL;
     int index = request_id % MAX_REQUEST_IDS;
     return &request_timings[index];
 }
@@ -91,24 +92,34 @@ esp_transport_handle_t STRATUM_V1_transport_init(tls_mode tls, char * cert)
     return transport;
 }
 
-void STRATUM_V1_initialize_buffer()
+void STRATUM_V1_cleanup_buffer(void)
 {
-    // Free any existing buffer (may be non-NULL if a previous V1 task was running)
     free(json_rpc_buffer);
+    json_rpc_buffer = NULL;
+    json_rpc_buffer_size = 0;
+    json_rpc_buffer_used = 0;
+}
+
+bool STRATUM_V1_initialize_buffer(void)
+{
+    // Release state left by a previous V1 task before starting a new session.
+    STRATUM_V1_cleanup_buffer();
 
     json_rpc_buffer = malloc(BUFFER_SIZE);
-    json_rpc_buffer_size = BUFFER_SIZE;
     if (json_rpc_buffer == NULL) {
-        printf("Error: Failed to allocate memory for buffer\n");
-        exit(1);
+        ESP_LOGE(TAG, "Failed to allocate JSON-RPC receive buffer");
+        return false;
     }
-    memset(json_rpc_buffer, 0, BUFFER_SIZE);
+    json_rpc_buffer_size = BUFFER_SIZE;
+    json_rpc_buffer_used = 0;
+    json_rpc_buffer[0] = '\0';
 
     if (request_timings == NULL) {
         request_timings = heap_caps_malloc(sizeof(RequestTiming) * MAX_REQUEST_IDS, MALLOC_CAP_SPIRAM);
         if (request_timings == NULL) {
-            printf("Error: Failed to allocate memory for request_timings\n");
-            exit(1);
+            ESP_LOGE(TAG, "Failed to allocate Stratum request timings");
+            STRATUM_V1_cleanup_buffer();
+            return false;
         }
     }
 
@@ -116,56 +127,58 @@ void STRATUM_V1_initialize_buffer()
         request_timings[i].timestamp_us = 0;
         request_timings[i].tracking = false;
     }
+
+    return true;
 }
 
-void cleanup_stratum_buffer()
+static void reset_json_buffer(void)
 {
-    free(json_rpc_buffer);
-    json_rpc_buffer = NULL;
-    if (request_timings) {
-        free(request_timings);
-        request_timings = NULL;
+    json_rpc_buffer_used = 0;
+    if (json_rpc_buffer != NULL) {
+        json_rpc_buffer[0] = '\0';
     }
 }
 
-static void realloc_json_buffer(size_t len)
+static bool ensure_json_buffer_capacity(size_t required_size)
 {
-    size_t old, new;
-
-    old = strlen(json_rpc_buffer);
-    new = old + len + 1;
-
-    if (new < json_rpc_buffer_size) {
-        return;
+    if (required_size <= json_rpc_buffer_size) {
+        return true;
     }
 
-    new = new + (BUFFER_SIZE - (new % BUFFER_SIZE));
-    void * new_sockbuf = realloc(json_rpc_buffer, new);
-
-    if (new_sockbuf == NULL) {
-        fprintf(stderr, "Error: realloc failed in recalloc_sock()\n");
-        ESP_LOGI(TAG, "Restarting System because of ERROR: realloc failed in recalloc_sock");
-        vTaskDelay(1000 / portTICK_PERIOD_MS);
-        esp_restart();
+    // One read can contain the newline plus the beginning of following lines.
+    // Keep that tail, but never let the receive allocation grow without bound.
+    const size_t max_buffer_size = STRATUM_V1_MAX_JSON_LINE_SIZE + BUFFER_SIZE + 1;
+    if (required_size > max_buffer_size) {
+        return false;
     }
 
-    json_rpc_buffer = new_sockbuf;
-    memset(json_rpc_buffer + old, 0, new - old);
-    json_rpc_buffer_size = new;
+    size_t new_size = ((required_size + BUFFER_SIZE - 1) / BUFFER_SIZE) * BUFFER_SIZE;
+    if (new_size > max_buffer_size) {
+        new_size = max_buffer_size;
+    }
+
+    void *new_buffer = realloc(json_rpc_buffer, new_size);
+    if (new_buffer == NULL) {
+        ESP_LOGE(TAG, "Failed to grow JSON-RPC receive buffer to %zu bytes", new_size);
+        return false;
+    }
+
+    json_rpc_buffer = new_buffer;
+    json_rpc_buffer_size = new_size;
+    return true;
 }
 
-char * STRATUM_V1_receive_jsonrpc_line(esp_transport_handle_t transport)
+char *STRATUM_V1_receive_jsonrpc_line(esp_transport_handle_t transport)
 {
-    if (json_rpc_buffer == NULL) {
-        STRATUM_V1_initialize_buffer();
+    if (json_rpc_buffer == NULL && !STRATUM_V1_initialize_buffer()) {
+        return NULL;
     }
-    char *line = NULL;
+
     char recv_buffer[BUFFER_SIZE];
-    int nbytes;
+    char *newline_pos = memchr(json_rpc_buffer, '\n', json_rpc_buffer_used);
 
-    while (!strstr(json_rpc_buffer, "\n")) {
-        memset(recv_buffer, 0, BUFFER_SIZE);
-        nbytes = esp_transport_read(transport, recv_buffer, BUFFER_SIZE - 1, TRANSPORT_TIMEOUT_MS);
+    while (newline_pos == NULL) {
+        int nbytes = esp_transport_read(transport, recv_buffer, sizeof(recv_buffer), TRANSPORT_TIMEOUT_MS);
         if (nbytes < 0) {
             const char *err_str;
             switch(nbytes) {
@@ -183,32 +196,57 @@ char * STRATUM_V1_receive_jsonrpc_line(esp_transport_handle_t transport)
                     break;
             }
             ESP_LOGE(TAG, "Error: transport read failed: %s (code: %d)", err_str, nbytes);
-            if (json_rpc_buffer) {
-                free(json_rpc_buffer);
-                json_rpc_buffer = NULL;
-            }
+            reset_json_buffer();
             return NULL;
         }
+
         if (nbytes > 0) {
-            realloc_json_buffer(nbytes);
-            strncat(json_rpc_buffer, recv_buffer, nbytes);
+            char *incoming_newline = memchr(recv_buffer, '\n', (size_t)nbytes);
+            size_t bytes_before_newline = incoming_newline != NULL
+                                              ? (size_t)(incoming_newline - recv_buffer)
+                                              : (size_t)nbytes;
+
+            if (json_rpc_buffer_used > STRATUM_V1_MAX_JSON_LINE_SIZE ||
+                bytes_before_newline > STRATUM_V1_MAX_JSON_LINE_SIZE - json_rpc_buffer_used) {
+                ESP_LOGE(TAG, "JSON-RPC line exceeds %d-byte limit", STRATUM_V1_MAX_JSON_LINE_SIZE);
+                reset_json_buffer();
+                return NULL;
+            }
+
+            size_t append_offset = json_rpc_buffer_used;
+            size_t required_size = append_offset + (size_t)nbytes + 1;
+            if (!ensure_json_buffer_capacity(required_size)) {
+                reset_json_buffer();
+                return NULL;
+            }
+
+            memcpy(json_rpc_buffer + append_offset, recv_buffer, (size_t)nbytes);
+            json_rpc_buffer_used += (size_t)nbytes;
+            json_rpc_buffer[json_rpc_buffer_used] = '\0';
+            if (incoming_newline != NULL) {
+                newline_pos = json_rpc_buffer + append_offset + bytes_before_newline;
+            }
         }
     }
 
-    // Extract the line
-    size_t buflen = strlen(json_rpc_buffer);
-    char *newline_pos = strchr(json_rpc_buffer, '\n');
-    if (newline_pos) {
-        size_t line_len = newline_pos - json_rpc_buffer;
-        line = strndup(json_rpc_buffer, line_len);  // Copy only up to \n
-        size_t remaining_len = buflen - line_len - 1;
-        if (remaining_len > 0) {
-            memmove(json_rpc_buffer, newline_pos + 1, remaining_len);
-            json_rpc_buffer[remaining_len] = '\0';
-        } else {
-            json_rpc_buffer[0] = '\0';
-        }
+    size_t line_len = (size_t)(newline_pos - json_rpc_buffer);
+    char *line = malloc(line_len + 1);
+    if (line == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate %zu-byte JSON-RPC line", line_len + 1);
+        reset_json_buffer();
+        return NULL;
     }
+
+    memcpy(line, json_rpc_buffer, line_len);
+    line[line_len] = '\0';
+
+    size_t remaining_len = json_rpc_buffer_used - line_len - 1;
+    if (remaining_len > 0) {
+        memmove(json_rpc_buffer, newline_pos + 1, remaining_len);
+    }
+    json_rpc_buffer_used = remaining_len;
+    json_rpc_buffer[json_rpc_buffer_used] = '\0';
+
     return line;
 }
 

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -382,10 +382,16 @@ static bool parse_set_extranonce(cJSON *json, StratumApiV1Message *message)
         ESP_LOGE(TAG, "Invalid extranonce data in set_extranonce");
         return false;
     }
+
+    int extranonce_2_len = extranonce2_size->valueint;
+    if (extranonce_2_len < 0) {
+        ESP_LOGE(TAG, "Invalid negative extranonce_2_len: %d", extranonce_2_len);
+        return false;
+    }
+
     if (message->extranonce_str) free(message->extranonce_str);
     message->extranonce_str = strdup(extranonce1->valuestring);
-    
-    int extranonce_2_len = extranonce2_size->valueint;
+
     if (extranonce_2_len > MAX_EXTRANONCE_2_LEN) {
         ESP_LOGW(TAG, "Extranonce_2_len %d exceeds maximum %d, clamping to maximum",
                  extranonce_2_len, MAX_EXTRANONCE_2_LEN);
@@ -441,10 +447,15 @@ static bool parse_subscribe_result(cJSON *json, StratumApiV1Message *message)
         return false;
     }
 
+    int extranonce_2_len = extranonce2_len->valueint;
+    if (extranonce_2_len < 0) {
+        ESP_LOGE(TAG, "Invalid negative extranonce_2_len: %d", extranonce_2_len);
+        return false;
+    }
+
     if (message->extranonce_str) free(message->extranonce_str);
     message->extranonce_str = strdup(extranonce->valuestring);
-    
-    int extranonce_2_len = extranonce2_len->valueint;
+
     if (extranonce_2_len > MAX_EXTRANONCE_2_LEN) {
         ESP_LOGW(TAG, "Extranonce_2_len %d exceeds maximum %d, clamping to maximum", 
                  extranonce_2_len, MAX_EXTRANONCE_2_LEN);

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -272,10 +272,47 @@ static bool parse_mining_notify(cJSON *json, StratumApiV1Message *message)
         ESP_LOGE(TAG, "Invalid params in mining.notify");
         return false;
     }
+
     int params_count = cJSON_GetArraySize(params);
-    if (params_count < 8) {
+    if (params_count < 9) {
         ESP_LOGE(TAG, "Not enough params in mining.notify: %d", params_count);
         return false;
+    }
+
+    cJSON *job_id_item = cJSON_GetArrayItem(params, 0);
+    cJSON *prev_block_hash_item = cJSON_GetArrayItem(params, 1);
+    cJSON *coinbase_1_item = cJSON_GetArrayItem(params, 2);
+    cJSON *coinbase_2_item = cJSON_GetArrayItem(params, 3);
+    cJSON *merkle_branch = cJSON_GetArrayItem(params, 4);
+    cJSON *version_item = cJSON_GetArrayItem(params, 5);
+    cJSON *target_item = cJSON_GetArrayItem(params, 6);
+    cJSON *ntime_item = cJSON_GetArrayItem(params, 7);
+    cJSON *clean_jobs_item = cJSON_GetArrayItem(params, params_count - 1);
+
+    if (!cJSON_IsString(job_id_item) ||
+        !cJSON_IsString(prev_block_hash_item) ||
+        !cJSON_IsString(coinbase_1_item) ||
+        !cJSON_IsString(coinbase_2_item) ||
+        !cJSON_IsArray(merkle_branch) ||
+        !cJSON_IsString(version_item) ||
+        !cJSON_IsString(target_item) ||
+        !cJSON_IsString(ntime_item) ||
+        !cJSON_IsBool(clean_jobs_item)) {
+        ESP_LOGE(TAG, "Invalid field type in mining.notify");
+        return false;
+    }
+
+    int merkle_branch_count = cJSON_GetArraySize(merkle_branch);
+    if (merkle_branch_count > MAX_MERKLE_BRANCHES) {
+        ESP_LOGE(TAG, "Too many Merkle branches: %d", merkle_branch_count);
+        return false;
+    }
+
+    for (int i = 0; i < merkle_branch_count; i++) {
+        if (!cJSON_IsString(cJSON_GetArrayItem(merkle_branch, i))) {
+            ESP_LOGE(TAG, "Invalid Merkle branch at index %d", i);
+            return false;
+        }
     }
 
     mining_notify *new_work = calloc(1, sizeof(mining_notify));
@@ -284,51 +321,40 @@ static bool parse_mining_notify(cJSON *json, StratumApiV1Message *message)
         return false;
     }
 
-    cJSON *job_id_item = cJSON_GetArrayItem(params, 0);
-    if (!job_id_item || !cJSON_IsString(job_id_item)) {
-        ESP_LOGE(TAG, "Invalid job_id in mining.notify");
-        free(new_work);
-        return false;
-    }
-
     new_work->job_id = strdup(job_id_item->valuestring);
-    new_work->prev_block_hash = strdup(cJSON_GetArrayItem(params, 1)->valuestring);
-    new_work->coinbase_1 = strdup(cJSON_GetArrayItem(params, 2)->valuestring);
-    new_work->coinbase_2 = strdup(cJSON_GetArrayItem(params, 3)->valuestring);
-
-    cJSON *merkle_branch = cJSON_GetArrayItem(params, 4);
-    if (!merkle_branch || !cJSON_IsArray(merkle_branch)) {
-        ESP_LOGE(TAG, "Invalid merkle_branch in mining.notify");
-        free(new_work->job_id);
-        free(new_work->prev_block_hash);
-        free(new_work->coinbase_1);
-        free(new_work->coinbase_2);
-        free(new_work);
+    new_work->prev_block_hash = strdup(prev_block_hash_item->valuestring);
+    new_work->coinbase_1 = strdup(coinbase_1_item->valuestring);
+    new_work->coinbase_2 = strdup(coinbase_2_item->valuestring);
+    if (!new_work->job_id || !new_work->prev_block_hash ||
+        !new_work->coinbase_1 || !new_work->coinbase_2) {
+        ESP_LOGE(TAG, "Memory allocation failed for mining.notify strings");
+        STRATUM_V1_free_mining_notify(new_work);
         return false;
     }
-    new_work->n_merkle_branches = cJSON_GetArraySize(merkle_branch);
-    if (new_work->n_merkle_branches > MAX_MERKLE_BRANCHES) {
-        ESP_LOGE(TAG, "Too many Merkle branches: %zu", new_work->n_merkle_branches);
-        free(new_work->job_id);
-        free(new_work->prev_block_hash);
-        free(new_work->coinbase_1);
-        free(new_work->coinbase_2);
-        free(new_work);
-        return false;
-    }
-    new_work->merkle_branches = malloc(HASH_SIZE * new_work->n_merkle_branches);
-    for (size_t i = 0; i < new_work->n_merkle_branches; i++) {
-        hex2bin(cJSON_GetArrayItem(merkle_branch, i)->valuestring, new_work->merkle_branches + HASH_SIZE * i, HASH_SIZE);
+
+    new_work->n_merkle_branches = (size_t)merkle_branch_count;
+    if (new_work->n_merkle_branches > 0) {
+        new_work->merkle_branches = malloc(HASH_SIZE * new_work->n_merkle_branches);
+        if (!new_work->merkle_branches) {
+            ESP_LOGE(TAG, "Memory allocation failed for Merkle branches");
+            STRATUM_V1_free_mining_notify(new_work);
+            return false;
+        }
+
+        for (size_t i = 0; i < new_work->n_merkle_branches; i++) {
+            cJSON *branch = cJSON_GetArrayItem(merkle_branch, i);
+            hex2bin(branch->valuestring,
+                    new_work->merkle_branches + HASH_SIZE * i,
+                    HASH_SIZE);
+        }
     }
 
-    new_work->version = strtoul(cJSON_GetArrayItem(params, 5)->valuestring, NULL, 16);
-    new_work->target = strtoul(cJSON_GetArrayItem(params, 6)->valuestring, NULL, 16);
-    new_work->ntime = strtoul(cJSON_GetArrayItem(params, 7)->valuestring, NULL, 16);
+    new_work->version = strtoul(version_item->valuestring, NULL, 16);
+    new_work->target = strtoul(target_item->valuestring, NULL, 16);
+    new_work->ntime = strtoul(ntime_item->valuestring, NULL, 16);
 
-    // params can be variable length
-    int paramsLength = cJSON_GetArraySize(params);
-    int value = cJSON_IsTrue(cJSON_GetArrayItem(params, paramsLength - 1));
-    new_work->clean_jobs = value;
+    // Some pools append extension fields; clean_jobs remains the final parameter.
+    new_work->clean_jobs = cJSON_IsTrue(clean_jobs_item);
 
     message->mining_notification = new_work;
     ESP_LOGD(TAG, "Parsed mining.notify: job_id=%s, clean_jobs=%d", new_work->job_id, new_work->clean_jobs);

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -32,6 +32,11 @@ static size_t json_rpc_buffer_used = 0;
 
 static RequestTiming *request_timings = NULL;
 
+__attribute__((weak)) char *stratum_api_strdup(const char *source)
+{
+    return strdup(source);
+}
+
 static RequestTiming* get_request_timing(int request_id) {
     if (request_id < 0 || request_timings == NULL) return NULL;
     int index = request_id % MAX_REQUEST_IDS;
@@ -102,7 +107,6 @@ void STRATUM_V1_cleanup_buffer(void)
 
 bool STRATUM_V1_initialize_buffer(void)
 {
-    // Release state left by a previous V1 task before starting a new session.
     STRATUM_V1_cleanup_buffer();
 
     json_rpc_buffer = malloc(BUFFER_SIZE);
@@ -113,6 +117,16 @@ bool STRATUM_V1_initialize_buffer(void)
     json_rpc_buffer_size = BUFFER_SIZE;
     json_rpc_buffer_used = 0;
     json_rpc_buffer[0] = '\0';
+
+    return true;
+}
+
+bool STRATUM_V1_initialize(void)
+{
+    // Release state left by a previous V1 task before starting a new session.
+    if (!STRATUM_V1_initialize_buffer()) {
+        return false;
+    }
 
     if (request_timings == NULL) {
         request_timings = heap_caps_malloc(sizeof(RequestTiming) * MAX_REQUEST_IDS, MALLOC_CAP_SPIRAM);
@@ -131,7 +145,7 @@ bool STRATUM_V1_initialize_buffer(void)
     return true;
 }
 
-static void reset_json_buffer(void)
+void STRATUM_V1_reset_buffer(void)
 {
     json_rpc_buffer_used = 0;
     if (json_rpc_buffer != NULL) {
@@ -196,7 +210,7 @@ char *STRATUM_V1_receive_jsonrpc_line(esp_transport_handle_t transport)
                     break;
             }
             ESP_LOGE(TAG, "Error: transport read failed: %s (code: %d)", err_str, nbytes);
-            reset_json_buffer();
+            STRATUM_V1_reset_buffer();
             return NULL;
         }
 
@@ -209,14 +223,14 @@ char *STRATUM_V1_receive_jsonrpc_line(esp_transport_handle_t transport)
             if (json_rpc_buffer_used > STRATUM_V1_MAX_JSON_LINE_SIZE ||
                 bytes_before_newline > STRATUM_V1_MAX_JSON_LINE_SIZE - json_rpc_buffer_used) {
                 ESP_LOGE(TAG, "JSON-RPC line exceeds %d-byte limit", STRATUM_V1_MAX_JSON_LINE_SIZE);
-                reset_json_buffer();
+                STRATUM_V1_reset_buffer();
                 return NULL;
             }
 
             size_t append_offset = json_rpc_buffer_used;
             size_t required_size = append_offset + (size_t)nbytes + 1;
             if (!ensure_json_buffer_capacity(required_size)) {
-                reset_json_buffer();
+                STRATUM_V1_reset_buffer();
                 return NULL;
             }
 
@@ -233,7 +247,7 @@ char *STRATUM_V1_receive_jsonrpc_line(esp_transport_handle_t transport)
     char *line = malloc(line_len + 1);
     if (line == NULL) {
         ESP_LOGE(TAG, "Failed to allocate %zu-byte JSON-RPC line", line_len + 1);
-        reset_json_buffer();
+        STRATUM_V1_reset_buffer();
         return NULL;
     }
 
@@ -303,6 +317,62 @@ static stratum_method parse_method(const cJSON *method_json)
     return METHOD_UNKNOWN;
 }
 
+static int hex_digit_value(char digit)
+{
+    if (digit >= '0' && digit <= '9') return digit - '0';
+    if (digit >= 'a' && digit <= 'f') return digit - 'a' + 10;
+    if (digit >= 'A' && digit <= 'F') return digit - 'A' + 10;
+    return -1;
+}
+
+static bool is_hex_string(const cJSON *item, size_t expected_length)
+{
+    if (!item || !cJSON_IsString(item) || item->valuestring == NULL ||
+        strlen(item->valuestring) != expected_length) {
+        return false;
+    }
+
+    for (size_t i = 0; i < expected_length; i++) {
+        if (hex_digit_value(item->valuestring[i]) < 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool is_even_length_hex_string(const cJSON *item)
+{
+    if (!item || !cJSON_IsString(item) || item->valuestring == NULL) {
+        return false;
+    }
+
+    size_t length = strlen(item->valuestring);
+    if ((length & 1U) != 0) {
+        return false;
+    }
+
+    for (size_t i = 0; i < length; i++) {
+        if (hex_digit_value(item->valuestring[i]) < 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool parse_hex_u32(const cJSON *item, uint32_t *result)
+{
+    if (result == NULL || !is_hex_string(item, 8)) {
+        return false;
+    }
+
+    uint32_t value = 0;
+    for (size_t i = 0; i < 8; i++) {
+        value = (value << 4) | (uint32_t)hex_digit_value(item->valuestring[i]);
+    }
+    *result = value;
+    return true;
+}
+
 static bool parse_mining_notify(cJSON *json, StratumApiV1Message *message)
 {
     cJSON *params = cJSON_GetObjectItem(json, "params");
@@ -327,16 +397,23 @@ static bool parse_mining_notify(cJSON *json, StratumApiV1Message *message)
     cJSON *ntime_item = cJSON_GetArrayItem(params, 7);
     cJSON *clean_jobs_item = cJSON_GetArrayItem(params, params_count - 1);
 
-    if (!cJSON_IsString(job_id_item) ||
-        !cJSON_IsString(prev_block_hash_item) ||
-        !cJSON_IsString(coinbase_1_item) ||
-        !cJSON_IsString(coinbase_2_item) ||
-        !cJSON_IsArray(merkle_branch) ||
-        !cJSON_IsString(version_item) ||
-        !cJSON_IsString(target_item) ||
-        !cJSON_IsString(ntime_item) ||
-        !cJSON_IsBool(clean_jobs_item)) {
-        ESP_LOGE(TAG, "Invalid field type in mining.notify");
+    if (!job_id_item || !cJSON_IsString(job_id_item) || job_id_item->valuestring == NULL ||
+        !is_hex_string(prev_block_hash_item, HASH_SIZE * 2) ||
+        !is_even_length_hex_string(coinbase_1_item) ||
+        !is_even_length_hex_string(coinbase_2_item) ||
+        !merkle_branch || !cJSON_IsArray(merkle_branch) ||
+        !clean_jobs_item || !cJSON_IsBool(clean_jobs_item)) {
+        ESP_LOGE(TAG, "Invalid field type or encoding in mining.notify");
+        return false;
+    }
+
+    uint32_t version;
+    uint32_t target;
+    uint32_t ntime;
+    if (!parse_hex_u32(version_item, &version) ||
+        !parse_hex_u32(target_item, &target) ||
+        !parse_hex_u32(ntime_item, &ntime)) {
+        ESP_LOGE(TAG, "Invalid version, target, or ntime in mining.notify");
         return false;
     }
 
@@ -347,7 +424,7 @@ static bool parse_mining_notify(cJSON *json, StratumApiV1Message *message)
     }
 
     for (int i = 0; i < merkle_branch_count; i++) {
-        if (!cJSON_IsString(cJSON_GetArrayItem(merkle_branch, i))) {
+        if (!is_hex_string(cJSON_GetArrayItem(merkle_branch, i), HASH_SIZE * 2)) {
             ESP_LOGE(TAG, "Invalid Merkle branch at index %d", i);
             return false;
         }
@@ -381,15 +458,20 @@ static bool parse_mining_notify(cJSON *json, StratumApiV1Message *message)
 
         for (size_t i = 0; i < new_work->n_merkle_branches; i++) {
             cJSON *branch = cJSON_GetArrayItem(merkle_branch, i);
-            hex2bin(branch->valuestring,
-                    new_work->merkle_branches + HASH_SIZE * i,
-                    HASH_SIZE);
+            size_t decoded = hex2bin(branch->valuestring,
+                                     new_work->merkle_branches + HASH_SIZE * i,
+                                     HASH_SIZE);
+            if (decoded != HASH_SIZE) {
+                ESP_LOGE(TAG, "Failed to decode Merkle branch at index %zu", i);
+                STRATUM_V1_free_mining_notify(new_work);
+                return false;
+            }
         }
     }
 
-    new_work->version = strtoul(version_item->valuestring, NULL, 16);
-    new_work->target = strtoul(target_item->valuestring, NULL, 16);
-    new_work->ntime = strtoul(ntime_item->valuestring, NULL, 16);
+    new_work->version = version;
+    new_work->target = target;
+    new_work->ntime = ntime;
 
     // Some pools append extension fields; clean_jobs remains the final parameter.
     new_work->clean_jobs = cJSON_IsTrue(clean_jobs_item);
@@ -453,8 +535,13 @@ static bool parse_set_extranonce(cJSON *json, StratumApiV1Message *message)
         return false;
     }
 
-    if (message->extranonce_str) free(message->extranonce_str);
-    message->extranonce_str = strdup(extranonce1->valuestring);
+    char *new_extranonce = stratum_api_strdup(extranonce1->valuestring);
+    if (new_extranonce == NULL) {
+        ESP_LOGE(TAG, "Memory allocation failed for extranonce1");
+        return false;
+    }
+    free(message->extranonce_str);
+    message->extranonce_str = new_extranonce;
 
     if (extranonce_2_len > MAX_EXTRANONCE_2_LEN) {
         ESP_LOGW(TAG, "Extranonce_2_len %d exceeds maximum %d, clamping to maximum",
@@ -517,8 +604,13 @@ static bool parse_subscribe_result(cJSON *json, StratumApiV1Message *message)
         return false;
     }
 
-    if (message->extranonce_str) free(message->extranonce_str);
-    message->extranonce_str = strdup(extranonce->valuestring);
+    char *new_extranonce = stratum_api_strdup(extranonce->valuestring);
+    if (new_extranonce == NULL) {
+        ESP_LOGE(TAG, "Memory allocation failed for subscribe extranonce1");
+        return false;
+    }
+    free(message->extranonce_str);
+    message->extranonce_str = new_extranonce;
 
     if (extranonce_2_len > MAX_EXTRANONCE_2_LEN) {
         ESP_LOGW(TAG, "Extranonce_2_len %d exceeds maximum %d, clamping to maximum", 

--- a/components/stratum/test/test_coinbase_decoder.c
+++ b/components/stratum/test/test_coinbase_decoder.c
@@ -7,37 +7,89 @@
 TEST_CASE("Varint decode single byte", "[coinbase_decoder]")
 {
     uint8_t data[] = {0x42};
-    int offset = 0;
-    uint64_t result = coinbase_decode_varint(data, &offset);
+    size_t offset = 0;
+    uint64_t result = 0;
+    TEST_ASSERT_TRUE(coinbase_decode_varint(data, sizeof(data), &offset, &result));
     TEST_ASSERT_TRUE(0x42 == result);
-    TEST_ASSERT_EQUAL_INT(1, offset);
+    TEST_ASSERT_EQUAL_UINT32(1, offset);
 }
 
 TEST_CASE("Varint decode FD format", "[coinbase_decoder]")
 {
     uint8_t data[] = {0xFD, 0x34, 0x12};  // 0x1234 in little-endian
-    int offset = 0;
-    uint64_t result = coinbase_decode_varint(data, &offset);
+    size_t offset = 0;
+    uint64_t result = 0;
+    TEST_ASSERT_TRUE(coinbase_decode_varint(data, sizeof(data), &offset, &result));
     TEST_ASSERT_TRUE(0x1234 == result);
-    TEST_ASSERT_EQUAL_INT(3, offset);
+    TEST_ASSERT_EQUAL_UINT32(3, offset);
 }
 
 TEST_CASE("Varint decode FE format", "[coinbase_decoder]")
 {
     uint8_t data[] = {0xFE, 0x78, 0x56, 0x34, 0x12};  // 0x12345678 in little-endian
-    int offset = 0;
-    uint64_t result = coinbase_decode_varint(data, &offset);
+    size_t offset = 0;
+    uint64_t result = 0;
+    TEST_ASSERT_TRUE(coinbase_decode_varint(data, sizeof(data), &offset, &result));
     TEST_ASSERT_TRUE(0x12345678 == result);
-    TEST_ASSERT_EQUAL_INT(5, offset);
+    TEST_ASSERT_EQUAL_UINT32(5, offset);
 }
 
 TEST_CASE("Varint decode FF format", "[coinbase_decoder]")
 {
     uint8_t data[] = {0xFF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
-    int offset = 0;
-    uint64_t result = coinbase_decode_varint(data, &offset);
+    size_t offset = 0;
+    uint64_t result = 0;
+    TEST_ASSERT_TRUE(coinbase_decode_varint(data, sizeof(data), &offset, &result));
     TEST_ASSERT_TRUE(0x0807060504030201ULL == result);
-    TEST_ASSERT_EQUAL_INT(9, offset);
+    TEST_ASSERT_EQUAL_UINT32(9, offset);
+}
+
+TEST_CASE("Varint decoder rejects every truncated extended encoding", "[coinbase_decoder]")
+{
+    static const struct {
+        uint8_t marker;
+        size_t complete_size;
+    } cases[] = {
+        {0xFD, 3},
+        {0xFE, 5},
+        {0xFF, 9},
+    };
+
+    for (size_t case_index = 0; case_index < sizeof(cases) / sizeof(cases[0]); case_index++) {
+        uint8_t data[9] = {cases[case_index].marker};
+        for (size_t truncated_size = 1; truncated_size < cases[case_index].complete_size; truncated_size++) {
+            size_t offset = 0;
+            uint64_t result = UINT64_MAX;
+            TEST_ASSERT_FALSE(coinbase_decode_varint(data, truncated_size, &offset, &result));
+            TEST_ASSERT_EQUAL_UINT32(0, offset);
+            TEST_ASSERT_TRUE(UINT64_MAX == result);
+        }
+    }
+}
+
+TEST_CASE("Coinbase notification rejects truncated output data and varints", "[coinbase_decoder]")
+{
+    static const char minimal_coinbase_1[] =
+        "00000000" "01"
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        "ffffffff" "020100";
+    static const char *truncated_coinbase_2[] = {
+        "fffffffffd",
+        "ffffffff01",
+        "ffffffff010000000000000000fd00",
+    };
+
+    for (size_t i = 0; i < sizeof(truncated_coinbase_2) / sizeof(truncated_coinbase_2[0]); i++) {
+        mining_notify notification = {
+            .coinbase_1 = (char *)minimal_coinbase_1,
+            .coinbase_2 = (char *)truncated_coinbase_2[i],
+            .target = 0x1d00ffff,
+        };
+        mining_notification_result_t result = {};
+
+        TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG,
+                          coinbase_process_notification(&notification, "", 0, NULL, false, &result));
+    }
 }
 
 TEST_CASE("Decode P2PKH address", "[coinbase_decoder]")
@@ -214,7 +266,7 @@ TEST_CASE("BIP-110 signaling not detected", "[coinbase_decoder]")
     mining_notify notify = { 0 };
     notify.version = 0x20000000;  // No BIP-110 signaling
     notify.job_id = "test_job";
-    notify.coinbase_1 = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4b03a5020cfabe6d6d379ae882651f6469f2ed6b8b40a4f9a4b41fd838a3ad6de8cba775f4e8f1d3080100000000000000";
+    notify.coinbase_1 = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4803a5020cfabe6d6d379ae882651f6469f2ed6b8b40a4f9a4b41fd838a3ad6de8cba775f4e8f1d3080100000000000000";
     notify.coinbase_2 = "41903d4c1b2f736c7573682f0000000003ca890d27000000001976a9147c154ed1dc59609e3d26abb2df2ea3d587cd8c4188ac00000000000000002c6a4c2952534b424c4f434b3a4cb4cb2ddfc37c41baf5ef6b6b4899e3253a8f1dfc7e5dd68a5b5b27005014ef0000000000000000266a24aa21a9ed5caa249f1af9fbf71c986fea8e076ca34ae3514fb2f86400561b28c7b15949bf00000000";
     
     mining_notification_result_t result = { 0 };
@@ -231,7 +283,7 @@ TEST_CASE("BIP-110 signaling detected", "[coinbase_decoder]")
     mining_notify notify = { 0 };
     notify.version = 0x20000010;  // Version with BIP-110 signaling
     notify.job_id = "test_job";
-    notify.coinbase_1 = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4b03a5020cfabe6d6d379ae882651f6469f2ed6b8b40a4f9a4b41fd838a3ad6de8cba775f4e8f1d3080100000000000000";
+    notify.coinbase_1 = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4803a5020cfabe6d6d379ae882651f6469f2ed6b8b40a4f9a4b41fd838a3ad6de8cba775f4e8f1d3080100000000000000";
     notify.coinbase_2 = "41903d4c1b2f736c7573682f0000000003ca890d27000000001976a9147c154ed1dc59609e3d26abb2df2ea3d587cd8c4188ac00000000000000002c6a4c2952534b424c4f434b3a4cb4cb2ddfc37c41baf5ef6b6b4899e3253a8f1dfc7e5dd68a5b5b27005014ef0000000000000000266a24aa21a9ed5caa249f1af9fbf71c986fea8e076ca34ae3514fb2f86400561b28c7b15949bf00000000";
     
     mining_notification_result_t result = { 0 };
@@ -248,7 +300,7 @@ TEST_CASE("BIP-110 signaling last block", "[coinbase_decoder]")
     mining_notify notify = { 0 };
     notify.version = 0x20000010;  // Version with BIP-110 signaling
     notify.job_id = "test_job";
-    notify.coinbase_1 = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4b031fbc0efabe6d6d379ae882651f6469f2ed6b8b40a4f9a4b41fd838a3ad6de8cba775f4e8f1d3080100000000000000";
+    notify.coinbase_1 = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff48031fbc0efabe6d6d379ae882651f6469f2ed6b8b40a4f9a4b41fd838a3ad6de8cba775f4e8f1d3080100000000000000";
     notify.coinbase_2 = "41903d4c1b2f736c7573682f0000000003ca890d27000000001976a9147c154ed1dc59609e3d26abb2df2ea3d587cd8c4188ac00000000000000002c6a4c2952534b424c4f434b3a4cb4cb2ddfc37c41baf5ef6b6b4899e3253a8f1dfc7e5dd68a5b5b27005014ef0000000000000000266a24aa21a9ed5caa249f1af9fbf71c986fea8e076ca34ae3514fb2f86400561b28c7b15949bf00000000";
     
     mining_notification_result_t result = { 0 };
@@ -266,7 +318,7 @@ TEST_CASE("BIP-110 signaling expired", "[coinbase_decoder]")
     mining_notify notify = { 0 };
     notify.version = 0x20000010;  // Version with BIP-110 signaling
     notify.job_id = "test_job";
-    notify.coinbase_1 = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4b0320bc0efabe6d6d379ae882651f6469f2ed6b8b40a4f9a4b41fd838a3ad6de8cba775f4e8f1d3080100000000000000";
+    notify.coinbase_1 = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff480320bc0efabe6d6d379ae882651f6469f2ed6b8b40a4f9a4b41fd838a3ad6de8cba775f4e8f1d3080100000000000000";
     notify.coinbase_2 = "41903d4c1b2f736c7573682f0000000003ca890d27000000001976a9147c154ed1dc59609e3d26abb2df2ea3d587cd8c4188ac00000000000000002c6a4c2952534b424c4f434b3a4cb4cb2ddfc37c41baf5ef6b6b4899e3253a8f1dfc7e5dd68a5b5b27005014ef0000000000000000266a24aa21a9ed5caa249f1af9fbf71c986fea8e076ca34ae3514fb2f86400561b28c7b15949bf00000000";
     
     mining_notification_result_t result = { 0 };

--- a/components/stratum/test/test_mining.c
+++ b/components/stratum/test/test_mining.c
@@ -4,7 +4,19 @@
 #include "utils.h"
 
 #include <limits.h>
+#include <stdlib.h>
 #include <string.h>
+
+static bool fail_next_mining_allocation;
+
+void *stratum_mining_malloc(size_t size)
+{
+    if (fail_next_mining_allocation) {
+        fail_next_mining_allocation = false;
+        return NULL;
+    }
+    return malloc(size);
+}
 
 TEST_CASE("Check coinbase tx construction", "[mining]")
 {
@@ -13,7 +25,7 @@ TEST_CASE("Check coinbase tx construction", "[mining]")
     const char *extranonce = "e9695791";
     const char *extranonce_2 = "99999999";    
     uint8_t coinbase_tx_hash[32];
-    calculate_coinbase_tx_hash(coinbase_1, coinbase_2, extranonce, extranonce_2, coinbase_tx_hash);
+    TEST_ASSERT_TRUE(calculate_coinbase_tx_hash(coinbase_1, coinbase_2, extranonce, extranonce_2, coinbase_tx_hash));
 
     char expected_coinbase_tx[] = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff20020862062f503253482f04b8864e5008e969579199999999072f736c7573682f000000000100f2052a010000001976a914d23fcdf86f7e756a64a7a9688ef9903327048ed988ac00000000";
     size_t expected_coinbase_tx_len = strlen(expected_coinbase_tx) / 2;
@@ -26,6 +38,68 @@ TEST_CASE("Check coinbase tx construction", "[mining]")
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_coinbase_tx_hash, coinbase_tx_hash, 32);
 }
 
+TEST_CASE("Coinbase hash rejects malformed hex", "[mining]")
+{
+    static const struct {
+        const char *coinbase_1;
+        const char *coinbase_2;
+        const char *extranonce;
+        const char *extranonce_2;
+    } cases[] = {
+        {"0", "00", "00", "00"},
+        {"00", "zz", "00", "00"},
+        {"00", "00", "0g", "00"},
+        {"00", "00", "00", "000"},
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        uint8_t hash[32];
+        memset(hash, 0xA5, sizeof(hash));
+        TEST_ASSERT_FALSE(calculate_coinbase_tx_hash(cases[i].coinbase_1, cases[i].coinbase_2,
+                                                     cases[i].extranonce, cases[i].extranonce_2,
+                                                     hash));
+        for (size_t byte = 0; byte < sizeof(hash); byte++) {
+            TEST_ASSERT_EQUAL_HEX8(0xA5, hash[byte]);
+        }
+    }
+}
+
+TEST_CASE("Coinbase hash enforces the assembled transaction limit", "[mining]")
+{
+    size_t max_hex_len = MAX_COINBASE_TX_BYTES * 2;
+    char *coinbase_1 = malloc(max_hex_len + 3);
+    TEST_ASSERT_NOT_NULL(coinbase_1);
+    memset(coinbase_1, '0', max_hex_len + 2);
+    coinbase_1[max_hex_len] = '\0';
+
+    uint8_t hash[32] = {};
+    TEST_ASSERT_TRUE(calculate_coinbase_tx_hash(coinbase_1, "", "", "", hash));
+
+    coinbase_1[max_hex_len] = '0';
+    coinbase_1[max_hex_len + 1] = '0';
+    coinbase_1[max_hex_len + 2] = '\0';
+    memset(hash, 0xA5, sizeof(hash));
+    TEST_ASSERT_FALSE(calculate_coinbase_tx_hash(coinbase_1, "", "", "", hash));
+    for (size_t byte = 0; byte < sizeof(hash); byte++) {
+        TEST_ASSERT_EQUAL_HEX8(0xA5, hash[byte]);
+    }
+
+    free(coinbase_1);
+}
+
+TEST_CASE("Coinbase hash reports allocation failure", "[mining]")
+{
+    uint8_t hash[32];
+    memset(hash, 0xA5, sizeof(hash));
+    fail_next_mining_allocation = true;
+
+    TEST_ASSERT_FALSE(calculate_coinbase_tx_hash("00", "", "", "", hash));
+    TEST_ASSERT_FALSE(fail_next_mining_allocation);
+    for (size_t byte = 0; byte < sizeof(hash); byte++) {
+        TEST_ASSERT_EQUAL_HEX8(0xA5, hash[byte]);
+    }
+}
+
 // Values calculated from esp-miner/components/stratum/test/verifiers/merklecalc.py
 TEST_CASE("Validate merkle root calculation", "[mining]")
 {
@@ -34,7 +108,7 @@ TEST_CASE("Validate merkle root calculation", "[mining]")
     const char *extranonce = "00f2052a";
     const char *extranonce_2 = "01000000";
     uint8_t coinbase_tx_hash[32];
-    calculate_coinbase_tx_hash(coinbase_1, coinbase_2, extranonce, extranonce_2, coinbase_tx_hash);
+    TEST_ASSERT_TRUE(calculate_coinbase_tx_hash(coinbase_1, coinbase_2, extranonce, extranonce_2, coinbase_tx_hash));
 
     uint8_t merkles[12][32];
     int num_merkles = 12;
@@ -66,7 +140,7 @@ TEST_CASE("Validate another merkle root calculation", "[mining]")
     const char *extranonce = "603f352a";
     const char *extranonce_2 = "01000000";
     uint8_t coinbase_tx_hash[32];
-    calculate_coinbase_tx_hash(coinbase_1, coinbase_2, extranonce, extranonce_2, coinbase_tx_hash);
+    TEST_ASSERT_TRUE(calculate_coinbase_tx_hash(coinbase_1, coinbase_2, extranonce, extranonce_2, coinbase_tx_hash));
 
     uint8_t merkles[5][32];
     int num_merkles = 5;
@@ -199,12 +273,12 @@ TEST_CASE("Test nonce diff checking 2", "[mining test_nonce][not-on-qemu]")
     notify_message.ntime = 0x647025b5;
 
     uint8_t coinbase_tx_hash[32];
-    calculate_coinbase_tx_hash(
+    TEST_ASSERT_TRUE(calculate_coinbase_tx_hash(
         "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4b0389130cfabe6d6d5cbab26a2599e92916edec5657a94a0708ddb970f5c45b5d12905085617eff8e",
         "31650707758de07b010000000000001cfd7038212f736c7573682f000000000379ad0c2a000000001976a9147c154ed1dc59609e3d26abb2df2ea3d587cd8c4188ac00000000000000002c6a4c2952534b424c4f434b3ae725d3994b811572c1f345deb98b56b465ef8e153ecbbd27fa37bf1b005161380000000000000000266a24aa21a9ed63b06a7946b190a3fda1d76165b25c9b883bcc6621b040773050ee2a1bb18f1800000000",
         "01000000",
         "00000000",
-        coinbase_tx_hash);
+        coinbase_tx_hash));
     uint8_t merkles[13][32];
     int num_merkles = 13;
 

--- a/components/stratum/test/test_stratum_json.c
+++ b/components/stratum/test/test_stratum_json.c
@@ -115,6 +115,15 @@ TEST_CASE("Parse stratum mining.subscribe result malformed", "[mining.subscribe]
     TEST_ASSERT_FALSE(STRATUM_V1_parse(&stratum_api_v1_message, json_string));
 }
 
+TEST_CASE("Reject negative mining.subscribe extranonce2 length", "[mining.subscribe]")
+{
+    StratumApiV1Message stratum_api_v1_message = {};
+    const char *json_string = "{\"result\":[[[\"mining.notify\",\"695482c0\"]],\"4de05269\",-1],\"id\":2,\"error\":null}";
+
+    TEST_ASSERT_FALSE(STRATUM_V1_parse(&stratum_api_v1_message, json_string));
+    TEST_ASSERT_NULL(stratum_api_v1_message.extranonce_str);
+}
+
 TEST_CASE("Parse stratum mining.set_version_mask params", "[stratum]")
 {
     StratumApiV1Message stratum_api_v1_message = {};
@@ -262,6 +271,15 @@ TEST_CASE("Parse stratum mining.set_extranonce invalid params", "[stratum]")
     StratumApiV1Message stratum_api_v1_message = {};
     const char *json_string = "{\"id\":1,\"method\":\"mining.set_extranonce\",\"params\":[]}";
     TEST_ASSERT_FALSE(STRATUM_V1_parse(&stratum_api_v1_message, json_string));
+}
+
+TEST_CASE("Reject negative mining.set_extranonce length", "[stratum]")
+{
+    StratumApiV1Message stratum_api_v1_message = {};
+    const char *json_string = "{\"id\":1,\"method\":\"mining.set_extranonce\",\"params\":[\"deadbeef\",-1]}";
+
+    TEST_ASSERT_FALSE(STRATUM_V1_parse(&stratum_api_v1_message, json_string));
+    TEST_ASSERT_NULL(stratum_api_v1_message.extranonce_str);
 }
 
 TEST_CASE("Parse stratum client.show_message", "[stratum]")

--- a/components/stratum/test/test_stratum_json.c
+++ b/components/stratum/test/test_stratum_json.c
@@ -1,6 +1,27 @@
 #include "unity.h"
 #include "stratum_api.h"
 
+#include <stdlib.h>
+#include <string.h>
+
+#define TEST_ZERO_HASH "0000000000000000000000000000000000000000000000000000000000000000"
+
+typedef struct {
+    const char *description;
+    const char *json;
+} invalid_notify_case_t;
+
+static bool fail_next_api_strdup;
+
+char *stratum_api_strdup(const char *source)
+{
+    if (fail_next_api_strdup) {
+        fail_next_api_strdup = false;
+        return NULL;
+    }
+    return strdup(source);
+}
+
 TEST_CASE("Parse stratum method", "[stratum]")
 {
     StratumApiV1Message stratum_api_v1_message = {};
@@ -122,6 +143,18 @@ TEST_CASE("Reject negative mining.subscribe extranonce2 length", "[mining.subscr
 
     TEST_ASSERT_FALSE(STRATUM_V1_parse(&stratum_api_v1_message, json_string));
     TEST_ASSERT_NULL(stratum_api_v1_message.extranonce_str);
+}
+
+TEST_CASE("Reject mining.subscribe when extranonce allocation fails", "[mining.subscribe]")
+{
+    StratumApiV1Message message = {};
+    const char *json = "{\"result\":[[[\"mining.notify\",\"695482c0\"]],\"4de05269\",8],\"id\":2,\"error\":null}";
+    fail_next_api_strdup = true;
+
+    TEST_ASSERT_FALSE(STRATUM_V1_parse(&message, json));
+    TEST_ASSERT_FALSE(fail_next_api_strdup);
+    TEST_ASSERT_NULL(message.extranonce_str);
+    TEST_ASSERT_FALSE(message.response_success);
 }
 
 TEST_CASE("Parse stratum mining.set_version_mask params", "[stratum]")
@@ -258,28 +291,142 @@ TEST_CASE("Parse stratum invalid json or malformed parameters", "[stratum]")
 
 TEST_CASE("Reject malformed mining.notify fields", "[mining.notify]")
 {
-    const char *invalid_notifications[] = {
-        // clean_jobs is missing
-        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[],\"version\",\"nbits\",\"ntime\"]}",
-        // Each fixed string field must actually be a string
-        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[null,\"prev\",\"cb1\",\"cb2\",[],\"version\",\"nbits\",\"ntime\",false]}",
-        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",null,\"cb1\",\"cb2\",[],\"version\",\"nbits\",\"ntime\",false]}",
-        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",1,\"cb2\",[],\"version\",\"nbits\",\"ntime\",false]}",
-        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",null,[],\"version\",\"nbits\",\"ntime\",false]}",
-        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[],1,\"nbits\",\"ntime\",false]}",
-        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[],\"version\",null,\"ntime\",false]}",
-        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[],\"version\",\"nbits\",false,false]}",
-        // Merkle path must be an array containing only strings
-        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",null,\"version\",\"nbits\",\"ntime\",false]}",
-        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[null],\"version\",\"nbits\",\"ntime\",false]}",
-        // clean_jobs must be a boolean
-        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[],\"version\",\"nbits\",\"ntime\",\"false\"]}",
+    static const invalid_notify_case_t cases[] = {
+        {
+            "missing clean_jobs",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\",[],"
+            "\"20000000\",\"1d00ffff\",\"65000000\"]}",
+        },
+        {
+            "null previous block hash",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",null,\"00\",\"00\",[],"
+            "\"20000000\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "numeric coinbase prefix",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",0,\"00\",[],"
+            "\"20000000\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "null coinbase suffix",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",null,[],"
+            "\"20000000\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "non-array Merkle branches",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\",null,"
+            "\"20000000\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "non-string Merkle branch",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\",[null],"
+            "\"20000000\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "numeric version",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\",[],"
+            "1,\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "null target",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\",[],"
+            "\"20000000\",null,\"65000000\",true]}",
+        },
+        {
+            "boolean ntime",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\",[],"
+            "\"20000000\",\"1d00ffff\",false,true]}",
+        },
+        {
+            "string clean_jobs",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\",[],"
+            "\"20000000\",\"1d00ffff\",\"65000000\",\"true\"]}",
+        },
     };
 
-    for (size_t i = 0; i < sizeof(invalid_notifications) / sizeof(invalid_notifications[0]); i++) {
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
         StratumApiV1Message message = {};
-        TEST_ASSERT_FALSE(STRATUM_V1_parse(&message, invalid_notifications[i]));
-        TEST_ASSERT_NULL(message.mining_notification);
+        TEST_ASSERT_FALSE_MESSAGE(STRATUM_V1_parse(&message, cases[i].json), cases[i].description);
+        TEST_ASSERT_NULL_MESSAGE(message.mining_notification, cases[i].description);
+        STRATUM_V1_reset_message(&message);
+    }
+}
+
+TEST_CASE("Reject mining.notify fields with malformed hex", "[mining.notify]")
+{
+    static const invalid_notify_case_t cases[] = {
+        {
+            "short previous block hash",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"00\",\"00\",\"00\",[],"
+            "\"20000000\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "non-hex previous block hash",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"g000000000000000000000000000000000000000000000000000000000000000\","
+            "\"00\",\"00\",[],\"20000000\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "odd-length coinbase prefix",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"0\",\"00\",[],"
+            "\"20000000\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "non-hex coinbase suffix",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"zz\",[],"
+            "\"20000000\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "short Merkle branch",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\",[\"00\"],"
+            "\"20000000\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "non-hex Merkle branch",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\","
+            "[\"g111111111111111111111111111111111111111111111111111111111111111\"],"
+            "\"20000000\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "short version",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\",[],"
+            "\"20\",\"1d00ffff\",\"65000000\",true]}",
+        },
+        {
+            "non-hex target",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\",[],"
+            "\"20000000\",\"1d00fffz\",\"65000000\",true]}",
+        },
+        {
+            "long ntime",
+            "{\"id\":null,\"method\":\"mining.notify\",\"params\":["
+            "\"job\",\"" TEST_ZERO_HASH "\",\"00\",\"00\",[],"
+            "\"20000000\",\"1d00ffff\",\"650000000\",true]}",
+        },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        StratumApiV1Message message = {};
+        TEST_ASSERT_FALSE_MESSAGE(STRATUM_V1_parse(&message, cases[i].json), cases[i].description);
+        TEST_ASSERT_NULL_MESSAGE(message.mining_notification, cases[i].description);
+        STRATUM_V1_reset_message(&message);
     }
 }
 
@@ -307,6 +454,17 @@ TEST_CASE("Reject negative mining.set_extranonce length", "[stratum]")
 
     TEST_ASSERT_FALSE(STRATUM_V1_parse(&stratum_api_v1_message, json_string));
     TEST_ASSERT_NULL(stratum_api_v1_message.extranonce_str);
+}
+
+TEST_CASE("Reject mining.set_extranonce when allocation fails", "[mining.set_extranonce]")
+{
+    StratumApiV1Message message = {};
+    const char *json = "{\"id\":1,\"method\":\"mining.set_extranonce\",\"params\":[\"deadbeef\",8]}";
+    fail_next_api_strdup = true;
+
+    TEST_ASSERT_FALSE(STRATUM_V1_parse(&message, json));
+    TEST_ASSERT_FALSE(fail_next_api_strdup);
+    TEST_ASSERT_NULL(message.extranonce_str);
 }
 
 TEST_CASE("Parse stratum client.show_message", "[stratum]")

--- a/components/stratum/test/test_stratum_json.c
+++ b/components/stratum/test/test_stratum_json.c
@@ -256,6 +256,33 @@ TEST_CASE("Parse stratum invalid json or malformed parameters", "[stratum]")
     TEST_ASSERT_FALSE(STRATUM_V1_parse(&stratum_api_v1_message2, json_string2));
 }
 
+TEST_CASE("Reject malformed mining.notify fields", "[mining.notify]")
+{
+    const char *invalid_notifications[] = {
+        // clean_jobs is missing
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[],\"version\",\"nbits\",\"ntime\"]}",
+        // Each fixed string field must actually be a string
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[null,\"prev\",\"cb1\",\"cb2\",[],\"version\",\"nbits\",\"ntime\",false]}",
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",null,\"cb1\",\"cb2\",[],\"version\",\"nbits\",\"ntime\",false]}",
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",1,\"cb2\",[],\"version\",\"nbits\",\"ntime\",false]}",
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",null,[],\"version\",\"nbits\",\"ntime\",false]}",
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[],1,\"nbits\",\"ntime\",false]}",
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[],\"version\",null,\"ntime\",false]}",
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[],\"version\",\"nbits\",false,false]}",
+        // Merkle path must be an array containing only strings
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",null,\"version\",\"nbits\",\"ntime\",false]}",
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[null],\"version\",\"nbits\",\"ntime\",false]}",
+        // clean_jobs must be a boolean
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"prev\",\"cb1\",\"cb2\",[],\"version\",\"nbits\",\"ntime\",\"false\"]}",
+    };
+
+    for (size_t i = 0; i < sizeof(invalid_notifications) / sizeof(invalid_notifications[0]); i++) {
+        StratumApiV1Message message = {};
+        TEST_ASSERT_FALSE(STRATUM_V1_parse(&message, invalid_notifications[i]));
+        TEST_ASSERT_NULL(message.mining_notification);
+    }
+}
+
 TEST_CASE("Parse stratum mining.set_extranonce params", "[stratum]")
 {
     StratumApiV1Message stratum_api_v1_message = {};

--- a/components/stratum/test/test_stratum_receive.c
+++ b/components/stratum/test/test_stratum_receive.c
@@ -1,0 +1,143 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_transport.h"
+#include "stratum_api.h"
+#include "unity.h"
+
+typedef struct
+{
+    const char * data;
+    size_t length;
+    size_t offset;
+    size_t max_chunk;
+} mock_transport_data_t;
+
+static int mock_transport_read(esp_transport_handle_t transport, char * buffer, int len, int timeout_ms)
+{
+    (void) timeout_ms;
+    mock_transport_data_t * mock = esp_transport_get_context_data(transport);
+    if (mock->offset >= mock->length) {
+        return ERR_TCP_TRANSPORT_CONNECTION_CLOSED_BY_FIN;
+    }
+
+    size_t bytes_to_copy = mock->length - mock->offset;
+    if (bytes_to_copy > (size_t) len) {
+        bytes_to_copy = (size_t) len;
+    }
+    if (mock->max_chunk > 0 && bytes_to_copy > mock->max_chunk) {
+        bytes_to_copy = mock->max_chunk;
+    }
+
+    memcpy(buffer, mock->data + mock->offset, bytes_to_copy);
+    mock->offset += bytes_to_copy;
+    return (int) bytes_to_copy;
+}
+
+static esp_transport_handle_t create_mock_transport(mock_transport_data_t * mock)
+{
+    esp_transport_handle_t transport = esp_transport_init();
+    if (transport == NULL) {
+        return NULL;
+    }
+
+    if (esp_transport_set_context_data(transport, mock) != ESP_OK ||
+        esp_transport_set_func(transport, NULL, mock_transport_read, NULL, NULL, NULL, NULL, NULL) != ESP_OK) {
+        esp_transport_destroy(transport);
+        return NULL;
+    }
+
+    return transport;
+}
+
+TEST_CASE("SV1 receive buffer handles fragmented and batched lines", "[stratum][receive]")
+{
+    const char * input = "first\nsecond line\nthird\n";
+    mock_transport_data_t mock = {
+        .data = input,
+        .length = strlen(input),
+        .max_chunk = 4,
+    };
+    esp_transport_handle_t transport = create_mock_transport(&mock);
+    TEST_ASSERT_NOT_NULL(transport);
+    TEST_ASSERT_TRUE(STRATUM_V1_initialize_buffer());
+
+    char * line = STRATUM_V1_receive_jsonrpc_line(transport);
+    TEST_ASSERT_EQUAL_STRING("first", line);
+    free(line);
+
+    line = STRATUM_V1_receive_jsonrpc_line(transport);
+    TEST_ASSERT_EQUAL_STRING("second line", line);
+    free(line);
+
+    line = STRATUM_V1_receive_jsonrpc_line(transport);
+    TEST_ASSERT_EQUAL_STRING("third", line);
+    free(line);
+
+    STRATUM_V1_cleanup_buffer();
+    esp_transport_destroy(transport);
+}
+
+TEST_CASE("SV1 receive buffer accepts the maximum line size", "[stratum][receive]")
+{
+    char * input = malloc(STRATUM_V1_MAX_JSON_LINE_SIZE + 2);
+    TEST_ASSERT_NOT_NULL(input);
+    memset(input, 'a', STRATUM_V1_MAX_JSON_LINE_SIZE);
+    input[STRATUM_V1_MAX_JSON_LINE_SIZE] = '\n';
+    input[STRATUM_V1_MAX_JSON_LINE_SIZE + 1] = '\0';
+
+    mock_transport_data_t mock = {
+        .data = input,
+        .length = STRATUM_V1_MAX_JSON_LINE_SIZE + 1,
+        .max_chunk = 251,
+    };
+    esp_transport_handle_t transport = create_mock_transport(&mock);
+    TEST_ASSERT_NOT_NULL(transport);
+    TEST_ASSERT_TRUE(STRATUM_V1_initialize_buffer());
+
+    char * line = STRATUM_V1_receive_jsonrpc_line(transport);
+    TEST_ASSERT_NOT_NULL(line);
+    TEST_ASSERT_EQUAL_UINT32(STRATUM_V1_MAX_JSON_LINE_SIZE, strlen(line));
+
+    free(line);
+    free(input);
+    STRATUM_V1_cleanup_buffer();
+    esp_transport_destroy(transport);
+}
+
+TEST_CASE("SV1 receive buffer rejects oversized lines and recovers", "[stratum][receive]")
+{
+    char * oversized = malloc(STRATUM_V1_MAX_JSON_LINE_SIZE + 3);
+    TEST_ASSERT_NOT_NULL(oversized);
+    memset(oversized, 'a', STRATUM_V1_MAX_JSON_LINE_SIZE + 1);
+    oversized[STRATUM_V1_MAX_JSON_LINE_SIZE + 1] = '\n';
+    oversized[STRATUM_V1_MAX_JSON_LINE_SIZE + 2] = '\0';
+
+    mock_transport_data_t oversized_mock = {
+        .data = oversized,
+        .length = STRATUM_V1_MAX_JSON_LINE_SIZE + 2,
+        .max_chunk = 257,
+    };
+    esp_transport_handle_t oversized_transport = create_mock_transport(&oversized_mock);
+    TEST_ASSERT_NOT_NULL(oversized_transport);
+    TEST_ASSERT_TRUE(STRATUM_V1_initialize_buffer());
+
+    TEST_ASSERT_NULL(STRATUM_V1_receive_jsonrpc_line(oversized_transport));
+    esp_transport_destroy(oversized_transport);
+    free(oversized);
+
+    const char * valid = "valid\n";
+    mock_transport_data_t valid_mock = {
+        .data = valid,
+        .length = strlen(valid),
+    };
+    esp_transport_handle_t valid_transport = create_mock_transport(&valid_mock);
+    TEST_ASSERT_NOT_NULL(valid_transport);
+
+    char * line = STRATUM_V1_receive_jsonrpc_line(valid_transport);
+    TEST_ASSERT_EQUAL_STRING("valid", line);
+
+    free(line);
+    STRATUM_V1_cleanup_buffer();
+    esp_transport_destroy(valid_transport);
+}

--- a/components/stratum/test/test_stratum_receive.c
+++ b/components/stratum/test/test_stratum_receive.c
@@ -78,6 +78,40 @@ TEST_CASE("SV1 receive buffer handles fragmented and batched lines", "[stratum][
     esp_transport_destroy(transport);
 }
 
+TEST_CASE("SV1 receive buffer discards a previous session tail", "[stratum][receive]")
+{
+    const char *first_input = "first\nstale\n";
+    mock_transport_data_t first_mock = {
+        .data = first_input,
+        .length = strlen(first_input),
+    };
+    esp_transport_handle_t first_transport = create_mock_transport(&first_mock);
+    TEST_ASSERT_NOT_NULL(first_transport);
+    TEST_ASSERT_TRUE(STRATUM_V1_initialize_buffer());
+
+    char *line = STRATUM_V1_receive_jsonrpc_line(first_transport);
+    TEST_ASSERT_EQUAL_STRING("first", line);
+    free(line);
+
+    STRATUM_V1_reset_buffer();
+
+    const char *second_input = "fresh\n";
+    mock_transport_data_t second_mock = {
+        .data = second_input,
+        .length = strlen(second_input),
+    };
+    esp_transport_handle_t second_transport = create_mock_transport(&second_mock);
+    TEST_ASSERT_NOT_NULL(second_transport);
+
+    line = STRATUM_V1_receive_jsonrpc_line(second_transport);
+    TEST_ASSERT_EQUAL_STRING("fresh", line);
+    free(line);
+
+    STRATUM_V1_cleanup_buffer();
+    esp_transport_destroy(first_transport);
+    esp_transport_destroy(second_transport);
+}
+
 TEST_CASE("SV1 receive buffer accepts the maximum line size", "[stratum][receive]")
 {
     char * input = malloc(STRATUM_V1_MAX_JSON_LINE_SIZE + 2);

--- a/main/tasks/create_jobs_task.c
+++ b/main/tasks/create_jobs_task.c
@@ -190,8 +190,9 @@ void create_jobs_task(void *pvParameters)
 
 static void generate_work(GlobalState *GLOBAL_STATE, mining_notify *notification, uint64_t extranonce_2, double difficulty)
 {
-    if (GLOBAL_STATE->extranonce_2_len > MAX_EXTRANONCE2_LEN) {
-        ESP_LOGE(TAG, "extranonce_2_len %d exceeds maximum %d, skipping job", GLOBAL_STATE->extranonce_2_len, MAX_EXTRANONCE2_LEN);
+    if (GLOBAL_STATE->extranonce_2_len < 0 || GLOBAL_STATE->extranonce_2_len > MAX_EXTRANONCE2_LEN) {
+        ESP_LOGE(TAG, "Invalid extranonce_2_len %d (expected 0-%d), skipping job",
+                 GLOBAL_STATE->extranonce_2_len, MAX_EXTRANONCE2_LEN);
         return;
     }
     char extranonce_2_str[MAX_EXTRANONCE2_STR];

--- a/main/tasks/create_jobs_task.c
+++ b/main/tasks/create_jobs_task.c
@@ -199,7 +199,12 @@ static void generate_work(GlobalState *GLOBAL_STATE, mining_notify *notification
     extranonce_2_generate(extranonce_2, GLOBAL_STATE->extranonce_2_len, extranonce_2_str);
 
     uint8_t coinbase_tx_hash[32];
-    calculate_coinbase_tx_hash(notification->coinbase_1, notification->coinbase_2, GLOBAL_STATE->extranonce_str, extranonce_2_str, coinbase_tx_hash);
+    if (!calculate_coinbase_tx_hash(notification->coinbase_1, notification->coinbase_2,
+                                    GLOBAL_STATE->extranonce_str, extranonce_2_str,
+                                    coinbase_tx_hash)) {
+        ESP_LOGE(TAG, "Invalid or oversized coinbase transaction, skipping job");
+        return;
+    }
 
     uint8_t merkle_root[32];
     calculate_merkle_root_hash(coinbase_tx_hash, (uint8_t(*)[32])notification->merkle_branches, notification->n_merkle_branches, merkle_root);

--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -179,7 +179,12 @@ void stratum_v1_task(void *pvParameters)
     // Set V1-specific free function for the work queue
     GLOBAL_STATE->stratum_queue.free_fn = (void (*)(void *))STRATUM_V1_free_mining_notify;
 
-    STRATUM_V1_initialize_buffer();
+    if (!STRATUM_V1_initialize_buffer()) {
+        ESP_LOGE(TAG, "Failed to initialize Stratum V1 receive state, notifying coordinator");
+        protocol_coordinator_notify_failure();
+        vTaskDelete(NULL);
+        return;
+    }
     int retry_attempts = 0;
     int retry_critical_attempts = 0;
 
@@ -188,8 +193,10 @@ void stratum_v1_task(void *pvParameters)
         // Check if coordinator wants us to shut down
         if (protocol_coordinator_v1_should_shutdown()) {
             ESP_LOGI(TAG, "Coordinator requested shutdown, exiting");
+            STRATUM_V1_cleanup_buffer();
             protocol_coordinator_v1_exited();
             vTaskDelete(NULL);
+            return;
         }
 
         if (!GLOBAL_STATE->ASIC_initalized) {
@@ -210,6 +217,7 @@ void stratum_v1_task(void *pvParameters)
             // recovery — see protocol_coordinator.c.
             ESP_LOGW(TAG, "Max V1 retry attempts reached (%d), notifying coordinator", retry_attempts);
             stratum_v1_close_connection(GLOBAL_STATE);
+            STRATUM_V1_cleanup_buffer();
             protocol_coordinator_notify_failure();
             vTaskDelete(NULL);
             return;
@@ -305,8 +313,10 @@ void stratum_v1_task(void *pvParameters)
             if (protocol_coordinator_v1_should_shutdown()) {
                 ESP_LOGI(TAG, "Coordinator requested shutdown during recv loop, exiting");
                 stratum_v1_close_connection(GLOBAL_STATE);
+                STRATUM_V1_cleanup_buffer();
                 protocol_coordinator_v1_exited();
                 vTaskDelete(NULL);
+                return;
             }
 
             char *line = STRATUM_V1_receive_jsonrpc_line(GLOBAL_STATE->transport);

--- a/main/tasks/stratum_v1_task.c
+++ b/main/tasks/stratum_v1_task.c
@@ -74,6 +74,7 @@ void stratum_v1_close_connection(GlobalState *GLOBAL_STATE)
     if (transport != NULL) {
         esp_transport_close(transport);
     }
+    STRATUM_V1_reset_buffer();
     SYSTEM_clean_jobs_queue(GLOBAL_STATE);
     vTaskDelay(1000 / portTICK_PERIOD_MS);
 }
@@ -179,7 +180,7 @@ void stratum_v1_task(void *pvParameters)
     // Set V1-specific free function for the work queue
     GLOBAL_STATE->stratum_queue.free_fn = (void (*)(void *))STRATUM_V1_free_mining_notify;
 
-    if (!STRATUM_V1_initialize_buffer()) {
+    if (!STRATUM_V1_initialize()) {
         ESP_LOGE(TAG, "Failed to initialize Stratum V1 receive state, notifying coordinator");
         protocol_coordinator_notify_failure();
         vTaskDelete(NULL);


### PR DESCRIPTION
## Summary

This hardens the Stratum V1 network receive and parsing paths against malformed or unbounded pool input.

- Reject negative `extranonce2_size` values from `mining.subscribe` and `mining.set_extranonce`, and validate the range again before generating work.
- Validate all required `mining.notify` fields and Merkle branch elements before dereferencing them, and handle every allocation failure with complete cleanup.
- Require the canonical nine `mining.notify` parameters while preserving compatibility with pools that insert extension fields before the final `clean_jobs` Boolean.
- Replace repeated `strlen`/`strncat` receive-buffer growth with explicit length tracking, `memcpy`, and linear scanning.
- Limit a Stratum V1 JSON-RPC line to 8 KiB so an unterminated network message cannot grow the heap without bound.
- Return initialization/allocation failures to the Stratum task and notify the protocol coordinator before the task exits, preventing it from remaining stuck in a running state.

## Why

Stratum V1 messages are controlled by the connected pool and were previously trusted in several memory-sensitive paths. A negative extranonce length could be converted to a very large unsigned size during work generation, malformed `mining.notify` fields could reach string and allocation operations with invalid pointers, and a connection that never sent a newline could force unbounded heap growth. These checks make those inputs fail closed without corrupting memory or silently leaving the protocol coordinator in the wrong state.

## Compatibility

The parser accepts the standard Bitcoin Stratum V1 `mining.notify` layout and retains the existing variable-length compatibility behavior used by ckpool-style messages, where `clean_jobs` remains the final parameter.

## Testing

- Built the Stratum component unit-test firmware with ESP-IDF v5.5.1.
- Built the complete ESP-Miner firmware, including Axe-OS.
- Added receive-buffer tests covering fragmented input, multiple newline-delimited messages in one read, the exact 8 KiB boundary, oversized-line rejection, and recovery.
- Added malformed JSON tests for negative extranonce lengths and invalid `mining.notify` field types.
- Flashed and tested on a bitaxeGamma 601 against both public-pool.io and ckpool.
