### PR TITLE
sv2: handle SetExtranoncePrefix (0x19)

### DIFF
--- a/components/stratum_v2/include/sv2_protocol.h
+++ b/components/stratum_v2/include/sv2_protocol.h
@@ -25,6 +25,7 @@
 #define SV2_MSG_SUBMIT_SHARES_EXTENDED                  0x1b
 #define SV2_MSG_SUBMIT_SHARES_SUCCESS                   0x1c
 #define SV2_MSG_SUBMIT_SHARES_ERROR                     0x1d
+#define SV2_MSG_SET_EXTRANONCE_PREFIX                   0x19
 #define SV2_MSG_SET_NEW_PREV_HASH                       0x20
 #define SV2_MSG_SET_TARGET                              0x21
 
@@ -84,6 +85,12 @@ typedef struct {
     uint16_t coinbase_prefix_len;
     uint8_t *coinbase_suffix;     // heap
     uint16_t coinbase_suffix_len;
+    // Extranonce prefix in force when this job arrived. Spec 5.3.10: a
+    // SetExtranoncePrefix applies to jobs sent after it, and work is generated
+    // from a job long after it arrived (and repeatedly, once per extranonce_2),
+    // so the value cannot be read from the connection at that point.
+    uint8_t  extranonce_prefix[32];
+    uint8_t  extranonce_prefix_len;
 } sv2_ext_job_t;
 
 #define SV2_PENDING_JOBS_SIZE 8
@@ -166,6 +173,12 @@ int sv2_parse_set_new_prev_hash(const uint8_t *payload, uint32_t len,
                                 uint32_t *channel_id, uint32_t *job_id,
                                 uint8_t prev_hash[32],
                                 uint32_t *min_ntime, uint32_t *nbits);
+
+// Parse SetExtranoncePrefix: channel_id U32 + extranonce_prefix B0_32.
+int sv2_parse_set_extranonce_prefix(const uint8_t *payload, uint32_t len,
+                                    uint32_t *channel_id,
+                                    uint8_t *extranonce_prefix,
+                                    uint8_t *extranonce_prefix_len);
 
 int sv2_parse_set_target(const uint8_t *payload, uint32_t len,
                          uint32_t *channel_id, uint8_t max_target[32]);

--- a/components/stratum_v2/sv2_protocol.c
+++ b/components/stratum_v2/sv2_protocol.c
@@ -299,6 +299,25 @@ int sv2_parse_set_new_prev_hash(const uint8_t *payload, uint32_t len,
     return 0;
 }
 
