### PR TITLE
Bound Wi-Fi scan results to fixed storage

### DIFF
--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -22,9 +22,6 @@
 #include "nvs_config.h"
 #include "esp_app_desc.h"
 
-// Maximum number of access points to scan
-#define MAX_AP_COUNT 20
-
 #if CONFIG_ESP_WPA3_SAE_PWE_HUNT_AND_PECK
 #define ESP_WIFI_SAE_MODE WPA3_SAE_PWE_HUNT_AND_PECK
 #define EXAMPLE_H2E_IDENTIFIER ""
@@ -62,7 +59,7 @@ static TimerHandle_t ip_acquire_timer = NULL;
 
 static bool is_scanning = false;
 static uint16_t ap_number = 0;
-static wifi_ap_record_t ap_info[MAX_AP_COUNT];
+static wifi_ap_record_t ap_info[WIFI_SCAN_MAX_AP_COUNT];
 static int s_retry_num = 0;
 static int clients_connected_to_ap = 0;
 static bool mdns_initialized = false;
@@ -316,8 +313,14 @@ esp_err_t get_wifi_current_rssi(int8_t *rssi)
 }
 
 // Function to scan for available WiFi networks
-esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count)
+esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, size_t records_capacity, uint16_t *ap_count)
 {
+    if (ap_records == NULL || ap_count == NULL || records_capacity == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    *ap_count = 0;
+
     if (is_scanning) {
         ESP_LOGW(TAG, "Scan already in progress");
         return ESP_ERR_INVALID_STATE;
@@ -325,6 +328,7 @@ esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count)
 
     ESP_LOGI(TAG, "Starting Wi-Fi scan!");
     is_scanning = true;
+    ap_number = 0;
 
     wifi_ap_record_t current_ap_info;
     if (esp_wifi_sta_get_ap_info(&current_ap_info) != ESP_OK) {
@@ -352,6 +356,7 @@ esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count)
         retries_remaining--;
         if (retries_remaining == 0) {
             is_scanning = false;
+            ap_number = 0;
             return ESP_FAIL;
         }
         vTaskDelay(1000 / portTICK_PERIOD_MS);
@@ -362,10 +367,19 @@ esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count)
         ESP_LOGW(TAG, "No Wi-Fi networks found");
     }
 
