### PR TITLE
Restrict API access to LAN peers and origins

### DIFF
--- a/components/api_rx/CMakeLists.txt
+++ b/components/api_rx/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "api_rx.c"
+    INCLUDE_DIRS "include"
+    PRIV_REQUIRES lwip
+)

--- a/components/api_rx/api_rx.c
+++ b/components/api_rx/api_rx.c
@@ -99,16 +99,30 @@ static bool api_rx_local_hostname_is_valid(const char *host)
         return false;
     }
 
-    for (const unsigned char *p = (const unsigned char *)host; *p != '\0'; p++) {
-        if (!isalnum(*p) && *p != '-' && *p != '.') {
-            return false;
-        }
+    size_t host_len = strlen(host);
+    if (host_len > 253) {
+        return false;
     }
 
-    size_t host_len = strlen(host);
-    if (host[0] == '.' || host[0] == '-' ||
-        host[host_len - 1] == '.' || host[host_len - 1] == '-') {
-        return false;
+    const unsigned char *label = (const unsigned char *)host;
+    for (const unsigned char *p = label;; p++) {
+        if (*p != '\0' && *p != '.') {
+            if (!isalnum(*p) && *p != '-') {
+                return false;
+            }
+            continue;
+        }
+
+        size_t label_len = (size_t)(p - label);
+        if (label_len == 0 || label_len > 63 ||
+            label[0] == '-' || label[label_len - 1] == '-') {
+            return false;
+        }
+
+        if (*p == '\0') {
+            break;
+        }
+        label = p + 1;
     }
 
     if (strchr(host, '.') == NULL) {

--- a/components/api_rx/api_rx.c
+++ b/components/api_rx/api_rx.c
@@ -7,38 +7,6 @@
 
 #include "api_rx.h"
 
-bool api_rx_websocket_payload_fits(size_t payload_len)
-{
-    return payload_len <= API_RX_MAX_WEBSOCKET_PAYLOAD_SIZE;
-}
-
-bool api_rx_websocket_origin_matches_host(const char *origin, const char *host)
-{
-    if (origin == NULL || host == NULL || host[0] == '\0') {
-        return false;
-    }
-
-    const char *authority = NULL;
-    static const char http_prefix[] = "http://";
-    static const char https_prefix[] = "https://";
-
-    if (strncasecmp(origin, http_prefix, sizeof(http_prefix) - 1) == 0) {
-        authority = origin + sizeof(http_prefix) - 1;
-    } else if (strncasecmp(origin, https_prefix, sizeof(https_prefix) - 1) == 0) {
-        authority = origin + sizeof(https_prefix) - 1;
-    } else {
-        return false;
-    }
-
-    size_t authority_len = strcspn(authority, "/?#");
-    if (authority_len == 0 || authority[authority_len] != '\0') {
-        return false;
-    }
-
-    size_t host_len = strlen(host);
-    return authority_len == host_len && strncasecmp(authority, host, host_len) == 0;
-}
-
 bool api_rx_ipv4_address_is_lan(const unsigned char address[4])
 {
     if (address == NULL) {

--- a/components/api_rx/api_rx.c
+++ b/components/api_rx/api_rx.c
@@ -1,7 +1,9 @@
-#include <arpa/inet.h>
 #include <ctype.h>
 #include <string.h>
 #include <strings.h>
+
+#include "lwip/inet.h"
+#include "lwip/sockets.h"
 
 #include "api_rx.h"
 

--- a/components/api_rx/api_rx.c
+++ b/components/api_rx/api_rx.c
@@ -1,0 +1,185 @@
+#include <arpa/inet.h>
+#include <ctype.h>
+#include <string.h>
+#include <strings.h>
+
+#include "api_rx.h"
+
+bool api_rx_websocket_payload_fits(size_t payload_len)
+{
+    return payload_len <= API_RX_MAX_WEBSOCKET_PAYLOAD_SIZE;
+}
+
+bool api_rx_websocket_origin_matches_host(const char *origin, const char *host)
+{
+    if (origin == NULL || host == NULL || host[0] == '\0') {
+        return false;
+    }
+
+    const char *authority = NULL;
+    static const char http_prefix[] = "http://";
+    static const char https_prefix[] = "https://";
+
+    if (strncasecmp(origin, http_prefix, sizeof(http_prefix) - 1) == 0) {
+        authority = origin + sizeof(http_prefix) - 1;
+    } else if (strncasecmp(origin, https_prefix, sizeof(https_prefix) - 1) == 0) {
+        authority = origin + sizeof(https_prefix) - 1;
+    } else {
+        return false;
+    }
+
+    size_t authority_len = strcspn(authority, "/?#");
+    if (authority_len == 0 || authority[authority_len] != '\0') {
+        return false;
+    }
+
+    size_t host_len = strlen(host);
+    return authority_len == host_len && strncasecmp(authority, host, host_len) == 0;
+}
+
+bool api_rx_ipv4_address_is_lan(const unsigned char address[4])
+{
+    if (address == NULL) {
+        return false;
+    }
+
+    return address[0] == 10 ||
+           (address[0] == 172 && address[1] >= 16 && address[1] <= 31) ||
+           (address[0] == 192 && address[1] == 168) ||
+           address[0] == 127 ||
+           (address[0] == 169 && address[1] == 254);
+}
+
+bool api_rx_ipv6_address_is_lan(const unsigned char address[16])
+{
+    if (address == NULL) {
+        return false;
+    }
+
+    static const unsigned char ipv4_mapped_prefix[12] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff
+    };
+    static const unsigned char loopback[16] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+    };
+
+    if (memcmp(address, ipv4_mapped_prefix, sizeof(ipv4_mapped_prefix)) == 0) {
+        return api_rx_ipv4_address_is_lan(address + sizeof(ipv4_mapped_prefix));
+    }
+
+    return (address[0] & 0xfeU) == 0xfcU ||
+           (address[0] == 0xfeU && (address[1] & 0xc0U) == 0x80U) ||
+           memcmp(address, loopback, sizeof(loopback)) == 0;
+}
+
+static bool api_rx_origin_port_is_valid(const char *port)
+{
+    if (port == NULL || *port == '\0') {
+        return false;
+    }
+
+    unsigned long value = 0;
+    for (const unsigned char *p = (const unsigned char *)port; *p != '\0'; p++) {
+        if (!isdigit(*p)) {
+            return false;
+        }
+        value = value * 10UL + (unsigned long)(*p - '0');
+        if (value > 65535UL) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool api_rx_local_hostname_is_valid(const char *host)
+{
+    if (host == NULL || *host == '\0') {
+        return false;
+    }
+
+    for (const unsigned char *p = (const unsigned char *)host; *p != '\0'; p++) {
+        if (!isalnum(*p) && *p != '-' && *p != '.') {
+            return false;
+        }
+    }
+
+    size_t host_len = strlen(host);
+    if (host[0] == '.' || host[0] == '-' ||
+        host[host_len - 1] == '.' || host[host_len - 1] == '-') {
+        return false;
+    }
+
+    if (strchr(host, '.') == NULL) {
+        return true;
+    }
+
+    static const char local_suffix[] = ".local";
+    size_t suffix_len = sizeof(local_suffix) - 1;
+    return host_len > suffix_len &&
+           strcasecmp(host + host_len - suffix_len, local_suffix) == 0;
+}
+
+bool api_rx_origin_is_lan(const char *origin)
+{
+    if (origin == NULL) {
+        return false;
+    }
+
+    const char *authority = NULL;
+    static const char http_prefix[] = "http://";
+    static const char https_prefix[] = "https://";
+
+    if (strncasecmp(origin, http_prefix, sizeof(http_prefix) - 1) == 0) {
+        authority = origin + sizeof(http_prefix) - 1;
+    } else if (strncasecmp(origin, https_prefix, sizeof(https_prefix) - 1) == 0) {
+        authority = origin + sizeof(https_prefix) - 1;
+    } else {
+        return false;
+    }
+
+    size_t authority_len = strcspn(authority, "/?#");
+    if (authority_len == 0 || authority[authority_len] != '\0' ||
+        authority_len >= 256 || memchr(authority, '@', authority_len) != NULL) {
+        return false;
+    }
+
+    char host[256];
+    if (authority[0] == '[') {
+        const char *closing_bracket = memchr(authority, ']', authority_len);
+        if (closing_bracket == NULL) {
+            return false;
+        }
+
+        size_t host_len = (size_t)(closing_bracket - authority - 1);
+        const char *remainder = closing_bracket + 1;
+        if (host_len == 0 || host_len >= sizeof(host) ||
+            (*remainder != '\0' &&
+             (*remainder != ':' || !api_rx_origin_port_is_valid(remainder + 1)))) {
+            return false;
+        }
+
+        memcpy(host, authority + 1, host_len);
+        host[host_len] = '\0';
+
+        unsigned char ipv6[16];
+        return inet_pton(AF_INET6, host, ipv6) == 1 &&
+               api_rx_ipv6_address_is_lan(ipv6);
+    }
+
+    const char *colon = memchr(authority, ':', authority_len);
+    size_t host_len = colon ? (size_t)(colon - authority) : authority_len;
+    if (host_len == 0 || host_len >= sizeof(host) ||
+        (colon != NULL && !api_rx_origin_port_is_valid(colon + 1))) {
+        return false;
+    }
+
+    memcpy(host, authority, host_len);
+    host[host_len] = '\0';
+
+    unsigned char ipv4[4];
+    if (inet_pton(AF_INET, host, ipv4) == 1) {
+        return api_rx_ipv4_address_is_lan(ipv4);
+    }
+
+    return api_rx_local_hostname_is_valid(host);
+}

--- a/components/api_rx/include/api_rx.h
+++ b/components/api_rx/include/api_rx.h
@@ -1,0 +1,15 @@
+#ifndef API_RX_H_
+#define API_RX_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#define API_RX_MAX_WEBSOCKET_PAYLOAD_SIZE 1024U
+
+bool api_rx_websocket_payload_fits(size_t payload_len);
+bool api_rx_websocket_origin_matches_host(const char *origin, const char *host);
+bool api_rx_ipv4_address_is_lan(const unsigned char address[4]);
+bool api_rx_ipv6_address_is_lan(const unsigned char address[16]);
+bool api_rx_origin_is_lan(const char *origin);
+
+#endif /* API_RX_H_ */

--- a/components/api_rx/include/api_rx.h
+++ b/components/api_rx/include/api_rx.h
@@ -2,12 +2,7 @@
 #define API_RX_H_
 
 #include <stdbool.h>
-#include <stddef.h>
 
-#define API_RX_MAX_WEBSOCKET_PAYLOAD_SIZE 1024U
-
-bool api_rx_websocket_payload_fits(size_t payload_len);
-bool api_rx_websocket_origin_matches_host(const char *origin, const char *host);
 bool api_rx_ipv4_address_is_lan(const unsigned char address[4]);
 bool api_rx_ipv6_address_is_lan(const unsigned char address[16]);
 bool api_rx_origin_is_lan(const char *origin);

--- a/components/api_rx/test/CMakeLists.txt
+++ b/components/api_rx/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "test_api_rx.c"
+    INCLUDE_DIRS "."
+    REQUIRES unity api_rx
+)

--- a/components/api_rx/test/test_api_rx.c
+++ b/components/api_rx/test/test_api_rx.c
@@ -1,57 +1,5 @@
-#include <stdint.h>
-
 #include "api_rx.h"
 #include "unity.h"
-
-TEST_CASE("WebSocket payload limit has strict boundary", "[api_rx]")
-{
-    TEST_ASSERT_TRUE(api_rx_websocket_payload_fits(0));
-    TEST_ASSERT_TRUE(api_rx_websocket_payload_fits(API_RX_MAX_WEBSOCKET_PAYLOAD_SIZE));
-    TEST_ASSERT_FALSE(api_rx_websocket_payload_fits(API_RX_MAX_WEBSOCKET_PAYLOAD_SIZE + 1U));
-    TEST_ASSERT_FALSE(api_rx_websocket_payload_fits(SIZE_MAX));
-}
-
-TEST_CASE("WebSocket origin must match request host", "[api_rx]")
-{
-    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
-        "http://192.168.1.42", "192.168.1.42"));
-    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
-        "http://bitaxe.local", "bitaxe.local"));
-    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
-        "https://BITAXE.local", "bitaxe.LOCAL"));
-    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
-        "http://bitaxe.local:8080", "bitaxe.local:8080"));
-    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
-        "HTTP://BITAXE.LOCAL", "bitaxe.local"));
-    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
-        "http://[fd00::1]:8080", "[fd00::1]:8080"));
-
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
-        "http://evil.local", "bitaxe.local"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
-        "http://bitaxe.local:8080", "bitaxe.local"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
-        "null", "bitaxe.local"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
-        "file://bitaxe.local", "bitaxe.local"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
-        "http://bitaxe.local/", "bitaxe.local"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
-        "http://bitaxe.local?query", "bitaxe.local"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
-        "http://bitaxe.local#fragment", "bitaxe.local"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
-        "http://bitaxe.local@example.com", "example.com"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
-        "http://bitaxe.local:invalid", "bitaxe.local"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
-        "http://", "bitaxe.local"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
-        "bitaxe.local", "bitaxe.local"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(NULL, "bitaxe.local"));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host("http://bitaxe.local", NULL));
-    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host("http://bitaxe.local", ""));
-}
 
 TEST_CASE("LAN address validation handles IPv4 and IPv6", "[api_rx]")
 {

--- a/components/api_rx/test/test_api_rx.c
+++ b/components/api_rx/test/test_api_rx.c
@@ -94,6 +94,14 @@ TEST_CASE("LAN address validation handles IPv4 and IPv6", "[api_rx]")
     TEST_ASSERT_FALSE(api_rx_ipv6_address_is_lan(deprecated_site_local_ipv6));
 }
 
