### PR TITLE
build: cap cJSON nesting depth at 32 (httpd stack overflow DoS)

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -11,6 +11,12 @@ CONFIG_HTTPD_MAX_URI_LEN=2048
 CONFIG_HTTPD_WS_SUPPORT=y
 CONFIG_HTTPD_WS_PRE_HANDSHAKE_CB_SUPPORT=y
 CONFIG_HTTPD_WS_POST_HANDSHAKE_CB_SUPPORT=y
+# Bound cJSON parse recursion: the httpd task stack is 8 KiB and the stock
+# nesting limit (1000) lets a ~220-byte deeply-nested body overflow it
+# (crash threshold measured at ~105-112 levels on hardware). AxeOS API bodies
+# are flat key/value maps (deepest legitimate payload ~3 levels), so 32 leaves
+# ample headroom while capping worst-case parse stack at ~2.5 KiB.
+CONFIG_CJSON_NESTING_LIMIT=32
 CONFIG_SPIRAM=y
 CONFIG_SPIRAM_MODE_OCT=y
 CONFIG_SPIRAM_SPEED_80M=y


### PR DESCRIPTION
## Summary

One-line config fix for an unauthenticated LAN DoS: the AxeOS API parses every request body with stock cJSON at the stock nesting limit (`CONFIG_CJSON_NESTING_LIMIT=1000`), but the httpd task runs on an **8 KiB stack** (`http_server.c:1845`) with compiler stack probing disabled. cJSON parses nested arrays/objects by mutual recursion (~70+ bytes of stack per level), so a **~220-byte** deeply-nested body overflows the stack long before the cap is reached.

## Measured on hardware (Bitaxe 401, BM1368, v2.14.2)

| Nesting depth | Body size | Result |
|---|---|---|
| 16–104 | 32–208 B | HTTP 200, mining uninterrupted |
| **112** | **224 B** | **panic reboot** (`resetReason="Software reset due to exception/panic"`) |
| **128** | **256 B** | crash reproduced |

Every JSON-accepting endpoint is reachable (`PATCH /api/system`, pool PUT/DELETE, `/api/system/boot`, `POST /api/theme`), the API has no authentication, and a sustained 1 pkt/s stream pins the unit in a reboot loop = mining halt. Body-size bounds (e.g. #1848) don't help — depth is orthogonal to size.

## Fix

`CONFIG_CJSON_NESTING_LIMIT=32` in `sdkconfig.defaults`. AxeOS bodies are flat key/value maps (deepest legitimate payload ~3 levels: the pools array), so 32 leaves ample headroom while bounding worst-case parse stack to ~2.5 KiB. The managed cJSON component already plumbs this Kconfig to `-DCJSON_NESTING_LIMIT`.

## Verification (same device, this commit)

- depth 31/32 → HTTP 200 (legit nesting unaffected)
- depth **128** and **1000** → **HTTP 400 "Invalid JSON"**, no crash, mining uninterrupted throughout
- flat `{}` PATCH → HTTP 200

(The payload used for testing is a pure JSON array — it touches nothing in NVS even when it parses, so the prober is non-mutating by construction.)