-    *ap_count = ap_number;
-    memset(ap_records, 0, (*ap_count) * sizeof(wifi_ap_record_simple_t));
-    for (int i = 0; i < ap_number; i++) {
+    size_t records_to_copy = ap_number;
+    if (records_to_copy > WIFI_SCAN_MAX_AP_COUNT) {
+        records_to_copy = WIFI_SCAN_MAX_AP_COUNT;
+    }
+    if (records_to_copy > records_capacity) {
+        records_to_copy = records_capacity;
+    }
+
+    *ap_count = (uint16_t)records_to_copy;
+    memset(ap_records, 0, records_to_copy * sizeof(*ap_records));
+    for (size_t i = 0; i < records_to_copy; i++) {
         memcpy(ap_records[i].ssid, ap_info[i].ssid, sizeof(ap_records[i].ssid));
+        ap_records[i].ssid[sizeof(ap_records[i].ssid) - 1U] = '\0';
         ap_records[i].rssi = ap_info[i].rssi;
         ap_records[i].authmode = ap_info[i].authmode;
     }
@@ -391,10 +405,26 @@ static void event_handler(void * arg, esp_event_base_t event_base, int32_t event
     if (event_base == WIFI_EVENT)
     {
         if (event_id == WIFI_EVENT_SCAN_DONE) {
-            esp_wifi_scan_get_ap_num(&ap_number);
-            ESP_LOGI(TAG, "Wi-Fi Scan Done");
-            if (esp_wifi_scan_get_ap_records(&ap_number, ap_info) != ESP_OK) {
-                ESP_LOGI(TAG, "Failed esp_wifi_scan_get_ap_records");
+            uint16_t total_found = 0;
+            uint16_t records_capacity =
+                (uint16_t)(sizeof(ap_info) / sizeof(ap_info[0]));
+
+            esp_err_t scan_err = esp_wifi_scan_get_ap_num(&total_found);
+            if (scan_err != ESP_OK) {
+                ESP_LOGW(TAG, "Failed to get Wi-Fi scan count: %s", esp_err_to_name(scan_err));
+                ap_number = 0;
+            } else {
+                ESP_LOGI(TAG, "Wi-Fi Scan Done: %u network(s) found", total_found);
+                scan_err = esp_wifi_scan_get_ap_records(&records_capacity, ap_info);
+                if (scan_err != ESP_OK) {
+                    ESP_LOGW(TAG, "Failed to get Wi-Fi scan records: %s", esp_err_to_name(scan_err));
+                    ap_number = 0;
+                } else {
+                    if (records_capacity > WIFI_SCAN_MAX_AP_COUNT) {
+                        records_capacity = WIFI_SCAN_MAX_AP_COUNT;
+                    }
+                    ap_number = records_capacity;
+                }
             }
             is_scanning = false;
         }

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -368,9 +368,6 @@ esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, size_t records_capacity
     }
 
     size_t records_to_copy = ap_number;
-    if (records_to_copy > WIFI_SCAN_MAX_AP_COUNT) {
-        records_to_copy = WIFI_SCAN_MAX_AP_COUNT;
-    }
     if (records_to_copy > records_capacity) {
         records_to_copy = records_capacity;
     }
@@ -405,25 +402,20 @@ static void event_handler(void * arg, esp_event_base_t event_base, int32_t event
     if (event_base == WIFI_EVENT)
     {
         if (event_id == WIFI_EVENT_SCAN_DONE) {
-            uint16_t total_found = 0;
-            uint16_t records_capacity =
-                (uint16_t)(sizeof(ap_info) / sizeof(ap_info[0]));
-
-            esp_err_t scan_err = esp_wifi_scan_get_ap_num(&total_found);
+            esp_err_t scan_err = esp_wifi_scan_get_ap_num(&ap_number);
             if (scan_err != ESP_OK) {
                 ESP_LOGW(TAG, "Failed to get Wi-Fi scan count: %s", esp_err_to_name(scan_err));
                 ap_number = 0;
             } else {
-                ESP_LOGI(TAG, "Wi-Fi Scan Done: %u network(s) found", total_found);
-                scan_err = esp_wifi_scan_get_ap_records(&records_capacity, ap_info);
+                ESP_LOGI(TAG, "Wi-Fi Scan Done: %u network(s) found", ap_number);
+                if (ap_number > WIFI_SCAN_MAX_AP_COUNT) {
+                    ap_number = WIFI_SCAN_MAX_AP_COUNT;
+                }
+
+                scan_err = esp_wifi_scan_get_ap_records(&ap_number, ap_info);
                 if (scan_err != ESP_OK) {
                     ESP_LOGW(TAG, "Failed to get Wi-Fi scan records: %s", esp_err_to_name(scan_err));
                     ap_number = 0;
-                } else {
-                    if (records_capacity > WIFI_SCAN_MAX_AP_COUNT) {
-                        records_capacity = WIFI_SCAN_MAX_AP_COUNT;
-                    }
-                    ap_number = records_capacity;
                 }
             }
             is_scanning = false;

--- a/components/connect/include/connect.h
+++ b/components/connect/include/connect.h
@@ -5,11 +5,14 @@
 #include <arpa/inet.h>
 #include <lwip/netdb.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "esp_err.h"
 #include "esp_wifi_types.h"
 
 typedef struct GlobalState GlobalState;
+
+#define WIFI_SCAN_MAX_AP_COUNT 20U
 
 // Structure to hold WiFi scan results
 typedef struct {
@@ -21,7 +24,7 @@ typedef struct {
 void toggle_wifi_softap(void);
 void wifi_init(GlobalState * GLOBAL_STATE);
 esp_err_t wifi_apply_hostname(const char *hostname);
-esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count);
+esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, size_t records_capacity, uint16_t *ap_count);
 esp_err_t get_wifi_current_rssi(int8_t *rssi);
 bool wifi_is_connected(void);
 esp_err_t update_mdns_hostname(const char *new_hostname, GlobalState *GLOBAL_STATE);

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -180,10 +180,10 @@ static esp_err_t GET_wifi_scan(httpd_req_t *req)
     // Give some time for the connected flag to take effect
     vTaskDelay(100 / portTICK_PERIOD_MS);
     
-    wifi_ap_record_simple_t ap_records[20];
+    wifi_ap_record_simple_t ap_records[WIFI_SCAN_MAX_AP_COUNT];
     uint16_t ap_count = 0;
 
-    esp_err_t err = wifi_scan(ap_records, &ap_count);
+    esp_err_t err = wifi_scan(ap_records, sizeof(ap_records) / sizeof(ap_records[0]), &ap_count);
     if (err != ESP_OK) {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "WiFi scan failed");
         return ESP_OK;


### PR DESCRIPTION
## What this fixes

The ESP-IDF scan result count was reused as the destination capacity for a fixed 20-entry global array, then copied through another fixed 20-entry HTTP buffer. More than 20 visible access points could therefore write past either array.

## Changes and reasoning

- Clamp `ap_number` directly to the existing 20-record limit before calling `esp_wifi_scan_get_ap_records()`.
- Pass the caller's destination capacity through `wifi_scan()` and clamp the copy as a second boundary defense.
- Clear stale scan state on failure and explicitly terminate copied SSIDs.

The endpoint still returns at most 20 networks; excess scan results are intentionally ignored. The direct driver-boundary clamp is the primary fix, while the explicit caller capacity keeps future callers from reintroducing the same assumption.

## Review follow-up

The implementation was simplified as requested: `ap_number` is now clamped at the API call instead of routing the limit through extra counting logic.

## Scope and related work

This does not change Wi-Fi selection policy or the trusted-network model. PR #690 previously corrected scan behavior, and #1759 audited HTTP handlers; neither enforces both fixed-capacity boundaries addressed here.

## Validation

- The current PR diff passes `git diff --check` against upstream `master` at `d3dbcc5`.
- In a fresh combined integration worktree, the ESP32-S3 unit-test image and full firmware built successfully with the locally available ESP-IDF 5.5.3. Temporary component-version compatibility gates were used; the full build also omitted only the ESP-IDF 6-only `ws_post_handshake_cb` initializers.
- The ESP-IDF scan API's input/output capacity contract was checked against the production call path. A hardware scan with more than 20 visible APs was not run locally.
- GitHub CI on the project's required ESP-IDF 6.0.2 is the authoritative current-head result and has been restarted by this update.
