### PR TITLE
Improve undervoltage detection in UI

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -258,7 +258,7 @@
               [value]="((info.voltage / (info.nominalVoltage + .5)) * 100)"
               [markers]="[{ value: (info.nominalVoltage / (info.nominalVoltage + .5)) * 100, label: info.nominalVoltage + ' V' }]">
             </app-progressbar>
-            @if (info.voltage < (info.nominalVoltage + .5) * 0.87) {
+            @if (info.voltage < (info.nominalVoltage) * 0.949) {
               <strong class="text-red-500">
                 Danger: Low Voltage
               </strong>

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -258,6 +258,7 @@
               [value]="((info.voltage / (info.nominalVoltage + .5)) * 100)"
               [markers]="[{ value: (info.nominalVoltage / (info.nominalVoltage + .5)) * 100, label: info.nominalVoltage + ' V' }]">
             </app-progressbar>
+            <!-- Adding 0.949 because we want to give it the 5mV headroom for weak psu's  -->
             @if (info.voltage < (info.nominalVoltage) * 0.949) {
               <strong class="text-red-500">
                 Danger: Low Voltage


### PR DESCRIPTION
The previous formula was a left-over from a hard coupling of the progress bar UI, not an actual undervoltage limit.

Fixes #1682