### PR TITLE
stratum: validate set_difficulty range (reject NaN/inf/<1/>uint32)

### DIFF
--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -16,6 +16,7 @@
 #include "esp_timer.h"
 #include "esp_heap_caps.h"
 #include <inttypes.h>
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -347,7 +348,16 @@ static bool parse_set_difficulty(cJSON *json, StratumApiV1Message *message)
         ESP_LOGE(TAG, "Invalid difficulty value in set_difficulty");
         return false;
     }
-    message->new_difficulty = difficulty->valuedouble;
+    double d = difficulty->valuedouble;
+    /* Reject NaN/inf and non-positive values, and keep the value inside the
+     * uint32 range used by get_difficulty_mask() (float->int cast is UB
+     * outside it). A >4e9 share difficulty is meaningless for this hardware
+     * class anyway. */
+    if (!isfinite(d) || d < 1.0 || d > 4294967295.0) {
+        ESP_LOGE(TAG, "Difficulty value out of range in set_difficulty: %f", d);
+        return false;
+    }
+    message->new_difficulty = d;
     ESP_LOGI(TAG, "Set pool difficulty: %.2f", message->new_difficulty);
     return true;
 }


### PR DESCRIPTION
Reported via coordinated disclosure by the 256 Foundation Red Team (finding RT-2026-052; follow-up to #1880, split out per maintainer preference).

## set_difficulty accepts −1 / 0 / inf / NaN → UB float→int cast + wrong-work modes

`parse_set_difficulty()` in `components/stratum/stratum_api.c` checked only `cJSON_IsNumber`, then stored the value verbatim into the pool difficulty. The pool (or a LAN MITM — stratum v1 is plaintext by default) could set difficulty to **−1**, **0**, **1e999** (→ +inf), or **NaN**.

Downstream, `get_difficulty_mask()` in `components/asic/asic_common.c` does `(uint32_t)ceil(difficulty)`: **undefined behavior** for negative/inf/NaN, and difficulty 0 yields mask 0 — the ASIC hardware filter then accepts every nonce, silently distorting work accounting versus the pool's share target ( floods of "easy" shares the pool rejects; local stats skew).

No crash demonstrated — this is a state-corruption / wrong-work hazard plus a UB hot spot.

**Fix:** reject non-finite, `< 1`, and `> UINT32_MAX` at parse time (message ignored, connection survives). The uint32 bound keeps the value inside the domain `get_difficulty_mask()`'s cast requires.

## Verification

Host fuzz harness (ESP-IDF `linux` target, ASan+UBSan, production `stratum_v1_task` + `components/stratum`):

- `-1`, `0`, `1e999`, `NaN` → all rejected (`Difficulty value out of range` / type check; NaN additionally rejected by cJSON's parser)
- valid `100.5` → accepted normally
- Combined with #1880's two patches: full 23-case hostile-pool battery + 19-case isolated prober pass with zero crashes / zero sanitizer reports and no regressions (EN2 clamps intact, valid subscribe/notify flows unchanged, `client.reconnect` still not followed).
