### PR TITLE
axe-os UI hardening: release-notes escaping, swarm action target, quicklink encoding

### DIFF
--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -345,7 +345,7 @@ private isIpAddress(value: string): boolean {
         return;
       }
 
-      if (this.swarm.some(item => item.connectionAddress === info['ipv4'])) {
+      if (this.swarm.some(item => item.connectionAddress === address)) {
         this.toastr.warning('Device already added to the swarm.', `Device at ${address}`);
         return;
       }
@@ -353,7 +353,10 @@ private isIpAddress(value: string): boolean {
       const device = {
         address: info['fullHostname'] || info['hostname'] || address,
         displayName: info['hostname'] ? info['hostname'].replace(/\.local$/i, '') : address,
-        connectionAddress: info['ipv4'] || address,
+        // The action target must be the address we actually
+        // connected to, never a response-supplied field — a rogue LAN
+        // responder could otherwise redirect restart/identify POSTs.
+        connectionAddress: address,
         ...asic,
         ...info,
         ...this.numerizeDeviceBestDiffs(info)
@@ -519,12 +522,23 @@ private isIpAddress(value: string): boolean {
   }
 
   private fallbackDeviceModel(data: any): any {
+    const safeColor = this.sanitizeSwarmColor(data.swarmColor);
+    if (data.swarmColor && !safeColor) {
+      data = { ...data, swarmColor: undefined };
+    }
     if (data.deviceModel && data.swarmColor && data.poolDifficulty && data.hashRate) return data;
     const deviceModel = data.deviceModel || this.deriveDeviceModel(data);
-    const swarmColor = data.swarmColor || this.deriveSwarmColor(deviceModel);
+    const swarmColor = safeColor || this.deriveSwarmColor(deviceModel);
     const poolDifficulty = data.poolDifficulty || data.stratumDiff;
     const hashRate = data.hashRate || data.hashRate_10m;
     return { ...data, deviceModel, swarmColor, poolDifficulty, hashRate };
+  }
+
+  // swarmColor is a remote-supplied string rendered as a CSS
+  // value; clamp it to the known palette instead of trusting the peer.
+  private sanitizeSwarmColor(color: any): string | null {
+    const palette = ['red', 'purple', 'blue', 'orange', 'green', 'cyan', 'gray'];
+    return (typeof color === 'string' && palette.includes(color)) ? color : null;
   }
 
   private numerizeDeviceBestDiffs(info: ISystemInfo) {

--- a/main/http_server/axe-os/src/app/components/update/update.component.ts
+++ b/main/http_server/axe-os/src/app/components/update/update.component.ts
@@ -178,13 +178,23 @@ export class UpdateComponent {
 
   // https://gist.github.com/elfefe/ef08e583e276e7617cd316ba2382fc40
   public simpleMarkdownParser(markdown: string): string {
-    const toHTML = markdown
+    // Escape HTML entities in the (remotely authored) input
+    // BEFORE generating any markup. Previously the regex chain ran on raw
+    // release-note text and XSS prevention rested entirely on Angular's
+    // [innerHTML] sanitizer.
+    const escaped = markdown
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+    const toHTML = escaped
       .replace(/^#{1,6}\s+(.+)$/gim, '<h4 class="mt-2">$1</h4>') // Headlines
       .replace(/\*\*(.+?)\*\*|__(.+?)__/gim, '<b>$1</b>') // Bold text
       .replace(/\*(.+?)\*|_(.+?)_/gim, '<i>$1</i>') // Italic text
-      .replace(/\[(.*?)\]\((.*?)\s?(?:"(.*?)")?\)/gm, '<a href="$2" class="underline text-white" target="_blank">$1</a>') // Markdown links
-      .replace(/(https?:\/\/github\.com\/.+\/(.+[^\s])+)/gim, (match, p1, p2) => `<a href="${p1}" target="_blank">${match.includes('/pull/') ? '#' : ''}${p2}</a>`) // Regular links
-      .replace(/@([^\s]+)/gim, ' <a href="https://github.com/$1" target="_blank">@$1</a> ') // Username links
+      .replace(/\[(.*?)\]\((.*?)\s?(?:&quot;(.*?)&quot;)?\)/gm, '<a href="$2" class="underline text-white" target="_blank" rel="noopener noreferrer">$1</a>') // Markdown links
+      .replace(/(https?:\/\/github\.com\/.+\/(.+[^\s])+)/gim, (match, p1, p2) => `<a href="${p1}" target="_blank" rel="noopener noreferrer">${match.includes('/pull/') ? '#' : ''}${p2}</a>`) // Regular links
+      .replace(/@([^\s]+)/gim, ' <a href="https://github.com/$1" target="_blank" rel="noopener noreferrer">@$1</a> ') // Username links
       .replace(/^\s*[-+*]\s?(.+)$/gim, '<li>$1</li>') // Unordered list
       .replace(/`([^`]+)`/gim, '<code class="bg-surface-100 rounded px-1">$1</code>') // Code
       .replace(/\r\n\r\n/gim, '<br>'); // Breaks

--- a/main/http_server/axe-os/src/app/services/quicklink.service.ts
+++ b/main/http_server/axe-os/src/app/services/quicklink.service.ts
@@ -18,7 +18,9 @@ export class QuicklinkService {
    * @returns A URL to the pool's user stats page, or undefined if no matching pool is found
    */
   public getQuickLink(stratumURL: string, stratumUser: string): string | undefined {
-    const user = stratumUser.split('.')[0];
+    // stratumUser is user-controlled via the settings API;
+    // encode it before splicing it into third-party URL paths/queries.
+    const user = encodeURIComponent(stratumUser.split('.')[0]);
 
     // Match entries against a lowercased stratum URL.
     const pools: Pool[] = [


### PR DESCRIPTION
Three small, independent UI fixes (one commit each):

**1. Escape release notes before markdown rendering (`update.component.ts`).** `simpleMarkdownParser` ran its regex chain on the raw, remotely authored GitHub release body and bound the result to `[innerHTML]` with no HTML-escaping step, relying entirely on Angular's sanitizer. The input is now entity-escaped before any markup is generated, and generated `target="_blank"` anchors carry `rel="noopener noreferrer"`.

**2. Swarm actions target the connected address (`swarm.component.ts`).** The swarm scanner accepted any LAN HTTP responder as a device and took `connectionAddress` from the response-supplied `ipv4` field, so a rogue responder could redirect restart/identify POSTs to an arbitrary IP. The address actually connected to is now used. Remote `swarmColor` strings are also clamped to the known palette before being rendered as CSS values.

**3. URL-encode stratum user in pool quicklinks (`quicklink.service.ts`).** `getQuickLink` spliced `stratumUser` into pool stats URL templates with no encoding, so a value containing `/`, `?` or `#` mutated the destination. The token is now `encodeURIComponent`'d.