### PR TITLE
time trust: plausibility-check pool ntime; enforce SV2 certificate validity window

### DIFF
--- a/components/stratum_v2/sv2_noise.c
+++ b/components/stratum_v2/sv2_noise.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "esp_log.h"
 #include "esp_random.h"
@@ -481,6 +482,25 @@ int sv2_noise_handshake(sv2_noise_ctx_t *ctx, esp_transport_handle_t transport,
 
     ESP_LOGI(TAG, "Server certificate: version=%d, valid_from=%lu, not_valid_after=%lu",
              cert_version, valid_from, not_valid_after);
+
+    // Enforce the certificate validity window. It is SV2's only
+    // revocation mechanism; without this check a leaked or retired pool
+    // endpoint key remains MITM-usable indefinitely. Note the wall clock
+    // here is pool-influenced unless the ntime plausibility checks in
+    // system.c are in place — the two fixes should ship together.
+    time_t now = time(NULL);
+    if (now > 0) {
+        if ((uint64_t) now < (uint64_t) valid_from) {
+            ESP_LOGE(TAG, "Server certificate not yet valid (valid_from=%lu, now=%lld)",
+                     (unsigned long) valid_from, (long long) now);
+            return -1;
+        }
+        if ((uint64_t) now > (uint64_t) not_valid_after) {
+            ESP_LOGE(TAG, "Server certificate expired (not_valid_after=%lu, now=%lld)",
+                     (unsigned long) not_valid_after, (long long) now);
+            return -1;
+        }
+    }
 
     // Step 15: Verify Schnorr signature if authority pubkey provided
     if (authority_pubkey) {

--- a/main/system.c
+++ b/main/system.c
@@ -387,12 +387,84 @@ void SYSTEM_notify_rejected_share(GlobalState * GLOBAL_STATE, char * error_msg)
     }    
 }
 
+// Pool-supplied ntime used to drive settimeofday() with no
+// plausibility band and a rate limiter that compared against the
+// supplied value itself. The device has no RTC/NTP, so the pool fully owned
+// the system clock — which is also the clock TLS certificate expiry (and the
+// SV2 certificate validity window) is judged against.
+//
+// Policy implemented here:
+//  - floor: ntime must not predate the firmware build time;
+//  - backward moves are rejected (small 5 min tolerance for pool jitter);
+//  - forward jumps are capped at 4 hours per accepted update;
+//  - the hourly rate limiter measures against the *current* system clock,
+//    not the supplied value, so a far-future set is no longer sticky.
+#define NTIME_BACKWARD_TOLERANCE_SEC (5 * 60)
+#define NTIME_MAX_FORWARD_JUMP_SEC (4 * 60 * 60)
+#define NTIME_MIN_SYNC_INTERVAL_SEC (60 * 60)
+// Cap for the very first clock set after boot (no trusted reference yet):
+// firmware build time + 400 days. Devices older than that simply skip clock
+// sync (mining is unaffected) rather than accepting an arbitrary epoch.
+#define NTIME_MAX_INITIAL_AGE_SEC (400LL * 24 * 60 * 60)
+
+// Epoch of firmware build, from the compiler's __DATE__/__TIME__ ("Mmm dd yyyy").
+// The device default timezone is UTC, so mktime() is UTC-based here.
+static time_t system_build_epoch(void)
+{
+    static const char month_names[] = "JanFebMarAprMayJunJulAugSepOctNovDec";
+    char mon[4] = {0};
+    int day = 0, year = 0, hour = 0, min = 0, sec = 0;
+    if (sscanf(__DATE__, "%3s %d %d", mon, &day, &year) != 3 ||
+        sscanf(__TIME__, "%d:%d:%d", &hour, &min, &sec) != 3) {
+        return 0;
+    }
+    const char *hit = strstr(month_names, mon);
+    if (hit == NULL) {
+        return 0;
+    }
+    struct tm build = {0};
+    build.tm_mon = (int) ((hit - month_names) / 3);
+    build.tm_mday = day;
+    build.tm_year = year - 1900;
+    build.tm_hour = hour;
+    build.tm_min = min;
+    build.tm_sec = sec;
+    return mktime(&build);
+}
+
 void SYSTEM_notify_new_ntime(GlobalState * GLOBAL_STATE, uint32_t ntime)
 {
     SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
 
-    // Hourly clock sync
-    if (module->lastClockSync + (60 * 60) > ntime) {
+    time_t now = time(NULL);
+    time_t floor = system_build_epoch();
+
+    if (floor > 0 && (int64_t) ntime < (int64_t) floor) {
+        ESP_LOGW(TAG, "Rejecting ntime %lu: predates firmware build time", (unsigned long) ntime);
+        return;
+    }
+
+    if (floor > 0 && now >= floor) {
+        int64_t delta = (int64_t) ntime - (int64_t) now;
+        if (delta < -NTIME_BACKWARD_TOLERANCE_SEC) {
+            ESP_LOGW(TAG, "Rejecting ntime %lu: backward jump of %lld s", (unsigned long) ntime, (long long) -delta);
+            return;
+        }
+        if (delta > NTIME_MAX_FORWARD_JUMP_SEC) {
+            ESP_LOGW(TAG, "Rejecting ntime %lu: forward jump of %lld s exceeds %d s",
+                     (unsigned long) ntime, (long long) delta, NTIME_MAX_FORWARD_JUMP_SEC);
+            return;
+        }
+    } else if (floor > 0) {
+        // Clock not set yet: accept only a plausible "now" relative to build time
+        if ((int64_t) ntime > (int64_t) floor + NTIME_MAX_INITIAL_AGE_SEC) {
+            ESP_LOGW(TAG, "Rejecting initial ntime %lu: too far past firmware build time", (unsigned long) ntime);
+            return;
+        }
+    }
+
+    // Hourly clock sync, measured against the current system clock
+    if (module->lastClockSync != 0 && (int64_t) now - (int64_t) module->lastClockSync < NTIME_MIN_SYNC_INTERVAL_SEC) {
         return;
     }
     ESP_LOGI(TAG, "Syncing clock");


### PR DESCRIPTION
Two commits that should ship together — the second's correctness depends on the first.

**Commit 1 — `system.c`: plausibility band for pool-supplied `ntime`.** Every V1 `mining.notify` and every V2 job fed pool-controlled `ntime` straight into `settimeofday()` with no bounds, and the hourly rate limiter compared against the supplied value itself, so a far-future set was sticky. The device has no RTC/NTP, so the pool effectively owned the system clock — the same clock TLS certificate expiry and the SV2 certificate window are judged against. `ntime` is now rejected if it predates the firmware build time, moves the clock backward (5 min tolerance), or jumps forward more than 4 h per accepted update; the first set after boot is capped at build time + 400 days; the rate limiter measures against the current system clock instead of the supplied value.

**Commit 2 — `sv2_noise.c`: enforce the SV2 server certificate validity window.** The Noise handshake parsed `valid_from`/`not_valid_after` from the pool's certificate message and verified the Schnorr signature, but never compared the window against current time. The window is SV2's only revocation mechanism, so a leaked or retired pool endpoint key remained usable indefinitely. Certificates outside their validity window now fail the handshake.