+int sv2_parse_set_extranonce_prefix(const uint8_t *payload, uint32_t len,
+                                    uint32_t *channel_id,
+                                    uint8_t *extranonce_prefix,
+                                    uint8_t *extranonce_prefix_len)
+{
+    // channel_id(4) + extranonce_prefix B0_32 (1 + N) = min 5 bytes
+    if (len < 5) return -1;
+
+    *channel_id = read_u32_le(payload);
+
+    uint8_t prefix_len = payload[4];
+    if (prefix_len > 32) return -1;
+    if (5 + (uint32_t)prefix_len > len) return -1;
+
+    *extranonce_prefix_len = prefix_len;
+    memcpy(extranonce_prefix, payload + 5, prefix_len);
+    return 0;
+}
+
 int sv2_parse_set_target(const uint8_t *payload, uint32_t len,
                          uint32_t *channel_id, uint8_t max_target[32])
 {

--- a/main/tasks/create_jobs_task.c
+++ b/main/tasks/create_jobs_task.c
@@ -341,7 +341,7 @@ static void generate_work_sv2_ext(GlobalState *GLOBAL_STATE, sv2_ext_job_t *ext_
     uint8_t coinbase_tx_hash[32];
     calculate_coinbase_tx_hash_bin(
         ext_job->coinbase_prefix, ext_job->coinbase_prefix_len,
-        conn->extranonce_prefix, conn->extranonce_prefix_len,
+        ext_job->extranonce_prefix, ext_job->extranonce_prefix_len,
         extranonce_2, extranonce_2_len,
         ext_job->coinbase_suffix, ext_job->coinbase_suffix_len,
         coinbase_tx_hash);

--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -313,7 +313,7 @@ static void stratum_v2_decode_coinbase(GlobalState *GLOBAL_STATE, sv2_conn_t *co
     // Convert binary prefix/suffix/extranonce to hex strings for the V1 decoder
     char *coinbase_1_hex = malloc(prefix_len * 2 + 1);
     char *coinbase_2_hex = malloc(job->coinbase_suffix_len * 2 + 1);
-    char *extranonce1_hex = malloc(conn->extranonce_prefix_len * 2 + 1);
+    char *extranonce1_hex = malloc(job->extranonce_prefix_len * 2 + 1);
     if (!coinbase_1_hex || !coinbase_2_hex || !extranonce1_hex) {
         ESP_LOGE(TAG, "Failed to allocate hex buffers for coinbase decode");
         free(coinbase_1_hex);
@@ -327,8 +327,8 @@ static void stratum_v2_decode_coinbase(GlobalState *GLOBAL_STATE, sv2_conn_t *co
             coinbase_1_hex, prefix_len * 2 + 1);
     bin2hex(job->coinbase_suffix, job->coinbase_suffix_len,
             coinbase_2_hex, job->coinbase_suffix_len * 2 + 1);
-    bin2hex(conn->extranonce_prefix, conn->extranonce_prefix_len,
-            extranonce1_hex, conn->extranonce_prefix_len * 2 + 1);
+    bin2hex(job->extranonce_prefix, job->extranonce_prefix_len,
+            extranonce1_hex, job->extranonce_prefix_len * 2 + 1);
     free(stripped_prefix);
 
     // SV2 spec: extranonce_size is the miner's rollable portion (not total)
@@ -369,7 +369,7 @@ static void stratum_v2_decode_coinbase(GlobalState *GLOBAL_STATE, sv2_conn_t *co
         ESP_LOGE(TAG, "Failed to decode extended job coinbase (err=0x%x, prefix_len=%u, "
                  "suffix_len=%u, en_prefix_len=%u, en_size=%u, prefix_start=%s)",
                  err, job->coinbase_prefix_len, job->coinbase_suffix_len,
-                 conn->extranonce_prefix_len, conn->extranonce_size, prefix_hex);
+                 job->extranonce_prefix_len, conn->extranonce_size, prefix_hex);
         free(result);
         return;
     }
@@ -439,6 +439,11 @@ static void stratum_v2_handle_new_extended_mining_job(GlobalState *GLOBAL_STATE,
              job->job_id, job->version, job->merkle_path_count,
              job->coinbase_prefix_len, job->coinbase_suffix_len,
              job->ntime > 0 ? "no" : "yes");
+
+    // Pin the prefix in force now: work for this job is generated later, and a
+    // SetExtranoncePrefix applies only to jobs sent after it (spec 5.3.10).
+    job->extranonce_prefix_len = conn->extranonce_prefix_len;
+    memcpy(job->extranonce_prefix, conn->extranonce_prefix, conn->extranonce_prefix_len);
 
     // Decode coinbase transaction (block height, scriptsig, outputs)
     stratum_v2_decode_coinbase(GLOBAL_STATE, conn, job);
@@ -586,6 +591,26 @@ static void stratum_v2_handle_set_new_prev_hash(GlobalState *GLOBAL_STATE, sv2_c
 }
 
 // Handle SetTarget message
+static void stratum_v2_handle_set_extranonce_prefix(sv2_conn_t *conn,
+                                                    const uint8_t *payload, uint32_t len)
+{
+    uint32_t channel_id;
+    uint8_t prefix[32];
+    uint8_t prefix_len;
+
+    if (sv2_parse_set_extranonce_prefix(payload, len, &channel_id, prefix, &prefix_len) != 0) {
+        ESP_LOGE(TAG, "Failed to parse SetExtranoncePrefix");
+        return;
+    }
+
+    char prefix_hex[65] = {0};
+    bin2hex(prefix, prefix_len, prefix_hex, sizeof(prefix_hex));
+    ESP_LOGI(TAG, "Set extranonce prefix: %s (applies to following jobs)", prefix_hex);
+
+    conn->extranonce_prefix_len = prefix_len;
+    memcpy(conn->extranonce_prefix, prefix, prefix_len);
+}
+
 static void stratum_v2_handle_set_target(GlobalState *GLOBAL_STATE, sv2_conn_t *conn,
                                          const uint8_t *payload, uint32_t len)
 {
@@ -1009,6 +1034,10 @@ void stratum_v2_task(void *pvParameters)
 
                 case SV2_MSG_NEW_EXTENDED_MINING_JOB:
                     stratum_v2_handle_new_extended_mining_job(GLOBAL_STATE, conn, recv_buf, hdr.msg_length);
+                    break;
+
+                case SV2_MSG_SET_EXTRANONCE_PREFIX:
+                    stratum_v2_handle_set_extranonce_prefix(conn, recv_buf, hdr.msg_length);
                     break;
 
                 case SV2_MSG_SET_NEW_PREV_HASH:


### PR DESCRIPTION
## What

Handle `SetExtranoncePrefix` (message type `0x19`). It was missing from the SV2
frame dispatch, so it hit the `default` arm and was logged as an unknown
message type.

This is what lets a pool or a proxy re-point a channel's extranonce while the
miner keeps mining — the SV2 equivalent of `mining.set_extranonce`, which the
SV1 path already opts into and handles. Useful mainly for proxies, which need
to hand each downstream miner its own extranonce.

## Implementation note

Spec 5.3.10: the new prefix applies to jobs sent *after* the message.
`generate_work_sv2_ext()` reads the prefix when it builds work, which happens
long after a job arrived and again for every `extranonce_2` — so a job now pins
the prefix that was in force when it arrived instead of reading the
connection's current one.

`extranonce_size` stays on the connection: 5.3.12 fixes it at channel opening
and this message does not change it.

## Testing

Builds clean against IDF 6.0.2, no new warnings. The parser is covered by a
native test over the B0_32 encoding (valid frame, empty prefix, length 32,
length > 32, truncated payload, short payload).

Not yet exercised on hardware against a pool that changes the prefix; the same
change on another ESP-Miner-derived firmware was, with shares accepted across
the switch and none rejected.
