### PR TITLE
Fix component inclusion warnings

### DIFF
--- a/components/asic/CMakeLists.txt
+++ b/components/asic/CMakeLists.txt
@@ -14,9 +14,8 @@ SRCS
 INCLUDE_DIRS 
     "include"
 
-PRIV_INCLUDE_DIRS
-    "../../main"
-    "../../main/tasks"
+PRIV_REQUIRES
+    "main"
 
 REQUIRES 
     "freertos"

--- a/components/asic/CMakeLists.txt
+++ b/components/asic/CMakeLists.txt
@@ -14,13 +14,15 @@ SRCS
 INCLUDE_DIRS 
     "include"
 
-PRIV_REQUIRES
-    "main"
-
 REQUIRES 
     "freertos"
     "esp_driver_uart"
     "stratum"
     "stratum_v2"
     "tcp_transport"
+)
+
+target_include_directories(${COMPONENT_LIB} PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/../../main"
+    "${CMAKE_CURRENT_LIST_DIR}/../../main/tasks"
 )

--- a/components/connect/CMakeLists.txt
+++ b/components/connect/CMakeLists.txt
@@ -5,9 +5,6 @@ SRCS
 INCLUDE_DIRS 
     "include"
 
-PRIV_REQUIRES
-    "main"
-
 REQUIRES
     "asic"
     "nvs_flash"
@@ -16,4 +13,9 @@ REQUIRES
     "stratum"
     "stratum_v2"
     "espressif__mdns"
+)
+
+target_include_directories(${COMPONENT_LIB} PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/../../main"
+    "${CMAKE_CURRENT_LIST_DIR}/../../main/tasks"
 )

--- a/components/connect/CMakeLists.txt
+++ b/components/connect/CMakeLists.txt
@@ -5,9 +5,8 @@ SRCS
 INCLUDE_DIRS 
     "include"
 
-PRIV_INCLUDE_DIRS
-    "../../main"
-    "../../main/tasks"
+PRIV_REQUIRES
+    "main"
 
 REQUIRES
     "asic"


### PR DESCRIPTION
Fixes these compiler warnings (4x):
```
CMake Warning at /home/mutatrum/esp/v6.0.2/esp-idf/tools/cmake/component_validation.cmake:122 (message):
  Private include directory '/home/mutatrum/code-workspace/esp-miner/main'
  belongs to component main but is being used by component asic.  It is
  recommended to define the component dependency for asic on the component
  main, i.e.  'idf_component_register(...  PRIV_REQUIRES main)' in the
  CMakeLists.txt of asic, and specify the included directory as
  idf_component_register(...  PRIV_INCLUDE_DIRS <dir relative to component>)
  in the CMakeLists.txt of component main.
Call Stack (most recent call first):
  /home/mutatrum/esp/v6.0.2/esp-idf/tools/cmake/component_validation.cmake:147 (__component_validation_check_include_dirs)
  /home/mutatrum/esp/v6.0.2/esp-idf/CMakeLists.txt:349 (__component_validation_run_checks)
```
At some time we should break the circular dependencies from components back to main, but that's a bigger change.