### PR TITLE
nvs_config: clamp ASIC frequency setting to 100–1200 MHz

### DIFF
--- a/main/nvs_config.c
+++ b/main/nvs_config.c
@@ -60,10 +60,13 @@ static Settings settings[NVS_CONFIG_COUNT] = {
     [NVS_CONFIG_SECONDARY_POOL_INDEX]                  = {.nvs_key_name = "sec_idx",         .type = TYPE_U16,   .default_value = {.u16 = 1},                                           .rest_name = "secondaryPoolIndex",                 .min = 0,  .max = MAX_POOLS - 1},
     [NVS_CONFIG_USE_FALLBACK_STRATUM]                  = {.nvs_key_name = "usefbstartum",    .type = TYPE_BOOL,                                                                         .rest_name = "useFallbackStratum",                 .min = 0,  .max = 1},
 
-    // Clamp frequency to the same 100-800 MHz band the BAP handler
-    // (bap_handlers.c) already enforces; previously the HTTP API accepted
-    // 1..65535 MHz, writing garbage PLL registers to the ASIC.
-    [NVS_CONFIG_ASIC_FREQUENCY]                        = {.nvs_key_name = "asicfrequency_f", .type = TYPE_FLOAT, .default_value = {.f   = CONFIG_ASIC_FREQUENCY},                       .rest_name = "frequency",                          .min = 100,  .max = 800},
+    // Clamp frequency to 100-1200 MHz. The PLL solver (components/asic/pll.c)
+    // searches feedback dividers 144-235 and silently returns zeros when no
+    // solution exists; those zeros are written to the ASIC registers
+    // unchecked. The ceiling keeps intentional overclocking (AxeOS ?oc mode)
+    // working while rejecting values no BM13xx PLL can express. Note the BAP
+    // UART/display path enforces its own tighter 100-800 MHz bound.
+    [NVS_CONFIG_ASIC_FREQUENCY]                        = {.nvs_key_name = "asicfrequency_f", .type = TYPE_FLOAT, .default_value = {.f   = CONFIG_ASIC_FREQUENCY},                       .rest_name = "frequency",                          .min = 100,  .max = 1200},
     [NVS_CONFIG_ASIC_VOLTAGE]                          = {.nvs_key_name = "asicvoltage",     .type = TYPE_U16,   .default_value = {.u16 = CONFIG_ASIC_VOLTAGE},                         .rest_name = "coreVoltage",                        .min = 1,  .max = UINT16_MAX},
     [NVS_CONFIG_OVERCLOCK_ENABLED]                     = {.nvs_key_name = "oc_enabled",      .type = TYPE_BOOL,                                                                         .rest_name = "overclockEnabled",                   .min = 0,  .max = 1},
     

--- a/main/nvs_config.c
+++ b/main/nvs_config.c
@@ -60,7 +60,10 @@ static Settings settings[NVS_CONFIG_COUNT] = {
     [NVS_CONFIG_SECONDARY_POOL_INDEX]                  = {.nvs_key_name = "sec_idx",         .type = TYPE_U16,   .default_value = {.u16 = 1},                                           .rest_name = "secondaryPoolIndex",                 .min = 0,  .max = MAX_POOLS - 1},
     [NVS_CONFIG_USE_FALLBACK_STRATUM]                  = {.nvs_key_name = "usefbstartum",    .type = TYPE_BOOL,                                                                         .rest_name = "useFallbackStratum",                 .min = 0,  .max = 1},
 
-    [NVS_CONFIG_ASIC_FREQUENCY]                        = {.nvs_key_name = "asicfrequency_f", .type = TYPE_FLOAT, .default_value = {.f   = CONFIG_ASIC_FREQUENCY},                       .rest_name = "frequency",                          .min = 1,  .max = UINT16_MAX},
+    // Clamp frequency to the same 100-800 MHz band the BAP handler
+    // (bap_handlers.c) already enforces; previously the HTTP API accepted
+    // 1..65535 MHz, writing garbage PLL registers to the ASIC.
+    [NVS_CONFIG_ASIC_FREQUENCY]                        = {.nvs_key_name = "asicfrequency_f", .type = TYPE_FLOAT, .default_value = {.f   = CONFIG_ASIC_FREQUENCY},                       .rest_name = "frequency",                          .min = 100,  .max = 800},
     [NVS_CONFIG_ASIC_VOLTAGE]                          = {.nvs_key_name = "asicvoltage",     .type = TYPE_U16,   .default_value = {.u16 = CONFIG_ASIC_VOLTAGE},                         .rest_name = "coreVoltage",                        .min = 1,  .max = UINT16_MAX},
     [NVS_CONFIG_OVERCLOCK_ENABLED]                     = {.nvs_key_name = "oc_enabled",      .type = TYPE_BOOL,                                                                         .rest_name = "overclockEnabled",                   .min = 0,  .max = 1},
     


### PR DESCRIPTION
The HTTP settings validator (`check_settings_and_update`) derives its numeric bounds from the settings table, which allowed `frequency` values of 1–65535 MHz. This clamps the accepted range to 100–1200 MHz.

**Why a limit is needed at all** — the failure chain for an out-of-range value:

1. The schema accepts the value and persists it to NVS (`nvs_config.c`).
2. On apply, `pll_get_parameters(target, ...)` (`components/asic/pll.c`) searches for PLL dividers that produce the requested clock. Its search space covers feedback dividers 144–235 — physically meaningful for the ~100–900 MHz operating region. For a target like 65535 MHz no solution exists, and the function has **no error return**: it yields its initialized all-zero parameters.
3. The per-chip `send_hash_frequency` (e.g. `bm1368.c`) packs those unchecked zeros into the PLL register write — a nonsense/divide-by-zero clock configuration goes straight onto the ASIC. Realistic outcome: the PLL never locks and the chip stops hashing until reboot + frequency reset.
4. The bogus value sits in NVS, so it is reapplied on every boot.

So an out-of-range frequency is a persistent denial-of-mining, recoverable only by manual intervention.

**Why 1200 and not 800:** the BAP UART/display handler (`bap_handlers.c`) enforces its own 100–800 MHz bound, and an earlier version of this PR matched it. But the HTTP API is also the path used by AxeOS's deliberate overclock mode (the `?oc` unlock in the settings UI), where values above 800 MHz are a legitimate, supported workflow. 1200 MHz leaves generous headroom for intentional overclocking while still rejecting values no BM13xx PLL can express. The BAP path keeps its tighter 800 bound independently — out of scope here.

Fan speed ranges are intentionally unchanged (0–100% is a legitimate manual override; the 75 °C thermal trip remains the backstop).