### PR TITLE
Correct hashrate register unit comment

### DIFF
--- a/main/tasks/hashrate_monitor_task.c
+++ b/main/tasks/hashrate_monitor_task.c
@@ -11,7 +11,7 @@
 
 #define EPSILON 0.0001f
 
-#define HASHRATE_UNIT 0x100000uLL // Hashrate register unit (2^24 hashes)
+#define HASHRATE_UNIT 0x100000uLL // Hashrate register unit (2^20 hashes)
 
 #define POLL_RATE 1000
 #define HASHRATE_1M_SIZE (60000 / POLL_RATE)  // 12


### PR DESCRIPTION
## Summary

- Correct the `HASHRATE_UNIT` comment from `2^24` to `2^20` hashes.
- Leave the executable `0x100000` multiplier unchanged.

## Why

`0x100000` equals `1,048,576`, or `2^20`, not `2^24`. The stale comment made the instantaneous register-based hashrate conversion look inconsistent with the value the firmware actually executes. The multiplier introduced in #1271 produced register hashrates that matched expected hardware hashrates; changing it to `2^24` would inflate the result by 16x.

## Impact

Documentation-only. Firmware behavior is unchanged.

## Validation

- Verified the parsed executable constant and documented exponent both resolve to `1,048,576` after the change.
- `git diff --check`
- Full firmware build not run because `idf.py` is unavailable locally; this change does not affect compiled behavior.
