### PR TITLE
hostname: validate charset as RFC 1123 label; keep mDNS conflict renames runtime-only

### DIFF
--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -171,10 +171,14 @@ static void initialize_mdns_if_needed(GlobalState *GLOBAL_STATE) {
             return;
         }
 
-        /* If conflict resolution changed the hostname, persist to NVS */
+        /* A conflict-resolved rename is applied at runtime only and
+         * is deliberately NOT persisted to NVS. mDNS conflict answers are
+         * unauthenticated multicast: any LAN host can spoof one, and persisting
+         * the rename let an attacker rewrite device identity and amplify flash
+         * writes. The configured hostname stays authoritative across reboots. */
         if (strcmp(final_hostname, hostname) != 0) {
-            nvs_config_set_string(NVS_CONFIG_HOSTNAME, final_hostname);
-            ESP_LOGI(TAG, "Hostname conflict resolved, updated NVS to: %s", final_hostname);
+            ESP_LOGW(TAG, "mDNS conflict: using '%s' for this session only, configured hostname '%s' unchanged",
+                     final_hostname, hostname);
         }
 
         /* Set mDNS hostname */
@@ -280,10 +284,11 @@ esp_err_t update_mdns_hostname(const char *new_hostname, GlobalState *GLOBAL_STA
         return ESP_ERR_NO_MEM;
     }
 
-    /* If the hostname was resolved to a different one, update NVS */
+    /* Runtime-only rename, never persisted (see note in the mDNS
+     * init path): spoofed conflict answers must not rewrite NVS identity. */
     if (strcmp(resolved_hostname, new_hostname) != 0) {
-        nvs_config_set_string(NVS_CONFIG_HOSTNAME, resolved_hostname);
-        ESP_LOGI(TAG, "Hostname conflict resolved, updated NVS to: %s", resolved_hostname);
+        ESP_LOGW(TAG, "mDNS conflict: using '%s' for this session only, configured hostname '%s' unchanged",
+                 resolved_hostname, new_hostname);
     }
 
     esp_err_t err = mdns_hostname_set(resolved_hostname);

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -307,6 +307,30 @@ static void normalize_hostname(char *hostname, size_t max_len) {
     }
 }
 
+// Validate hostname charset (RFC 1123 label: letters, digits,
+// hyphens; no leading/trailing hyphen; <= 63 chars). The value flows into the
+// mDNS responder name, DHCP option 12 and the display, none of which sanitize.
+static bool is_valid_hostname(const char *hostname) {
+    if (hostname == NULL) {
+        return false;
+    }
+    size_t len = strlen(hostname);
+    if (len == 0 || len > 63) {
+        return false;
+    }
+    if (hostname[0] == '-' || hostname[len - 1] == '-') {
+        return false;
+    }
+    for (size_t i = 0; i < len; i++) {
+        char c = hostname[i];
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+              (c >= '0' && c <= '9') || c == '-')) {
+            return false;
+        }
+    }
+    return true;
+}
+
 esp_err_t is_network_allowed(httpd_req_t * req)
 {
     if (GLOBAL_STATE->SYSTEM_MODULE.ap_enabled == true) {
@@ -838,6 +862,11 @@ bool check_settings_and_update(const cJSON * const root, char **redirect_url)
         char normalized_new_hostname[64];
         strlcpy(normalized_new_hostname, hostname_item->valuestring, sizeof(normalized_new_hostname));
         normalize_hostname(normalized_new_hostname, sizeof(normalized_new_hostname));
+        if (!is_valid_hostname(normalized_new_hostname)) {
+            ESP_LOGW(TAG, "Invalid hostname charset: '%s'", hostname_item->valuestring);
+            free(old_hostname);
+            return false;
+        }
         if (strcmp(old_hostname, normalized_new_hostname) != 0) {
             hostname_changed = true;
             ESP_LOGI(TAG, "Hostname change detected: %s -> %s", old_hostname, hostname_item->valuestring);


### PR DESCRIPTION
Two hostname-handling fixes:

**1. No charset validation.** The settings API length-checked `hostname` (1–32) but never validated its contents, so arbitrary strings flowed into the mDNS responder name, DHCP option 12 and the display, none of which sanitize. Values are now validated as RFC 1123 labels (letters, digits, hyphens; no leading/trailing hyphen; ≤ 63 chars) before being accepted.

**2. mDNS conflict resolution persisted spoofable renames.** `check_and_resolve_hostname_conflict` trusts any multicast A-record answer, and both call sites persisted the resulting rename to NVS — so a spoofed conflict answer could rewrite the device's configured identity and cause repeated flash writes. Conflict renames are now applied for the runtime session only; the configured hostname remains authoritative across reboots.