### PR TITLE
Harden API and WebSocket receive paths

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -74,6 +74,30 @@ static int system_statistics_prebuffer_len = 256;
 static int system_wifi_scan_prebuffer_len = 256;
 static int api_common_prebuffer_len = 256;
 
+esp_err_t HTTP_receive_body(httpd_req_t *req, char *buffer, size_t buffer_size)
+{
+    if (req == NULL || buffer == NULL || buffer_size == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const size_t content_len = req->content_len;
+    if (content_len == 0 || content_len >= buffer_size) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    size_t received_len = 0;
+    while (received_len < content_len) {
+        int received = httpd_req_recv(req, buffer + received_len, content_len - received_len);
+        if (received <= 0) {
+            return ESP_FAIL;
+        }
+        received_len += (size_t)received;
+    }
+
+    buffer[received_len] = '\0';
+    return ESP_OK;
+}
+
 typedef enum
 {
     SRC_HASHRATE,
@@ -1043,25 +1067,16 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
         return ESP_OK;
     }
 
-    int total_len = req->content_len;
-    int cur_len = 0;
     char * buf = ((rest_server_context_t *) (req->user_ctx))->scratch;
-    int received = 0;
-    if (total_len >= SCRATCH_BUFSIZE) {
-        /* Respond with 500 Internal Server Error */
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "content too long");
-        return ESP_OK;
+    esp_err_t receive_result = HTTP_receive_body(req, buf, SCRATCH_BUFSIZE);
+    if (receive_result == ESP_ERR_INVALID_SIZE) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid request length");
+        return ESP_FAIL;
     }
-    while (cur_len < total_len) {
-        received = httpd_req_recv(req, buf + cur_len, total_len);
-        if (received <= 0) {
-            /* Respond with 500 Internal Server Error */
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to post control value");
-            return ESP_OK;
-        }
-        cur_len += received;
+    if (receive_result != ESP_OK) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to receive request data");
+        return ESP_FAIL;
     }
-    buf[total_len] = '\0';
 
     cJSON * root = cJSON_Parse(buf);
     if (root == NULL) {
@@ -1246,17 +1261,16 @@ static esp_err_t PUT_system_pool(httpd_req_t *req)
         return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid pool index");
     }
 
-    int total_len = req->content_len;
-    if (total_len <= 0 || total_len >= SCRATCH_BUFSIZE) {
-        return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid request length");
-    }
-
     char *buf = ((rest_server_context_t *)(req->user_ctx))->scratch;
-    int received = httpd_req_recv(req, buf, total_len);
-    if (received <= 0) {
-        return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to receive request data");
+    esp_err_t receive_result = HTTP_receive_body(req, buf, SCRATCH_BUFSIZE);
+    if (receive_result == ESP_ERR_INVALID_SIZE) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid request length");
+        return ESP_FAIL;
     }
-    buf[received] = '\0';
+    if (receive_result != ESP_OK) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to receive request data");
+        return ESP_FAIL;
+    }
 
     cJSON *root = cJSON_Parse(buf);
     if (!root) {
@@ -1428,25 +1442,18 @@ static esp_err_t POST_system_boot(httpd_req_t *req)
         return ESP_OK;
     }
 
-    size_t total_len = req->content_len;
-    if (total_len == 0) {
-        return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Empty request body");
+    char *buf = ((rest_server_context_t *)(req->user_ctx))->scratch;
+    esp_err_t receive_result = HTTP_receive_body(req, buf, SCRATCH_BUFSIZE);
+    if (receive_result == ESP_ERR_INVALID_SIZE) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid request length");
+        return ESP_FAIL;
     }
-
-    char *buf = malloc(total_len + 1);
-    if (!buf) {
-        return httpd_resp_send_500(req);
+    if (receive_result != ESP_OK) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
     }
-
-    int ret = httpd_req_recv(req, buf, total_len);
-    if (ret <= 0) {
-        free(buf);
-        return httpd_resp_send_500(req);
-    }
-    buf[ret] = '\0';
 
     cJSON *root = cJSON_Parse(buf);
-    free(buf);
     if (!root) {
         return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid JSON");
     }

--- a/main/http_server/http_server.h
+++ b/main/http_server/http_server.h
@@ -11,5 +11,6 @@ esp_err_t is_network_allowed(httpd_req_t * req);
 esp_err_t set_cors_headers(httpd_req_t * req);
 esp_err_t start_rest_server(GlobalState * GLOBAL_STATE);
 esp_err_t HTTP_send_json(httpd_req_t * req, const cJSON * item, int * prebuffer_len);
+esp_err_t HTTP_receive_body(httpd_req_t *req, char *buffer, size_t buffer_size);
 
 #endif /* HTTP_SERVER_H_ */

--- a/main/http_server/theme_api.c
+++ b/main/http_server/theme_api.c
@@ -47,12 +47,15 @@ static esp_err_t theme_post_handler(httpd_req_t *req)
 
     // Read POST data
     char content[1024];
