### PR TITLE
Set global user context in http server request handlers 

### DIFF
--- a/main/http_server/axe-os/api/system/asic_settings.c
+++ b/main/http_server/axe-os/api/system/asic_settings.c
@@ -8,21 +8,14 @@
 
 static int system_asic_prebuffer_len = 256;
 
-// static const char *TAG = "asic_settings";
-static GlobalState *GLOBAL_STATE = NULL;
-
 // Function declarations from http_server.c
 extern esp_err_t is_network_allowed(httpd_req_t *req);
 extern esp_err_t set_cors_headers(httpd_req_t *req);
 
-// Initialize the ASIC API with the global state
-void asic_api_init(GlobalState *global_state) {
-    GLOBAL_STATE = global_state;
-}
-
 /* Handler for system asic endpoint */
 esp_err_t GET_system_asic(httpd_req_t *req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }

--- a/main/http_server/axe-os/api/system/asic_settings.h
+++ b/main/http_server/axe-os/api/system/asic_settings.h
@@ -7,7 +7,4 @@
 // Function to handle the /api/system/asic endpoint
 esp_err_t GET_system_asic(httpd_req_t *req);
 
-// Initialize the ASIC API with the global state
-void asic_api_init(GlobalState *global_state);
-
 #endif // ASIC_API_SETTINGS_H_

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -213,6 +213,7 @@ static esp_err_t GET_wifi_scan(httpd_req_t *req)
 
 #define FILE_PATH_MAX (ESP_VFS_PATH_MAX + 128)
 #define MESSAGE_QUEUE_SIZE (128)
+#define MAX_REST_PAYLOAD_SIZE (16384) /* 16 KB max REST JSON payload */
 
 #define CHECK_FILE_EXTENSION(filename, ext) (strcasecmp(&filename[strlen(filename) - strlen(ext)], ext) == 0)
 
@@ -1038,7 +1039,7 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     }
 
     int total_len = req->content_len;
-    if (total_len <= 0 || total_len > 16384) {
+    if (total_len <= 0 || total_len > MAX_REST_PAYLOAD_SIZE) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Content length invalid or too large");
         return ESP_OK;
     }
@@ -1250,7 +1251,7 @@ static esp_err_t PUT_system_pool(httpd_req_t *req)
     }
 
     int total_len = req->content_len;
-    if (total_len <= 0 || total_len > 16384) {
+    if (total_len <= 0 || total_len > MAX_REST_PAYLOAD_SIZE) {
         return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid request length");
     }
 
@@ -1441,9 +1442,9 @@ static esp_err_t POST_system_boot(httpd_req_t *req)
         return ESP_OK;
     }
 
-    size_t total_len = req->content_len;
-    if (total_len == 0) {
-        return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Empty request body");
+    int total_len = req->content_len;
+    if (total_len <= 0 || total_len > MAX_REST_PAYLOAD_SIZE) {
+        return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Content length invalid or too large");
     }
 
     char *buf = malloc(total_len + 1);

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -11,7 +11,6 @@
 #include "freertos/task.h"
 #include "esp_http_server.h"
 #include "esp_log.h"
-#include "esp_netif.h"
 #include "esp_system.h"
 #include "esp_timer.h"
 #include "esp_wifi.h"
@@ -22,8 +21,6 @@
 #include "esp_wifi.h"
 #include "lwip/inet.h"
 #include <arpa/inet.h>
-#include "lwip/lwip_napt.h"
-#include "lwip/netdb.h"
 #include "lwip/sockets.h"
 
 #include "cJSON.h"
@@ -35,7 +32,6 @@
 #include "theme_api.h"
 #include "axe-os/api/system/asic_settings.h"
 #include "display.h"
-#include "mdns.h"
 #include "http_server.h"
 #include "embedded_web_ui.h"
 #include "websocket.h"
@@ -152,9 +148,6 @@ static esp_err_t GET_system_logs(httpd_req_t *req)
     return res;
 }
 
-static GlobalState * GLOBAL_STATE;
-static httpd_handle_t server = NULL;
-
 esp_err_t HTTP_send_json(httpd_req_t * req, const cJSON * item, int * prebuffer_len)
 {
     const char * response = cJSON_PrintBuffered(item, *prebuffer_len, false);
@@ -219,14 +212,7 @@ static esp_err_t GET_wifi_scan(httpd_req_t *req)
     } while (0)
 
 #define FILE_PATH_MAX (ESP_VFS_PATH_MAX + 128)