+TEST_CASE("HTTP origins reject malformed DNS labels", "[api_rx]")
+{
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://foo..local"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://foo-.local"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan(
+        "http://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.local"));
+}
+
 TEST_CASE("HTTP origins must identify a LAN host", "[api_rx]")
 {
     TEST_ASSERT_TRUE(api_rx_origin_is_lan("http://192.168.1.42"));
@@ -110,4 +118,65 @@ TEST_CASE("HTTP origins must identify a LAN host", "[api_rx]")
     TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://bitaxe.local/path"));
     TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://user@bitaxe.local"));
     TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://bitaxe.local:invalid"));
+}
+
+TEST_CASE("IPv4 LAN classification covers every range boundary", "[api_rx]")
+{
+    static const struct {
+        unsigned char address[4];
+        bool expected;
+    } cases[] = {
+        {{9, 255, 255, 255}, false}, {{10, 0, 0, 0}, true},
+        {{10, 255, 255, 255}, true}, {{11, 0, 0, 0}, false},
+        {{127, 0, 0, 0}, true}, {{127, 255, 255, 255}, true},
+        {{128, 0, 0, 0}, false}, {{172, 15, 255, 255}, false},
+        {{172, 16, 0, 0}, true}, {{172, 31, 255, 255}, true},
+        {{172, 32, 0, 0}, false}, {{169, 253, 255, 255}, false},
+        {{169, 254, 0, 0}, true}, {{169, 254, 255, 255}, true},
+        {{169, 255, 0, 0}, false}, {{192, 167, 255, 255}, false},
+        {{192, 168, 0, 0}, true}, {{192, 168, 255, 255}, true},
+        {{192, 169, 0, 0}, false},
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        TEST_ASSERT_EQUAL_INT(cases[i].expected,
+                              api_rx_ipv4_address_is_lan(cases[i].address));
+    }
+    TEST_ASSERT_FALSE(api_rx_ipv4_address_is_lan(NULL));
+}
+
+TEST_CASE("IPv6 LAN classification covers prefix boundaries", "[api_rx]")
+{
+    const unsigned char below_unique_local[16] = {0xfb};
+    const unsigned char unique_local_start[16] = {0xfc};
+    const unsigned char unique_local_end[16] = {0xfd, 0xff};
+    const unsigned char below_link_local[16] = {0xfe, 0x7f};
+    const unsigned char link_local_start[16] = {0xfe, 0x80};
+    const unsigned char link_local_end[16] = {0xfe, 0xbf};
+    const unsigned char above_link_local[16] = {0xfe, 0xc0};
+    const unsigned char unspecified[16] = {0};
+
+    TEST_ASSERT_FALSE(api_rx_ipv6_address_is_lan(below_unique_local));
+    TEST_ASSERT_TRUE(api_rx_ipv6_address_is_lan(unique_local_start));
+    TEST_ASSERT_TRUE(api_rx_ipv6_address_is_lan(unique_local_end));
+    TEST_ASSERT_FALSE(api_rx_ipv6_address_is_lan(below_link_local));
+    TEST_ASSERT_TRUE(api_rx_ipv6_address_is_lan(link_local_start));
+    TEST_ASSERT_TRUE(api_rx_ipv6_address_is_lan(link_local_end));
+    TEST_ASSERT_FALSE(api_rx_ipv6_address_is_lan(above_link_local));
+    TEST_ASSERT_FALSE(api_rx_ipv6_address_is_lan(unspecified));
+    TEST_ASSERT_FALSE(api_rx_ipv6_address_is_lan(NULL));
+}
+
+TEST_CASE("HTTP origin parser covers authority boundaries", "[api_rx]")
+{
+    TEST_ASSERT_TRUE(api_rx_origin_is_lan("HTTP://BITAXE.LOCAL"));
+    TEST_ASSERT_TRUE(api_rx_origin_is_lan("http://192.168.1.42:65535"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://192.168.1.42:"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://192.168.1.42:65536"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://[fe80::1"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://fe80::1"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://bitaxe.local?query"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://bitaxe.local#fragment"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan(NULL));
 }

--- a/components/api_rx/test/test_api_rx.c
+++ b/components/api_rx/test/test_api_rx.c
@@ -1,0 +1,113 @@
+#include <stdint.h>
+
+#include "api_rx.h"
+#include "unity.h"
+
+TEST_CASE("WebSocket payload limit has strict boundary", "[api_rx]")
+{
+    TEST_ASSERT_TRUE(api_rx_websocket_payload_fits(0));
+    TEST_ASSERT_TRUE(api_rx_websocket_payload_fits(API_RX_MAX_WEBSOCKET_PAYLOAD_SIZE));
+    TEST_ASSERT_FALSE(api_rx_websocket_payload_fits(API_RX_MAX_WEBSOCKET_PAYLOAD_SIZE + 1U));
+    TEST_ASSERT_FALSE(api_rx_websocket_payload_fits(SIZE_MAX));
+}
+
+TEST_CASE("WebSocket origin must match request host", "[api_rx]")
+{
+    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
+        "http://192.168.1.42", "192.168.1.42"));
+    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
+        "http://bitaxe.local", "bitaxe.local"));
+    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
+        "https://BITAXE.local", "bitaxe.LOCAL"));
+    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
+        "http://bitaxe.local:8080", "bitaxe.local:8080"));
+    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
+        "HTTP://BITAXE.LOCAL", "bitaxe.local"));
+    TEST_ASSERT_TRUE(api_rx_websocket_origin_matches_host(
+        "http://[fd00::1]:8080", "[fd00::1]:8080"));
+
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
+        "http://evil.local", "bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
+        "http://bitaxe.local:8080", "bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
+        "null", "bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
+        "file://bitaxe.local", "bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
+        "http://bitaxe.local/", "bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
+        "http://bitaxe.local?query", "bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
+        "http://bitaxe.local#fragment", "bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
+        "http://bitaxe.local@example.com", "example.com"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
+        "http://bitaxe.local:invalid", "bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
+        "http://", "bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(
+        "bitaxe.local", "bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host(NULL, "bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host("http://bitaxe.local", NULL));
+    TEST_ASSERT_FALSE(api_rx_websocket_origin_matches_host("http://bitaxe.local", ""));
+}
+
+TEST_CASE("LAN address validation handles IPv4 and IPv6", "[api_rx]")
+{
+    const unsigned char private_ipv4[4] = {192, 168, 1, 42};
+    const unsigned char public_ipv4[4] = {8, 8, 8, 8};
+    const unsigned char mapped_private_ipv6[16] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 10, 0, 0, 2
+    };
+    const unsigned char mapped_public_ipv6[16] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 8, 8, 8, 8
+    };
+    const unsigned char unique_local_ipv6[16] = {
+        0xfd, 0x12, 0x34, 0x56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+    };
+    const unsigned char link_local_ipv6[16] = {
+        0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+    };
+    const unsigned char loopback_ipv6[16] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+    };
+    const unsigned char global_ipv6[16] = {
+        0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0, 0, 0, 0, 0, 0, 0, 0, 0x88, 0x88
+    };
+    const unsigned char global_ipv6_with_private_tail[16] = {
+        0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 192, 168, 1, 42
+    };
+    const unsigned char deprecated_site_local_ipv6[16] = {
+        0xfe, 0xc0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+    };
+
+    TEST_ASSERT_TRUE(api_rx_ipv4_address_is_lan(private_ipv4));
+    TEST_ASSERT_FALSE(api_rx_ipv4_address_is_lan(public_ipv4));
+    TEST_ASSERT_TRUE(api_rx_ipv6_address_is_lan(mapped_private_ipv6));
+    TEST_ASSERT_FALSE(api_rx_ipv6_address_is_lan(mapped_public_ipv6));
+    TEST_ASSERT_TRUE(api_rx_ipv6_address_is_lan(unique_local_ipv6));
+    TEST_ASSERT_TRUE(api_rx_ipv6_address_is_lan(link_local_ipv6));
+    TEST_ASSERT_TRUE(api_rx_ipv6_address_is_lan(loopback_ipv6));
+    TEST_ASSERT_FALSE(api_rx_ipv6_address_is_lan(global_ipv6));
+    TEST_ASSERT_FALSE(api_rx_ipv6_address_is_lan(global_ipv6_with_private_tail));
+    TEST_ASSERT_FALSE(api_rx_ipv6_address_is_lan(deprecated_site_local_ipv6));
+}
+
+TEST_CASE("HTTP origins must identify a LAN host", "[api_rx]")
+{
+    TEST_ASSERT_TRUE(api_rx_origin_is_lan("http://192.168.1.42"));
+    TEST_ASSERT_TRUE(api_rx_origin_is_lan("https://10.0.0.2:8443"));
+    TEST_ASSERT_TRUE(api_rx_origin_is_lan("http://bitaxe.local"));
+    TEST_ASSERT_TRUE(api_rx_origin_is_lan("http://bitaxe"));
+    TEST_ASSERT_TRUE(api_rx_origin_is_lan("http://[fd12:3456::1]:8080"));
+    TEST_ASSERT_TRUE(api_rx_origin_is_lan("http://[fe80::1]"));
+
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("https://example.com"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://8.8.8.8"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://[2001:4860:4860::8888]"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("file://bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://bitaxe.local/path"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://user@bitaxe.local"));
+    TEST_ASSERT_FALSE(api_rx_origin_is_lan("http://bitaxe.local:invalid"));
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -67,6 +67,7 @@ INCLUDE_DIRS
     "${CMAKE_CURRENT_BINARY_DIR}"
 
 REQUIRES
+    "api_rx"
     "asic"
     "connect"
     "dns_server"

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -20,8 +20,6 @@
 #include "dns_server.h"
 #include "esp_ota_ops.h"
 #include "esp_wifi.h"
-#include "lwip/inet.h"
-#include <arpa/inet.h>
 #include "lwip/lwip_napt.h"
 #include "lwip/netdb.h"
 #include "lwip/sockets.h"
@@ -45,6 +43,7 @@
 #include "log_buffer.h"
 #include "cjson_utils.h"
 #include "utils.h"
+#include "api_rx.h"
 
 static const char * TAG = "http_server";
 static const char * CORS_TAG = "CORS";
@@ -230,61 +229,29 @@ typedef struct rest_server_context
 
 #define CHECK_FILE_EXTENSION(filename, ext) (strcasecmp(&filename[strlen(filename) - strlen(ext)], ext) == 0)
 
-static esp_err_t ip_in_private_range(uint32_t address) {
-    uint32_t ip_address = ntohl(address);
-
-    // 10.0.0.0 - 10.255.255.255 (Class A)
-    if ((ip_address >= 0x0A000000) && (ip_address <= 0x0AFFFFFF)) {
-        return ESP_OK;
-    }
-
-    // 172.16.0.0 - 172.31.255.255 (Class B)
-    if ((ip_address >= 0xAC100000) && (ip_address <= 0xAC1FFFFF)) {
-        return ESP_OK;
-    }
-
-    // 192.168.0.0 - 192.168.255.255 (Class C)
-    if ((ip_address >= 0xC0A80000) && (ip_address <= 0xC0A8FFFF)) {
-        return ESP_OK;
-    }
-
-    return ESP_FAIL;
-}
-
-static uint32_t extract_origin_ip_addr(char *origin)
+static bool request_peer_is_lan(httpd_req_t *req)
 {
-    char host_str[128];
-    uint32_t origin_ip_addr = 0;
+    int sockfd = httpd_req_to_sockfd(req);
+    struct sockaddr_storage peer = {0};
+    socklen_t peer_size = sizeof(peer);
 
-    // Find the start of the hostname in the Origin header
-    const char *prefix = "http://";
-    char *host_start = strstr(origin, prefix);
-    if (host_start) {
-        host_start += strlen(prefix); // Move past "http://"
-
-        // Extract the hostname portion (up to the next '/')
-        char *host_end = strchr(host_start, '/');
-        size_t host_len = host_end ? (size_t)(host_end - host_start) : strlen(host_start);
-        if (host_len < sizeof(host_str)) {
-            strncpy(host_str, host_start, host_len);
-            host_str[host_len] = '\0'; // Null-terminate the string
-
-            // Check if it's an IP address or hostname
-            struct in_addr addr;
-            if (inet_pton(AF_INET, host_str, &addr) == 1) {
-                origin_ip_addr = addr.s_addr;
-                ESP_LOGD(CORS_TAG, "Extracted IP address %lu", origin_ip_addr);
-            } else {
-                ESP_LOGD(CORS_TAG, "Origin contains hostname: %s (not an IP)", host_str);
-                // For hostnames, return 0 to indicate it's not an IP address
-                origin_ip_addr = 0;
-            }
-        } else {
-            ESP_LOGW(CORS_TAG, "Hostname string is too long: %s", host_start);
-        }
+    if (getpeername(sockfd, (struct sockaddr *)&peer, &peer_size) < 0) {
+        ESP_LOGE(CORS_TAG, "Error getting client IP");
+        return false;
     }
 
-    return origin_ip_addr;
+    if (peer.ss_family == AF_INET) {
+        const struct sockaddr_in *ipv4 = (const struct sockaddr_in *)&peer;
+        return api_rx_ipv4_address_is_lan((const unsigned char *)&ipv4->sin_addr);
+    }
+
+    if (peer.ss_family == AF_INET6) {
+        const struct sockaddr_in6 *ipv6 = (const struct sockaddr_in6 *)&peer;
+        return api_rx_ipv6_address_is_lan(ipv6->sin6_addr.s6_addr);
+    }
+
+    ESP_LOGW(CORS_TAG, "Unsupported client address family: %d", peer.ss_family);
+    return false;
 }
 
 // Helper function to normalize hostname by stripping ".local" suffix if present
@@ -309,123 +276,27 @@ static void normalize_hostname(char *hostname, size_t max_len) {
 
 esp_err_t is_network_allowed(httpd_req_t * req)
 {
-    if (GLOBAL_STATE->SYSTEM_MODULE.ap_enabled == true) {
-        ESP_LOGI(CORS_TAG, "Device in AP mode. Allowing CORS.");
-        return ESP_OK;
-    }
-
-    int sockfd = httpd_req_to_sockfd(req);
-    char ipstr[INET6_ADDRSTRLEN];
-    struct sockaddr_in6 addr;   // esp_http_server uses IPv6 addressing
-    socklen_t addr_size = sizeof(addr);
-
-    if (getpeername(sockfd, (struct sockaddr *)&addr, &addr_size) < 0) {
-        ESP_LOGE(CORS_TAG, "Error getting client IP");
+    if (!request_peer_is_lan(req)) {
+        ESP_LOGI(CORS_TAG, "Client peer address is not a LAN address");
         return ESP_FAIL;
     }
 
-    uint32_t request_ip_addr = addr.sin6_addr.un.u32_addr[3];
-
-    // // Convert to IPv6 string
-    // inet_ntop(AF_INET, &addr.sin6_addr, ipstr, sizeof(ipstr));
-
-    // Convert to IPv4 string
-    inet_ntop(AF_INET, &request_ip_addr, ipstr, sizeof(ipstr));
-
-    // Attempt to get the Origin header.
-    char origin[128];
-    uint32_t origin_ip_addr;
-    if (httpd_req_get_hdr_value_str(req, "Origin", origin, sizeof(origin)) == ESP_OK) {
-        ESP_LOGD(CORS_TAG, "Origin header: %s", origin);
-        origin_ip_addr = extract_origin_ip_addr(origin);
-    } else {
-        ESP_LOGD(CORS_TAG, "No origin header found.");
-        origin_ip_addr = request_ip_addr;
-    }
-
-    if (origin_ip_addr != 0 && ip_in_private_range(origin_ip_addr) == ESP_OK && ip_in_private_range(request_ip_addr) == ESP_OK) {
-        ESP_LOGD(CORS_TAG, "Origin and IP both in private range. Allowing.");
+    size_t origin_len = httpd_req_get_hdr_value_len(req, "Origin");
+    if (origin_len == 0) {
+        ESP_LOGD(CORS_TAG, "LAN request has no Origin header");
         return ESP_OK;
     }
-    
-    // If origin contains hostname (origin_ip_addr == 0), proceed to hostname validation
-    if (origin_ip_addr == 0) {
-        ESP_LOGD(CORS_TAG, "Origin contains hostname, proceeding to hostname validation");
+
+    char origin[256];
+    if (origin_len >= sizeof(origin) ||
+        httpd_req_get_hdr_value_str(req, "Origin", origin, sizeof(origin)) != ESP_OK ||
+        !api_rx_origin_is_lan(origin)) {
+        ESP_LOGI(CORS_TAG, "Rejecting request with non-LAN Origin");
+        return ESP_FAIL;
     }
 
-    // Check if Origin header matches the avahi hostname or is a local-network hostname
-    if (httpd_req_get_hdr_value_len(req, "Origin") > 0) {
-        httpd_req_get_hdr_value_str(req, "Origin", origin, sizeof(origin));
-        ESP_LOGD(CORS_TAG, "Origin header: %s", origin);
-
-        // Extract the host portion from the origin for local-hostname validation
-        char host_str[128] = {0};
-        const char *prefix = "http://";
-        char *host_start = strstr(origin, prefix);
-        bool is_local_hostname = false;
-        if (host_start) {
-            host_start += strlen(prefix);
-            // Strip port if present
-            char *colon = strchr(host_start, ':');
-            char *slash = strchr(host_start, '/');
-            size_t host_len = 0;
-            if (colon) {
-                host_len = colon - host_start;
-            } else if (slash) {
-                host_len = slash - host_start;
-            } else {
-                host_len = strlen(host_start);
-            }
-            if (host_len > 0 && host_len < sizeof(host_str)) {
-                strncpy(host_str, host_start, host_len);
-                host_str[host_len] = '\0';
-
-                // Allow any .local hostname (mDNS, inherently local network)
-                size_t hlen = strlen(host_str);
-                if (hlen > 6 && strcasecmp(host_str + hlen - 6, ".local") == 0) {
-                    is_local_hostname = true;
-                    ESP_LOGD(CORS_TAG, "Origin host '%s' is a .local mDNS hostname - allowing", host_str);
-                }
-                // Allow any bare hostname (no dots, only resolvable on local network)
-                else if (strchr(host_str, '.') == NULL) {
-                    is_local_hostname = true;
-                    ESP_LOGD(CORS_TAG, "Origin host '%s' is a bare local hostname - allowing", host_str);
-                }
-            }
-        }
-
-        if (is_local_hostname) {
-            ESP_LOGD(CORS_TAG, "Request from local hostname - allowing access");
-            return ESP_OK;
-        }
-
-        // Fall back to exact match against this device's configured hostname
-        char *hostname = nvs_config_get_string(NVS_CONFIG_HOSTNAME);
-        ESP_LOGD(CORS_TAG, "Configured hostname: %s", hostname);
-        // Match origin as http://<hostname>.local[:port] or http://<hostname>[:port]
-        const char *patterns[] = { "http://%s.local", "http://%s" };
-        bool matched = false;
-        for (int i = 0; i < 2 && !matched; i++) {
-            char expected[256];
-            snprintf(expected, sizeof(expected), patterns[i], hostname);
-            size_t len = strlen(expected);
-            // Origin must start with expected, followed by end-of-string or ':port'
-            if (strncmp(origin, expected, len) == 0 &&
-                (origin[len] == '\0' || origin[len] == ':')) {
-                matched = true;
-            }
-        }
-        free(hostname);
-        if (matched) {
-            ESP_LOGD(CORS_TAG, "Request from hostname - allowing access");
-            return ESP_OK;
-        }
-    } else {
-        ESP_LOGD(CORS_TAG, "No Origin header found");
-    }
-
-    ESP_LOGI(CORS_TAG, "Client is NOT in the private ip ranges or same range as server.");
-    return ESP_FAIL;
+    ESP_LOGD(CORS_TAG, "Peer address and Origin are both on the LAN");
+    return ESP_OK;
 }
 
 /* Function for stopping the webserver */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ set(EXTRA_COMPONENT_DIRS "../components")
 # - when invoking CMake directly: cmake -D TEST_COMPONENTS="xxxxx" ..
 # - when using idf.py: idf.py -T xxxxx build
 #
-set(TEST_COMPONENTS "stratum asic" CACHE STRING "List of components to test")
+set(TEST_COMPONENTS "stratum asic api_rx" CACHE STRING "List of components to test")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 


### PR DESCRIPTION
## What this fixes

The API trusted a loosely parsed peer/origin boundary. Malformed authorities, public addresses, unsupported socket families, and local-looking but invalid DNS names could be classified inconsistently.

## Changes and reasoning

- Add a focused `api_rx` component that classifies IPv4 and IPv6 peers, including private, loopback, link-local, ULA, and IPv4-mapped ranges.
- Strictly parse HTTP(S) origins, bracketed IPv6 literals, numeric ports, local addresses, bare hostnames, and `.local` names.
- Enforce DNS limits per label: a 253-byte host maximum, 1-63 byte labels, and no empty labels or leading/trailing hyphens.
- Reject malformed authorities, public addresses, and unsupported address families rather than guessing.

These checks make the firmware's existing LAN-only trust boundary explicit and testable. They do not add authentication or change valid LAN clients.

## Review follow-up

The DNS-label validation and regressions requested by @johnny9 are included. Cases such as `foo..local`, `foo-.local`, and a 64-byte label now fail closed.

## Scope and related work

This PR is independent of #1846 and #1848; it contains only peer/origin classification and its integration/tests. Open PR #1845 is related HTTP access-control work, but does not make this DNS-label and address-family validation obsolete.

## Validation

- The current PR diff passes `git diff --check` against upstream `master` at `d3dbcc5`.
- In a fresh combined integration worktree, the ESP32-S3 unit-test image and full firmware built successfully with the locally available ESP-IDF 5.5.3. Temporary component-version compatibility gates were used; the full build also omitted only the ESP-IDF 6-only `ws_post_handshake_cb` initializers.
- The added tests were compiled and linked into the test image, but were not executed locally because no ESP32-S3 QEMU or device is available.
- GitHub CI on the project's required ESP-IDF 6.0.2 is the authoritative current-head result and has been restarted by this update.