-    int ret = httpd_req_recv(req, content, sizeof(content) - 1);
-    if (ret <= 0) {
+    esp_err_t receive_result = HTTP_receive_body(req, content, sizeof(content));
+    if (receive_result == ESP_ERR_INVALID_SIZE) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid request length");
+        return ESP_FAIL;
+    }
+    if (receive_result != ESP_OK) {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to read request");
         return ESP_FAIL;
     }
-    content[ret] = '\0';
 
     cJSON *root = cJSON_Parse(content);
     if (!root) {

--- a/main/http_server/websocket.c
+++ b/main/http_server/websocket.c
@@ -12,6 +12,7 @@
 #include "log_buffer.h"
 
 #define WS_LOG_SCRATCH_SIZE 2048
+#define WS_RX_MAX_PAYLOAD_SIZE 1024
 
 static const char * TAG = "websocket";
 
@@ -215,15 +216,18 @@ esp_err_t websocket_handler(httpd_req_t *req)
         return ret;
     }
 
-    // If there's a payload, drain it
+    // Inbound application data is ignored, but it must be drained to keep the
+    // WebSocket stream synchronized. Never allocate based on a peer-provided
+    // frame length.
     if (ws_pkt.len > 0) {
-        uint8_t *buf = (uint8_t *)calloc(1, ws_pkt.len + 1);
-        if (buf) {
-            ws_pkt.payload = buf;
-            ret = httpd_ws_recv_frame(req, &ws_pkt, ws_pkt.len);
-            free(buf);
-            return ret;
+        if (ws_pkt.len > WS_RX_MAX_PAYLOAD_SIZE) {
+            ESP_LOGW(TAG, "Rejecting oversized WebSocket frame: %zu bytes", ws_pkt.len);
+            return ESP_ERR_INVALID_SIZE;
         }
+
+        uint8_t buf[WS_RX_MAX_PAYLOAD_SIZE];
+        ws_pkt.payload = buf;
+        return httpd_ws_recv_frame(req, &ws_pkt, sizeof(buf));
     }
 
     return ESP_OK;


### PR DESCRIPTION
## Summary

Harden inbound HTTP API and WebSocket handling against oversized, fragmented, and malformed client input.

- Add a bounded HTTP body receive helper alongside the existing HTTP server code.
- Keep request lengths as `size_t`, require space for the terminating NUL, and reject zero or oversized JSON bodies.
- Use the bounded receive path for system settings, pool settings, boot selection, and theme updates.
- Replace peer-sized WebSocket heap allocation with a fixed 1 KiB stack buffer.
- Reject oversized WebSocket frames so ESP-IDF closes and cleans up the session.

## Why

`PATCH /api/system` previously narrowed the network-controlled `req->content_len` from `size_t` to `int`. On ESP32, a value such as `4294967294` becomes `-2`, bypasses the upper-bound check, and reaches `buf[total_len] = '\0'`, producing an out-of-bounds write before a request body is required.

Several JSON handlers also called `httpd_req_recv()` only once, so ordinary TCP fragmentation could produce partial JSON parsing and leave request data unread. The WebSocket handler allocated `frame_length + 1` bytes without an application-level maximum, allowing a client to consume heap or leave the stream unsynchronized after allocation failure.

## Validation

### Build

- ESP-IDF v5.5.1 firmware build: `idf.py build`
- `git diff --check`

### Hardware testing

Flashed the resulting firmware over USB to a physical bitaxeGamma 601 with one BM1370 and monitored the serial console throughout the tests.

The miner booted normally, joined Wi-Fi, reached its configured 525 MHz frequency, connected to CKPool, received new work, and continued submitting accepted shares during and after the malformed API traffic. At the end of the test it was hashing at approximately 1.09 TH/s with 29 accepted shares, zero rejected shares, approximately 7.65 MB free heap, and no panic, watchdog reset, allocation failure, or unexpected reboot in the serial log.

Live API cases exercised against the device included:

- Baseline system-info and theme requests returned HTTP 200.
- A valid theme body split across several TCP writes returned HTTP 200.
- A 10,239-byte settings body split into 137-byte writes was fully received and returned HTTP 200.
- Settings lengths of 10,240 and `4294967294` were safely rejected; the device remained healthy and the next system-info request returned HTTP 200.
- A normal WebSocket connection completed the HTTP 101 upgrade and remained active.
- A masked 1,025-byte WebSocket frame was rejected and its client session was removed.
- A WebSocket frame declaring the 64-bit length `0xffffffff` was rejected and its client session was removed.
- A final API health check returned HTTP 200 while mining continued.

## ESP-IDF limitation

ESP-IDF v5.5.1 stores the protocol's 64-bit WebSocket payload length in the ESP32's 32-bit `size_t`. This change enforces a strict application limit on the parsed value and removes all peer-sized allocation, but an encoded value above 32 bits that truncates to a small value cannot be distinguished in application code. Rejecting that form before narrowing requires a corresponding ESP-IDF parser change.