-#define SCRATCH_BUFSIZE (10240)
 #define MESSAGE_QUEUE_SIZE (128)
-
-typedef struct rest_server_context
-{
-    char base_path[ESP_VFS_PATH_MAX + 1];
-    char scratch[SCRATCH_BUFSIZE];
-} rest_server_context_t;
 
 #define CHECK_FILE_EXTENSION(filename, ext) (strcasecmp(&filename[strlen(filename) - strlen(ext)], ext) == 0)
 
@@ -309,6 +295,12 @@ static void normalize_hostname(char *hostname, size_t max_len) {
 
 esp_err_t is_network_allowed(httpd_req_t * req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
+    if (!GLOBAL_STATE) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
     if (GLOBAL_STATE->SYSTEM_MODULE.ap_enabled == true) {
         ESP_LOGI(CORS_TAG, "Device in AP mode. Allowing CORS.");
         return ESP_OK;
@@ -426,15 +418,6 @@ esp_err_t is_network_allowed(httpd_req_t * req)
 
     ESP_LOGI(CORS_TAG, "Client is NOT in the private ip ranges or same range as server.");
     return ESP_FAIL;
-}
-
-/* Function for stopping the webserver */
-void stop_webserver(httpd_handle_t server)
-{
-    if (server) {
-        /* Stop the httpd server */
-        httpd_stop(server);
-    }
 }
 
 /* Set HTTP response content type according to file extension */
@@ -555,8 +538,7 @@ static esp_err_t rest_common_get_handler_spiffs(httpd_req_t * req)
     char gz_file[FILE_PATH_MAX];
     uint8_t filePathLength = sizeof(filepath);
 
-    rest_server_context_t * rest_context = (rest_server_context_t *) req->user_ctx;
-    strlcpy(filepath, rest_context->base_path, filePathLength);
+    filepath[0] = '\0';
     if (req->uri[strlen(req->uri) - 1] == '/') {
         strlcat(filepath, "/index.html", filePathLength);
     } else {
@@ -590,16 +572,23 @@ static esp_err_t rest_common_get_handler_spiffs(httpd_req_t * req)
         httpd_resp_set_hdr(req, "Content-Encoding", "gzip");
     }
 
-    char * chunk = rest_context->scratch;
+    char * chunk = (char *)malloc(4096);
+    if (!chunk) {
+        close(fd);
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Out of memory");
+        return ESP_FAIL;
+    }
+
     ssize_t read_bytes;
     do {
-        /* Read file in chunks into the scratch buffer */
-        read_bytes = read(fd, chunk, SCRATCH_BUFSIZE);
+        /* Read file in chunks into the buffer */
+        read_bytes = read(fd, chunk, 4096);
         if (read_bytes == -1) {
             ESP_LOGE(TAG, "Failed to read file : %s", file_to_open);
         } else if (read_bytes > 0) {
             /* Send the buffer contents as HTTP response chunk */
             if (httpd_resp_send_chunk(req, chunk, read_bytes) != ESP_OK) {
+                free(chunk);
                 close(fd);
                 ESP_LOGE(TAG, "File sending failed!");
                 /* Abort sending file */
@@ -611,6 +600,7 @@ static esp_err_t rest_common_get_handler_spiffs(httpd_req_t * req)
         }
     } while (read_bytes > 0);
     /* Close file after sending complete */
+    free(chunk);
     close(fd);
     ESP_LOGI(TAG, "File sending complete");
     /* Respond with an empty chunk to signal HTTP response completion */
@@ -775,7 +765,8 @@ static bool validate_pool_json(const cJSON *pool_item, int i) {
     return true;
 }
 
-static void update_pool_nvs(const cJSON *pool_item, int i) {
+static void update_pool_nvs(const cJSON *pool_item, int i, GlobalState *GLOBAL_STATE)
+{
     cJSON *p_obj = cJSON_CreateObject();
     
     cJSON *new_pass = cJSON_GetObjectItem(pool_item, "stratumPassword");
@@ -827,7 +818,7 @@ static void update_pool_nvs(const cJSON *pool_item, int i) {
     SYSTEM_load_pool_from_nvs(GLOBAL_STATE, i);
 }
 
-bool check_settings_and_update(const cJSON * const root, char **redirect_url)
+bool check_settings_and_update(const cJSON * const root, char **redirect_url, GlobalState * GLOBAL_STATE)
 {
     bool result = true;
     char *old_hostname = NULL;
@@ -1006,7 +997,7 @@ bool check_settings_and_update(const cJSON * const root, char **redirect_url)
                 if (id_item && cJSON_IsNumber(id_item)) {
                     int idx = id_item->valueint;
                     if (idx >= 0 && idx < MAX_POOLS) {
-                        update_pool_nvs(pool_item, idx);
+                        update_pool_nvs(pool_item, idx, GLOBAL_STATE);
                     }
                 }
             }
@@ -1035,6 +1026,7 @@ bool check_settings_and_update(const cJSON * const root, char **redirect_url)
 
 static esp_err_t PATCH_update_settings(httpd_req_t * req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
@@ -1046,26 +1038,31 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     }
 
     int total_len = req->content_len;
-    int cur_len = 0;
-    char * buf = ((rest_server_context_t *) (req->user_ctx))->scratch;
-    int received = 0;
-    if (total_len >= SCRATCH_BUFSIZE) {
-        /* Respond with 500 Internal Server Error */
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "content too long");
+    if (total_len <= 0 || total_len > 16384) {
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Content length invalid or too large");
         return ESP_OK;
     }
+
+    char * buf = (char *)malloc(total_len + 1);
+    if (!buf) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Out of memory");
+        return ESP_FAIL;
+    }
+
+    int cur_len = 0;
     while (cur_len < total_len) {
-        received = httpd_req_recv(req, buf + cur_len, total_len);
+        int received = httpd_req_recv(req, buf + cur_len, total_len - cur_len);
         if (received <= 0) {
-            /* Respond with 500 Internal Server Error */
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to post control value");
-            return ESP_OK;
+            free(buf);
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to receive update payload");
+            return ESP_FAIL;
         }
         cur_len += received;
     }
     buf[total_len] = '\0';
 
     cJSON * root = cJSON_Parse(buf);
+    free(buf);
     if (root == NULL) {
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid JSON");
         return ESP_OK;
@@ -1078,7 +1075,7 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
     free(current_hostname);
 
     char *redirect_url = NULL;
-    if (!check_settings_and_update(root, &redirect_url)) {
+    if (!check_settings_and_update(root, &redirect_url, GLOBAL_STATE)) {
         cJSON_Delete(root);
         if (redirect_url) {
             free(redirect_url);
@@ -1119,6 +1116,8 @@ static esp_err_t PATCH_update_settings(httpd_req_t * req)
 
 static esp_err_t POST_identify(httpd_req_t * req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
+
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
@@ -1195,6 +1194,7 @@ static esp_err_t POST_restart(httpd_req_t * req)
 
 static esp_err_t POST_dismiss_block_found(httpd_req_t * req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
@@ -1230,6 +1230,7 @@ static esp_err_t POST_dismiss_block_found(httpd_req_t * req)
 
 static esp_err_t PUT_system_pool(httpd_req_t *req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
@@ -1249,18 +1250,24 @@ static esp_err_t PUT_system_pool(httpd_req_t *req)
     }
 
     int total_len = req->content_len;
-    if (total_len <= 0 || total_len >= SCRATCH_BUFSIZE) {
+    if (total_len <= 0 || total_len > 16384) {
         return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid request length");
     }
 
-    char *buf = ((rest_server_context_t *)(req->user_ctx))->scratch;
+    char *buf = (char *)malloc(total_len + 1);
+    if (!buf) {
+        return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Out of memory");
+    }
+
     int received = httpd_req_recv(req, buf, total_len);
     if (received <= 0) {
+        free(buf);
         return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to receive request data");
     }
     buf[received] = '\0';
 
     cJSON *root = cJSON_Parse(buf);
+    free(buf);
     if (!root) {
         return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid JSON");
     }
@@ -1270,7 +1277,7 @@ static esp_err_t PUT_system_pool(httpd_req_t *req)
         return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid pool configuration payload");
     }
 
-    update_pool_nvs(root, idx);
+    update_pool_nvs(root, idx, GLOBAL_STATE);
     cJSON_Delete(root);
 
     cJSON *resp = cJSON_CreateObject();
@@ -1284,6 +1291,7 @@ static esp_err_t PUT_system_pool(httpd_req_t *req)
 
 static esp_err_t DELETE_system_pool(httpd_req_t *req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
@@ -1326,6 +1334,7 @@ static esp_err_t DELETE_system_pool(httpd_req_t *req)
 
 static esp_err_t POST_mining_pause(httpd_req_t * req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
@@ -1352,6 +1361,7 @@ static esp_err_t POST_mining_pause(httpd_req_t * req)
 
 static esp_err_t POST_mining_resume(httpd_req_t * req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
@@ -1377,8 +1387,9 @@ static esp_err_t POST_mining_resume(httpd_req_t * req)
 }
 
 /* Simple handler for getting system handler */
-static esp_err_t GET_system_info(httpd_req_t * req)
+static esp_err_t GET_system_info(httpd_req_t *req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
@@ -1604,6 +1615,7 @@ static esp_err_t GET_system_statistics(httpd_req_t * req)
 
 static esp_err_t GET_scoreboard(httpd_req_t * req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
@@ -1654,6 +1666,7 @@ static esp_err_t GET_scoreboard(httpd_req_t * req)
 
 esp_err_t POST_WWW_update(httpd_req_t * req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
@@ -1740,6 +1753,7 @@ esp_err_t POST_WWW_update(httpd_req_t * req)
  */
 esp_err_t POST_OTA_update(httpd_req_t * req)
 {
+    GlobalState *GLOBAL_STATE = (GlobalState *)httpd_get_global_user_ctx(req->handle);
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
@@ -1830,19 +1844,10 @@ esp_err_t http_404_error_handler(httpd_req_t * req, httpd_err_code_t err)
     return ESP_OK;
 }
 
-esp_err_t start_rest_server(GlobalState * global_state)
+esp_err_t start_rest_server(GlobalState * GLOBAL_STATE)
 {
-    GLOBAL_STATE = global_state;
-    // Initialize the ASIC API with the global state
-    asic_api_init(GLOBAL_STATE);
-    const char * base_path = "";
-
-    REST_CHECK(base_path, "wrong base path", err);
-    rest_server_context_t * rest_context = calloc(1, sizeof(rest_server_context_t));
-    REST_CHECK(rest_context, "No memory for rest context", err);
-    strlcpy(rest_context->base_path, base_path, sizeof(rest_context->base_path));
-
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+    config.global_user_ctx = GLOBAL_STATE;
     config.uri_match_fn = httpd_uri_match_wildcard;
     config.stack_size = 8192;
     config.max_open_sockets = 20;
@@ -1851,6 +1856,9 @@ esp_err_t start_rest_server(GlobalState * global_state)
     config.lru_purge_enable = true;
 
     ESP_LOGI(TAG, "Starting HTTP Server");
+    
+    httpd_handle_t server = NULL;
+
     REST_CHECK(httpd_start(&server, &config) == ESP_OK, "Start server failed", err_start);
 
     // Initialize the WebSocket registry with the valid server handle
@@ -1859,28 +1867,25 @@ esp_err_t start_rest_server(GlobalState * global_state)
     httpd_uri_t api_options_uri = {
         .uri = "/api/*", 
         .method = HTTP_OPTIONS, 
-        .handler = handle_options_request, 
-        .user_ctx = NULL
+        .handler = handle_options_request
     };
     httpd_register_uri_handler(server, &api_options_uri);
 
     httpd_uri_t recovery_explicit_get_uri = {
         .uri = "/recovery", 
         .method = HTTP_GET, 
-        .handler = rest_recovery_handler, 
-        .user_ctx = rest_context
+        .handler = rest_recovery_handler
     };
     httpd_register_uri_handler(server, &recovery_explicit_get_uri);
     
     // Register theme API endpoints
-    ESP_ERROR_CHECK(register_theme_api_endpoints(server, rest_context));
+    ESP_ERROR_CHECK(register_theme_api_endpoints(server));
 
     /* URI handler for fetching system info */
     httpd_uri_t system_info_get_uri = {
         .uri = "/api/system/info", 
         .method = HTTP_GET, 
-        .handler = GET_system_info, 
-        .user_ctx = rest_context
+        .handler = GET_system_info
     };
     httpd_register_uri_handler(server, &system_info_get_uri);
 
@@ -1888,8 +1893,7 @@ esp_err_t start_rest_server(GlobalState * global_state)
     httpd_uri_t system_boot_post_uri = {
         .uri = "/api/system/boot", 
         .method = HTTP_POST, 
-        .handler = POST_system_boot, 
-        .user_ctx = rest_context
+        .handler = POST_system_boot
     };
     httpd_register_uri_handler(server, &system_boot_post_uri);
 
@@ -1897,8 +1901,7 @@ esp_err_t start_rest_server(GlobalState * global_state)
     httpd_uri_t system_asic_get_uri = {
         .uri = "/api/system/asic", 
         .method = HTTP_GET, 
-        .handler = GET_system_asic, 
-        .user_ctx = rest_context
+        .handler = GET_system_asic
     };
     httpd_register_uri_handler(server, &system_asic_get_uri);
 
@@ -1906,16 +1909,14 @@ esp_err_t start_rest_server(GlobalState * global_state)
     httpd_uri_t system_statistics_get_uri = {
         .uri = "/api/system/statistics", 
         .method = HTTP_GET, 
-        .handler = GET_system_statistics, 
-        .user_ctx = rest_context
+        .handler = GET_system_statistics
     };
     httpd_register_uri_handler(server, &system_statistics_get_uri);
 
     httpd_uri_t scoreboard_get_uri = {
         .uri = "/api/system/scoreboard",
         .method = HTTP_GET,
-        .handler = GET_scoreboard,
-        .user_ctx = rest_context
+        .handler = GET_scoreboard
     };
     httpd_register_uri_handler(server, &scoreboard_get_uri);
 
@@ -1923,8 +1924,7 @@ esp_err_t start_rest_server(GlobalState * global_state)
     httpd_uri_t wifi_scan_get_uri = {
         .uri = "/api/system/wifi/scan",
         .method = HTTP_GET,
-        .handler = GET_wifi_scan,
-        .user_ctx = rest_context
+        .handler = GET_wifi_scan
     };
     httpd_register_uri_handler(server, &wifi_scan_get_uri);
 
@@ -1932,86 +1932,75 @@ esp_err_t start_rest_server(GlobalState * global_state)
     httpd_uri_t system_logs_get_uri = {
         .uri = "/api/system/logs",
         .method = HTTP_GET,
-        .handler = GET_system_logs,
-        .user_ctx = rest_context
+        .handler = GET_system_logs
     };
     httpd_register_uri_handler(server, &system_logs_get_uri);
 
     httpd_uri_t system_identify_uri = {
         .uri = "/api/system/identify", .method = HTTP_POST, 
-        .handler = POST_identify, 
-        .user_ctx = rest_context
+        .handler = POST_identify
     };
     httpd_register_uri_handler(server, &system_identify_uri);
 
     httpd_uri_t system_restart_uri = {
         .uri = "/api/system/restart", .method = HTTP_POST, 
-        .handler = POST_restart, 
-        .user_ctx = rest_context
+        .handler = POST_restart
     };
     httpd_register_uri_handler(server, &system_restart_uri);
 
     httpd_uri_t system_mining_pause_uri = {
         .uri = "/api/system/pause",
         .method = HTTP_POST,
-        .handler = POST_mining_pause,
-        .user_ctx = rest_context
+        .handler = POST_mining_pause
     };
     httpd_register_uri_handler(server, &system_mining_pause_uri);
 
     httpd_uri_t system_mining_resume_uri = {
         .uri = "/api/system/resume",
         .method = HTTP_POST,
-        .handler = POST_mining_resume,
-        .user_ctx = rest_context
+        .handler = POST_mining_resume
     };
     httpd_register_uri_handler(server, &system_mining_resume_uri);
 
     httpd_uri_t system_dismiss_block_found_uri = {
         .uri = "/api/system/blockFound/dismiss",
         .method = HTTP_POST, 
-        .handler = POST_dismiss_block_found, 
-        .user_ctx = NULL
+        .handler = POST_dismiss_block_found
     };
     httpd_register_uri_handler(server, &system_dismiss_block_found_uri);
 
     httpd_uri_t update_system_settings_uri = {
         .uri = "/api/system", 
         .method = HTTP_PATCH, 
-        .handler = PATCH_update_settings, 
-        .user_ctx = rest_context
+        .handler = PATCH_update_settings
     };
     httpd_register_uri_handler(server, &update_system_settings_uri);
 
     httpd_uri_t system_pool_put_uri = {
         .uri = "/api/system/pools/*",
         .method = HTTP_PUT,
-        .handler = PUT_system_pool,
-        .user_ctx = rest_context
+        .handler = PUT_system_pool
     };
     httpd_register_uri_handler(server, &system_pool_put_uri);
 
     httpd_uri_t system_pool_delete_uri = {
         .uri = "/api/system/pools/*",
         .method = HTTP_DELETE,
-        .handler = DELETE_system_pool,
-        .user_ctx = rest_context
+        .handler = DELETE_system_pool
     };
     httpd_register_uri_handler(server, &system_pool_delete_uri);
 
     httpd_uri_t update_post_ota_firmware = {
-        .uri = "/api/system/OTA", 
-        .method = HTTP_POST, 
-        .handler = POST_OTA_update, 
-        .user_ctx = NULL
+        .uri = "/api/system/OTA",
+        .method = HTTP_POST,
+        .handler = POST_OTA_update
     };
     httpd_register_uri_handler(server, &update_post_ota_firmware);
 
     httpd_uri_t update_post_ota_www = {
         .uri = "/api/system/OTAWWW", 
         .method = HTTP_POST, 
-        .handler = POST_WWW_update, 
-        .user_ctx = NULL
+        .handler = POST_WWW_update,
     };
     httpd_register_uri_handler(server, &update_post_ota_www);
 
@@ -2019,7 +2008,7 @@ esp_err_t start_rest_server(GlobalState * global_state)
         .uri = "/api/ws", 
         .method = HTTP_GET, 
         .handler = websocket_handler, 
-        .user_ctx = (void *)WS_TYPE_LOGS, 
+        .user_ctx = (void *)&WS_CTX_LOGS,
         .is_websocket = true,
         .ws_pre_handshake_cb = websocket_pre_handshake,
         .ws_post_handshake_cb = websocket_post_handshake
@@ -2030,7 +2019,7 @@ esp_err_t start_rest_server(GlobalState * global_state)
         .uri = "/api/ws/live", 
         .method = HTTP_GET, 
         .handler = websocket_handler, 
-        .user_ctx = (void *)WS_TYPE_API, 
+        .user_ctx = (void *)&WS_CTX_API,
         .is_websocket = true,
         .ws_pre_handshake_cb = websocket_pre_handshake,
         .ws_post_handshake_cb = websocket_post_handshake
@@ -2040,8 +2029,7 @@ esp_err_t start_rest_server(GlobalState * global_state)
     httpd_uri_t api_common_uri = {
         .uri = "/api/*",
         .method = HTTP_ANY,
-        .handler = rest_api_common_handler,
-        .user_ctx = rest_context
+        .handler = rest_api_common_handler
     };
     httpd_register_uri_handler(server, &api_common_uri);
     /* URI handler for getting web server files */
@@ -2049,8 +2037,7 @@ esp_err_t start_rest_server(GlobalState * global_state)
     httpd_uri_t common_get_uri = {
         .uri = "/*", 
         .method = HTTP_GET, 
-        .handler = use_custom ? rest_common_get_handler_spiffs : rest_common_get_handler_embedded, 
-        .user_ctx = rest_context
+        .handler = use_custom ? rest_common_get_handler_spiffs : rest_common_get_handler_embedded
     };
     httpd_register_uri_handler(server, &common_get_uri);
 
@@ -2074,7 +2061,5 @@ esp_err_t start_rest_server(GlobalState * global_state)
 
     return ESP_OK;
 err_start:
-    free(rest_context);
-err:
     return ESP_FAIL;
 }

--- a/main/http_server/theme_api.c
+++ b/main/http_server/theme_api.c
@@ -43,7 +43,10 @@ static esp_err_t theme_post_handler(httpd_req_t *req)
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
 
-    set_cors_headers(req);
+    if (set_cors_headers(req) != ESP_OK) {
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
 
     // Read POST data
     char content[1024];
@@ -82,20 +85,18 @@ static esp_err_t theme_post_handler(httpd_req_t *req)
     return ESP_OK;
 }
 
-esp_err_t register_theme_api_endpoints(httpd_handle_t server, void* ctx)
+esp_err_t register_theme_api_endpoints(httpd_handle_t server)
 {
     httpd_uri_t theme_get = {
         .uri = "/api/theme",
         .method = HTTP_GET,
-        .handler = theme_get_handler,
-        .user_ctx = ctx
+        .handler = theme_get_handler
     };
 
     httpd_uri_t theme_post = {
         .uri = "/api/theme",
         .method = HTTP_POST,
-        .handler = theme_post_handler,
-        .user_ctx = ctx
+        .handler = theme_post_handler
     };
 
     ESP_ERROR_CHECK(httpd_register_uri_handler(server, &theme_get));

--- a/main/http_server/theme_api.h
+++ b/main/http_server/theme_api.h
@@ -7,6 +7,6 @@
 #define DEFAULT_COLOR "#F80421"
 
 // Register theme API endpoints
-esp_err_t register_theme_api_endpoints(httpd_handle_t server, void* ctx);
+esp_err_t register_theme_api_endpoints(httpd_handle_t server);
 
 #endif // THEME_API_H

--- a/main/http_server/websocket.c
+++ b/main/http_server/websocket.c
@@ -26,6 +26,9 @@ static SemaphoreHandle_t clients_mutex = NULL;
 static httpd_handle_t server_handle = NULL;
 static TaskHandle_t s_websocket_log_task_handle = NULL;
 
+const WebSocketEndpointCtx WS_CTX_LOGS = { .type = WS_TYPE_LOGS };
+const WebSocketEndpointCtx WS_CTX_API  = { .type = WS_TYPE_API  };
+
 void websocket_set_log_task_handle(TaskHandle_t task_handle)
 {
     s_websocket_log_task_handle = task_handle;
@@ -195,7 +198,8 @@ esp_err_t websocket_pre_handshake(httpd_req_t *req)
 
 esp_err_t websocket_post_handshake(httpd_req_t *req)
 {
-    WebSocketClientType type = (WebSocketClientType)(uintptr_t)req->user_ctx;
+    const WebSocketEndpointCtx *ws_ctx = (const WebSocketEndpointCtx *)(req ? req->user_ctx : NULL);
+    WebSocketClientType type = ws_ctx ? ws_ctx->type : WS_TYPE_LOGS;
     int fd = httpd_req_to_sockfd(req);
     if (websocket_add_client(fd, type) != ESP_OK) {
         ESP_LOGE(TAG, "Unexpected failure adding client, fd: %d", fd);

--- a/main/http_server/websocket.h
+++ b/main/http_server/websocket.h
@@ -20,6 +20,13 @@ typedef enum {
     WS_TYPE_MAX
 } WebSocketClientType;
 
+typedef struct {
+    WebSocketClientType type;
+} WebSocketEndpointCtx;
+
+extern const WebSocketEndpointCtx WS_CTX_LOGS;
+extern const WebSocketEndpointCtx WS_CTX_API;
+
 esp_err_t websocket_add_client(int fd, WebSocketClientType type);
 void websocket_remove_client(int fd);
 void websocket_broadcast(WebSocketClientType type, httpd_ws_frame_t *pkt);


### PR DESCRIPTION
This PR sets GlobalState as global_user_ctx for all http handlers, simplifying code.

It also wraps the user_ctx for websocket handlers into a struct so it can be safely cast.

Finally, it removed legacy rest_server_context_t as it was not used and likely came from origin ESP example code. The scratch buffer is now heap allocated, instead of a shared buffer.

This is a first PR in a series of 3:

GlobalState cleanup (this PR);
Memory first OTA and toaster updates for firmware updates;
Direct firmware updates from GitHub (to be discussed).