### PR TITLE
fix: preserve offline devices during manual refresh

### DIFF
--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -293,16 +293,13 @@ private isIpAddress(value: string): boolean {
     });
   }
 
-  private getAllDeviceInfo(addresses: string[], errorHandler: (error: any, address: string) => Observable<SwarmDevice[] | null>, fetchAsic: boolean = true) {
+  private getAllDeviceInfo(addresses: string[], errorHandler: (error: any, address: string) => Observable<SwarmDevice | null>, fetchAsic: boolean = true) {
     return from(addresses).pipe(
       mergeMap(address => forkJoin({
-        info: this.httpClient.get(`http://${address}/api/system/info`).pipe(catchError(() => of(null))),
+        info: this.httpClient.get(`http://${address}/api/system/info`),
         asic: fetchAsic ? this.httpClient.get(`http://${address}/api/system/asic`).pipe(catchError(() => of({}))) : of({})
       }).pipe(
         map(({ info, asic }) => {
-          if (info === null) {
-            return null;
-          }
 
           const existingDevice = this.swarm.find(device => device.connectionAddress === address);
           const result = {
@@ -423,10 +420,14 @@ private isIpAddress(value: string): boolean {
       asicCount: existingDevice?.asicCount || 1,
       hashRate: 0,
       sharesAccepted: 0,
+      sharesRejected: 0,
       power: 0,
       voltage: 0,
       temp: 0,
+      temp2: 0,
+      vrTemp: 0,
       bestDiff: 0,
+      bestSessionDiff: 0,
       version: '',
       uptimeSeconds: 0,
       poolDifficulty: 0,

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -300,7 +300,6 @@ private isIpAddress(value: string): boolean {
         asic: fetchAsic ? this.httpClient.get(`http://${address}/api/system/asic`).pipe(catchError(() => of({}))) : of({})
       }).pipe(
         map(({ info, asic }) => {
-
           const existingDevice = this.swarm.find(device => device.connectionAddress === address);
           const result = {
             address: (info as any)['fullHostname'] || (info as any)['hostname'] || address,


### PR DESCRIPTION
Fixes the Swarm page becoming partially empty after manually refreshing a list containing an offline device.

## Root cause

Errors from `/api/system/info` were converted to `null` before reaching the per-device refresh error handler. The refresh result could therefore contain `null` entries, which were assigned to the swarm list and caused template rendering to fail.

<img width="1484" height="497" alt="Swarm" src="https://github.com/user-attachments/assets/79449112-f36d-4a85-b0c3-032d1ce59b9f" />

## Changes

- Route system-info failures through the existing refresh error handler.
- Preserve offline devices in the list with their live statistics cleared.
- Correct the error-handler type from an array result to a single-device result.
- Clear stale secondary metrics:
  - Rejected shares
  - Session best difficulty
  - Secondary ASIC temperature
  - Voltage-regulator temperature

## Result

When a device is unreachable, the Swarm page remains fully rendered. The device stays visible with zeroed runtime statistics while its hostname and IP are preserved.

<img width="1417" height="89" alt="Swarm-fix" src="https://github.com/user-attachments/assets/19049187-0138-4c1c-977a-da9da81ecc91" />

## Testing

- Scanned a network containing multiple devices.
- Made a previously discovered device unavailable.
- Manually refreshed the Swarm page.
- Verified that the page remained rendered and responsive.
- Verified that both primary and secondary runtime values were cleared for the offline device.