### PR TITLE
Add BM1372/BM1373 ASIC driver support

### DIFF
--- a/components/asic/CMakeLists.txt
+++ b/components/asic/CMakeLists.txt
@@ -1,5 +1,6 @@
 idf_component_register(
 SRCS 
+    "bm1373.c"
     "bm1370.c"
     "bm1368.c"
     "bm1366.c"

--- a/components/asic/asic.c
+++ b/components/asic/asic.c
@@ -6,6 +6,7 @@
 #include "bm1366.h"
 #include "bm1368.h"
 #include "bm1370.h"
+#include "bm1373.h"
 
 #include "asic.h"
 #include "global_state.h"
@@ -27,6 +28,8 @@ uint8_t ASIC_init(GlobalState * GLOBAL_STATE)
             return BM1368_init(GLOBAL_STATE);
         case BM1370:
             return BM1370_init(GLOBAL_STATE);
+        case BM1373:
+            return BM1373_init(GLOBAL_STATE);
     }
     ESP_LOGE(TAG, "Unknown ASIC id %d", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
     return 0;
@@ -43,6 +46,8 @@ task_result * ASIC_process_work(GlobalState * GLOBAL_STATE)
             return BM1368_process_work(GLOBAL_STATE);
         case BM1370:
             return BM1370_process_work(GLOBAL_STATE);
+        case BM1373:
+            return BM1373_process_work(GLOBAL_STATE);
     }
     ESP_LOGE(TAG, "Unknown ASIC id %d — cannot process work", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
     return NULL;
@@ -59,6 +64,8 @@ int ASIC_set_max_baud(GlobalState * GLOBAL_STATE)
             return BM1368_set_max_baud();
         case BM1370:
             return BM1370_set_max_baud();
+        case BM1373:
+            return BM1373_set_max_baud();
     }
     ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set max baud", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
     return 0;
@@ -78,6 +85,9 @@ void ASIC_send_work(GlobalState * GLOBAL_STATE, bm_job * next_job)
             break;
         case BM1370:
             BM1370_send_work(GLOBAL_STATE, next_job);
+            break;
+        case BM1373:
+            BM1373_send_work(GLOBAL_STATE, next_job);
             break;
         default:
             ESP_LOGE(TAG, "Unknown ASIC id %d — cannot send work", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
@@ -100,6 +110,9 @@ void ASIC_set_version_mask(GlobalState * GLOBAL_STATE, uint32_t mask)
         case BM1370:
             BM1370_set_version_mask(mask);
             break;
+        case BM1373:
+            BM1373_set_version_mask(mask);
+            break;
         default:
             ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set version mask", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
             break;
@@ -120,6 +133,9 @@ void ASIC_set_frequency(GlobalState * GLOBAL_STATE)
             return;
         case BM1370:
             do_frequency_transition(GLOBAL_STATE, BM1370_send_hash_frequency);
+            return;
+        case BM1373:
+            do_frequency_transition(GLOBAL_STATE, BM1373_send_hash_frequency);
             return;
     }
     ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set frequency", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
@@ -144,6 +160,9 @@ void ASIC_set_nonce_space(GlobalState * GLOBAL_STATE)
         case BM1370:
             BM1370_set_nonce_space(nonce_percent, frequency, asic_count, cores);
             return;
+        case BM1373:
+            BM1373_set_nonce_space(nonce_percent, frequency, asic_count, cores);
+            return;
     }
     ESP_LOGE(TAG, "Unknown ASIC id %d — cannot set nonce space", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
 }
@@ -163,6 +182,7 @@ double ASIC_get_asic_job_frequency_ms(GlobalState * GLOBAL_STATE)
         case BM1366:
         case BM1368:
         case BM1370:
+        case BM1373:
             return asic_default_timeout_divided;
     }
     ESP_LOGE(TAG, "Unknown ASIC id %d — cannot compute job frequency", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);
@@ -183,6 +203,9 @@ void ASIC_read_registers(GlobalState * GLOBAL_STATE)
             break;
         case BM1370:
             BM1370_read_registers();
+            break;
+        case BM1373:
+            BM1373_read_registers();
             break;
         default:
             ESP_LOGE(TAG, "Unknown ASIC id %d — cannot read registers", GLOBAL_STATE->DEVICE_CONFIG.family.asic.id);

--- a/components/asic/asic_common.c
+++ b/components/asic/asic_common.c
@@ -79,7 +79,7 @@ int _next_power_of_two(int num)
     return power;
 }
 
-int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response_length)
+int count_asic_chips_with_id_alias(uint16_t asic_count, uint16_t chip_id, uint16_t chip_id_alias, int chip_id_response_length)
 {
     uint8_t buffer[11] = {0};
 
@@ -109,8 +109,12 @@ int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response
         }
 
         uint16_t received_chip_id = (buffer[2] << 8) | buffer[3];
-        if (received_chip_id != chip_id) {
-            ESP_LOGW(TAG, "CHIP_ID response mismatch: expected 0x%04x, got 0x%04x", chip_id, received_chip_id);
+        if (received_chip_id != chip_id && received_chip_id != chip_id_alias) {
+            if (chip_id == chip_id_alias) {
+                ESP_LOGW(TAG, "CHIP_ID response mismatch: expected 0x%04x, got 0x%04x", chip_id, received_chip_id);
+            } else {
+                ESP_LOGW(TAG, "CHIP_ID response mismatch: expected 0x%04x or 0x%04x, got 0x%04x", chip_id, chip_id_alias, received_chip_id);
+            }
             ESP_LOG_BUFFER_HEX(TAG, buffer, received);
             continue;
         }
@@ -143,6 +147,11 @@ int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response
     }
 
     return chip_counter;
+}
+
+int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response_length)
+{
+    return count_asic_chips_with_id_alias(asic_count, chip_id, chip_id, chip_id_response_length);
 }
 
 esp_err_t receive_work(uint8_t * buffer, int buffer_size, uint64_t *out_timestamp_us)

--- a/components/asic/bm1373.c
+++ b/components/asic/bm1373.c
@@ -1,0 +1,549 @@
+#include "bm1373.h"
+
+#include "crc.h"
+#include "global_state.h"
+#include "mining.h"
+#include "serial.h"
+#include "utils.h"
+
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "frequency_transition_bmXX.h"
+#include "pll.h"
+
+#include <arpa/inet.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define BM1372_CHIP_ID 0x1372
+#define BM1373_CHIP_ID_ALIAS 0x1373
+#define BM1372_CHIP_ID_RESPONSE_LENGTH 9
+
+#define BM1372_REGISTER_PLL0_PARAMETER 0x08
+#define BM1372_REGISTER_HASH_COUNTING_NUMBER 0x10
+#define BM1372_REGISTER_TICKET_MASK 0x14
+#define BM1372_REGISTER_MISC_CONTROL 0x18
+#define BM1372_REGISTER_MISC_CONTROL_ADD 0x19
+#define BM1372_REGISTER_FAST_UART_CONFIGURATION 0x28
+#define BM1372_REGISTER_CORE_COMMAND 0x3C
+#define BM1372_REGISTER_ANALOG_MUX_CONTROL 0x54
+#define BM1372_REGISTER_IO_DRIVER_STRENGTH 0x58
+#define BM1372_REGISTER_ROSC_PAD_DISABLE 0x68
+#define BM1372_REGISTER_SOFT_RESET_CONTROL 0xA8
+#define BM1372_REGISTER_VERSION_ROLLING 0xA4
+#define BM1372_REGISTER_AUTO_WORK_CONFIGURATION 0xC4
+
+// The generic BM13xx nonce-space calculation makes BM1372/BM1373 chips search
+// overlapping work. This is the known-good S21 Pro stock register value.
+#define BM1372_HASH_COUNTING_NUMBER_S21_PRO 0x00001EB5
+
+#define BM1372_CORE_REGISTER_CLOCK_DELAY_CTRL 0x00
+#define BM1372_CORE_REGISTER_CORE_ENABLE 0x02
+#define BM1372_CORE_REGISTER_CLOCK_SELECT_CTRL 0x0B
+#define BM1372_CORE_REGISTER_NONCE_BIN_OVERFLOW_CTRL 0x0D
+
+#define BM1372_SOFT_RESET_FAST 0xF00701F0
+#define BM1372_RNO_ENABLE 0xFF00C100
+#define BM1372_CRR_DISABLE 0x00000000
+#define BM1372_CLOCK_SELECT 0x00
+#define BM1372_CLOCK_DELAY_PWTH6_CCDLY2 0x5A
+#define BM1372_CORE_ENABLE 0xAA
+#define BM1372_NONCE_BIN_OVERFLOW_DISABLE 0x04
+#define BM1372_IO_DRIVER_STRENGTH_DEFAULT 0x00011111
+#define BM1372_IO_DRIVER_STRENGTH_DOMAIN_END 0x0001F111
+#define BM1372_ROSC_PAD_DISABLE 0x5AA55AA5
+#define BM1372_ANALOG_MUX_TEMPERATURE_DIODE 0x00000002
+#define BM1372_AUTO_WORK_CONFIGURATION 0x00000000
+#define BM1372_FAST_UART_3M 0x80000000
+
+#define BM1372_ASIC_BAUD 3000000
+#define BM1372_WRITE_RETRIES 3
+#define BM1372_WRITE_RETRY_DELAY_MS 50
+#define BM1372_INIT_STEP_DELAY_MS 10
+#define BM1372_FAST_RESET_DELAY_MS 20
+#define BM1372_SET_ADDRESS_STRIDE 0x10
+#define BM1372_COMMAND_ADDRESS_SHIFT 2
+
+#define TYPE_JOB 0x20
+#define TYPE_CMD 0x40
+
+#define GROUP_SINGLE 0x00
+#define GROUP_ALL 0x10
+
+#define CMD_SETADDRESS 0x00
+#define CMD_WRITE 0x01
+#define CMD_READ 0x02
+#define CMD_INACTIVE 0x03
+
+static const register_type_t REGISTER_MAP[] = {
+    [0x4C] = REGISTER_ERROR_COUNT,
+    [0x88] = REGISTER_DOMAIN_0_COUNT,
+    [0x89] = REGISTER_DOMAIN_1_COUNT,
+    [0x8A] = REGISTER_DOMAIN_2_COUNT,
+    [0x8B] = REGISTER_DOMAIN_3_COUNT,
+    [0x8C] = REGISTER_TOTAL_COUNT
+};
+
+typedef struct __attribute__((__packed__))
+{
+    uint32_t nonce;
+    uint8_t midstate_num;
+    uint8_t id;
+    uint16_t version;
+} bm1373_asic_result_job_t;
+
+typedef struct __attribute__((__packed__))
+{
+    uint32_t value;
+    uint8_t asic_address;
+    uint8_t register_address;
+    uint16_t : 16;
+} bm1373_asic_result_cmd_t;
+
+typedef struct __attribute__((__packed__))
+{
+    uint16_t preamble;
+    union {
+        bm1373_asic_result_job_t job;
+        bm1373_asic_result_cmd_t cmd;
+    };
+    uint8_t crc             : 5;
+    uint8_t                 : 2;
+    uint8_t is_job_response : 1;
+} bm1373_asic_result_t;
+
+static const char * TAG = "bm1372/73";
+
+static task_result result;
+
+static uint8_t chip_command_address_interval;
+static uint8_t chip_response_address_interval;
+static uint8_t chip_nonce_address_interval;
+static uint8_t detected_chip_count;
+static uint8_t detected_voltage_domains;
+static bool frequency_write_failed;
+
+/// @brief
+/// @param ftdi
+/// @param header
+/// @param data
+/// @param len
+static bool _send_BM1373(uint8_t header, const uint8_t * data, uint8_t data_len, bool debug)
+{
+    packet_type_t packet_type = (header & TYPE_JOB) ? JOB_PACKET : CMD_PACKET;
+    uint8_t total_length = (packet_type == JOB_PACKET) ? (data_len + 6) : (data_len + 5);
+    uint8_t buf[total_length];
+
+    // add the preamble
+    buf[0] = 0x55;
+    buf[1] = 0xAA;
+
+    // add the header field
+    buf[2] = header;
+
+    // add the length field
+    buf[3] = (packet_type == JOB_PACKET) ? (data_len + 4) : (data_len + 3);
+
+    // add the data
+    memcpy(buf + 4, data, data_len);
+
+    // add the correct crc type
+    if (packet_type == JOB_PACKET) {
+        uint16_t crc16_total = crc16_false(buf + 2, data_len + 2);
+        buf[4 + data_len] = (crc16_total >> 8) & 0xFF;
+        buf[5 + data_len] = crc16_total & 0xFF;
+    } else {
+        buf[4 + data_len] = crc5(buf + 2, data_len + 2);
+    }
+
+    for (uint8_t attempt = 1; attempt <= BM1372_WRITE_RETRIES; attempt++) {
+        int bytes_written = SERIAL_send(buf, total_length, debug);
+        if (bytes_written == total_length) {
+            return true;
+        }
+
+        ESP_LOGW(TAG, "ASIC write failed (%d/%u bytes), attempt %u/%u",
+                 bytes_written, total_length, attempt, BM1372_WRITE_RETRIES);
+        if (attempt < BM1372_WRITE_RETRIES) {
+            vTaskDelay(pdMS_TO_TICKS(BM1372_WRITE_RETRY_DELAY_MS));
+        }
+    }
+
+    ESP_LOGE(TAG, "ASIC write failed after %u attempts", BM1372_WRITE_RETRIES);
+    return false;
+}
+
+static bool _write_register(uint8_t group, uint8_t chip_address, uint8_t register_address, uint32_t value)
+{
+    uint8_t command[6] = {
+        chip_address,
+        register_address,
+        (uint8_t)(value >> 24),
+        (uint8_t)(value >> 16),
+        (uint8_t)(value >> 8),
+        (uint8_t)value,
+    };
+
+    return _send_BM1373(TYPE_CMD | group | CMD_WRITE, command, sizeof(command), BM1373_SERIALTX_DEBUG);
+}
+
+static bool _write_broadcast(uint8_t register_address, uint32_t value)
+{
+    return _write_register(GROUP_ALL, 0, register_address, value);
+}
+
+static bool _write_chip(uint8_t chip_address, uint8_t register_address, uint32_t value)
+{
+    return _write_register(GROUP_SINGLE, chip_address, register_address, value);
+}
+
+static bool _write_core_register(uint8_t core_register, uint8_t value)
+{
+    uint32_t command = 0x80008000 | ((uint32_t)core_register << 8) | value;
+    return _write_broadcast(BM1372_REGISTER_CORE_COMMAND, command);
+}
+
+static bool _send_chain_inactive(void)
+{
+    const uint8_t command[2] = {0x00, 0x00};
+    return _send_BM1373(TYPE_CMD | GROUP_ALL | CMD_INACTIVE, command, sizeof(command), BM1373_SERIALTX_DEBUG);
+}
+
+static bool _set_chip_address(uint8_t chip_address)
+{
+    const uint8_t command[2] = {chip_address, 0x00};
+    return _send_BM1373(TYPE_CMD | GROUP_SINGLE | CMD_SETADDRESS, command, sizeof(command), BM1373_SERIALTX_DEBUG);
+}
+
+void BM1373_set_version_mask(uint32_t version_mask)
+{
+    uint32_t versions_to_roll = version_mask >> 13;
+    uint32_t value = 0x90000000 | (versions_to_roll & 0xFFFF);
+    if (!_write_broadcast(BM1372_REGISTER_VERSION_ROLLING, value)) {
+        ESP_LOGE(TAG, "Failed to set version mask");
+    }
+}
+
+void BM1373_set_hash_counting_number(uint32_t hcn)
+{
+    if (!_write_broadcast(BM1372_REGISTER_HASH_COUNTING_NUMBER, hcn)) {
+        ESP_LOGE(TAG, "Failed to set hash counting number");
+    }
+}
+
+void BM1373_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores)
+{
+    (void)nonce_percent;
+    (void)frequency;
+    (void)asic_count;
+    (void)cores;
+
+    BM1373_set_hash_counting_number(BM1372_HASH_COUNTING_NUMBER_S21_PRO);
+}
+
+float BM1373_send_hash_frequency(float target_freq)
+{
+    uint8_t fb_divider, refdiv, postdiv1, postdiv2;
+    float frequency;
+
+    pll_get_parameters(target_freq, 160, 239, &fb_divider, &refdiv, &postdiv1, &postdiv2, &frequency);
+
+    uint8_t vdo_scale = (fb_divider * FREQ_MULT / refdiv >= 2400) ? 0x50 : 0x40;
+    uint8_t postdiv = (((postdiv1 - 1) & 0xf) << 4) | ((postdiv2 - 1) & 0xf);
+    uint32_t pll_value = ((uint32_t)vdo_scale << 24) |
+                         ((uint32_t)fb_divider << 16) |
+                         ((uint32_t)refdiv << 8) |
+                         postdiv;
+
+    // Every chip in the Bitaxe chain runs at the same target frequency. A
+    // broadcast also avoids the BM1372's distinct assigned/command address
+    // encodings during the frequency ramp.
+    bool success = _write_broadcast(BM1372_REGISTER_PLL0_PARAMETER, pll_value);
+
+    if (!success) {
+        frequency_write_failed = true;
+        ESP_LOGE(TAG, "Failed to program one or more ASIC PLLs");
+    }
+
+    ESP_LOGI(TAG, "Setting Frequency to %g MHz (%g)", target_freq, frequency);
+
+    return frequency;
+}
+
+uint8_t BM1373_init(GlobalState * GLOBAL_STATE)
+{
+    uint8_t expected_chip_count = GLOBAL_STATE->DEVICE_CONFIG.family.asic_count;
+
+    chip_command_address_interval = 0;
+    chip_response_address_interval = 0;
+    chip_nonce_address_interval = 0;
+    detected_chip_count = 0;
+    detected_voltage_domains = 0;
+    frequency_write_failed = false;
+
+    // Discover the chain at reset baud before changing any ASIC configuration.
+    const uint8_t chip_id_request[2] = {0x00, 0x00};
+    if (!_send_BM1373(TYPE_CMD | GROUP_ALL | CMD_READ, chip_id_request,
+                      sizeof(chip_id_request), BM1373_SERIALTX_DEBUG)) {
+        return 0;
+    }
+
+    int chip_counter = count_asic_chips_with_id_alias(expected_chip_count,
+                                                      BM1372_CHIP_ID,
+                                                      BM1373_CHIP_ID_ALIAS,
+                                                      BM1372_CHIP_ID_RESPONSE_LENGTH);
+    if (chip_counter != expected_chip_count) {
+        ESP_LOGE(TAG, "Expected %u BM1372/BM1373 ASICs, detected %d",
+                 expected_chip_count, chip_counter);
+        return 0;
+    }
+
+    detected_chip_count = chip_counter;
+    detected_voltage_domains = GLOBAL_STATE->DEVICE_CONFIG.family.voltage_domains;
+    chip_command_address_interval = BM1372_SET_ADDRESS_STRIDE >> BM1372_COMMAND_ADDRESS_SHIFT;
+    chip_response_address_interval = BM1372_SET_ADDRESS_STRIDE;
+    chip_nonce_address_interval = 256 / detected_chip_count;
+    if (chip_nonce_address_interval == 0) {
+        ESP_LOGE(TAG, "Invalid nonce address interval for %u ASICs", detected_chip_count);
+        return 0;
+    }
+
+    if (!_send_chain_inactive()) {
+        return 0;
+    }
+    vTaskDelay(pdMS_TO_TICKS(BM1372_INIT_STEP_DELAY_MS));
+
+    for (uint8_t chip = 0; chip < detected_chip_count; chip++) {
+        if (!_set_chip_address(chip * BM1372_SET_ADDRESS_STRIDE)) {
+            return 0;
+        }
+    }
+    vTaskDelay(pdMS_TO_TICKS(BM1372_INIT_STEP_DELAY_MS));
+
+    // Match the stock BM1372 setup order: nonce overflow, ticket mask, IO,
+    // ring-oscillator pads, then UART and the staged core initialization.
+    if (!_write_core_register(BM1372_CORE_REGISTER_NONCE_BIN_OVERFLOW_CTRL,
+                              BM1372_NONCE_BIN_OVERFLOW_DISABLE)) {
+        return 0;
+    }
+
+    uint8_t difficulty_mask[6];
+    get_difficulty_mask(GLOBAL_STATE->DEVICE_CONFIG.family.asic.difficulty, difficulty_mask);
+    if (!_send_BM1373(TYPE_CMD | GROUP_ALL | CMD_WRITE, difficulty_mask,
+                      sizeof(difficulty_mask), BM1373_SERIALTX_DEBUG)) {
+        return 0;
+    }
+
+    if (!_write_broadcast(BM1372_REGISTER_IO_DRIVER_STRENGTH,
+                          BM1372_IO_DRIVER_STRENGTH_DEFAULT)) {
+        return 0;
+    }
+
+    uint8_t domains = detected_voltage_domains == 0 ? 1 : detected_voltage_domains;
+    for (uint8_t domain = 0; domain < domains; domain++) {
+        uint8_t domain_first_chip = (domain * detected_chip_count) / domains;
+        uint8_t domain_end_exclusive = ((domain + 1) * detected_chip_count) / domains;
+        if (domain_end_exclusive == domain_first_chip) {
+            continue;
+        }
+        uint8_t domain_end_chip = domain_end_exclusive - 1;
+        if (!_write_chip(domain_end_chip * chip_command_address_interval,
+                         BM1372_REGISTER_IO_DRIVER_STRENGTH,
+                         BM1372_IO_DRIVER_STRENGTH_DOMAIN_END)) {
+            return 0;
+        }
+    }
+
+    if (!_write_broadcast(BM1372_REGISTER_ROSC_PAD_DISABLE, BM1372_ROSC_PAD_DISABLE)) {
+        return 0;
+    }
+    vTaskDelay(pdMS_TO_TICKS(BM1372_INIT_STEP_DELAY_MS));
+
+    int asic_baud = BM1373_set_max_baud();
+    if (asic_baud == 0 || SERIAL_set_baud(asic_baud) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to switch BM1372/BM1373 UART to %d baud", BM1372_ASIC_BAUD);
+        return 0;
+    }
+    SERIAL_clear_buffer();
+    vTaskDelay(pdMS_TO_TICKS(BM1372_INIT_STEP_DELAY_MS));
+
+    if (!_write_broadcast(BM1372_REGISTER_SOFT_RESET_CONTROL, BM1372_SOFT_RESET_FAST)) {
+        return 0;
+    }
+    vTaskDelay(pdMS_TO_TICKS(BM1372_FAST_RESET_DELAY_MS));
+
+    if (!_write_broadcast(BM1372_REGISTER_MISC_CONTROL, BM1372_RNO_ENABLE)) {
+        return 0;
+    }
+    vTaskDelay(pdMS_TO_TICKS(BM1372_INIT_STEP_DELAY_MS));
+
+    if (!_write_broadcast(BM1372_REGISTER_MISC_CONTROL_ADD, BM1372_CRR_DISABLE)) {
+        return 0;
+    }
+    vTaskDelay(pdMS_TO_TICKS(BM1372_INIT_STEP_DELAY_MS));
+
+    if (!_write_core_register(BM1372_CORE_REGISTER_CLOCK_SELECT_CTRL, BM1372_CLOCK_SELECT)) {
+        return 0;
+    }
+    vTaskDelay(pdMS_TO_TICKS(BM1372_INIT_STEP_DELAY_MS));
+
+    if (!_write_core_register(BM1372_CORE_REGISTER_CLOCK_DELAY_CTRL,
+                              BM1372_CLOCK_DELAY_PWTH6_CCDLY2)) {
+        return 0;
+    }
+    vTaskDelay(pdMS_TO_TICKS(BM1372_INIT_STEP_DELAY_MS));
+
+    if (!_write_core_register(BM1372_CORE_REGISTER_CORE_ENABLE, BM1372_CORE_ENABLE)) {
+        return 0;
+    }
+    vTaskDelay(pdMS_TO_TICKS(BM1372_INIT_STEP_DELAY_MS));
+
+    if (!_write_broadcast(BM1372_REGISTER_ANALOG_MUX_CONTROL,
+                          BM1372_ANALOG_MUX_TEMPERATURE_DIODE)) {
+        return 0;
+    }
+
+    // A hardware reset restores the PLL baseline even during a live recovery.
+    GLOBAL_STATE->POWER_MANAGEMENT_MODULE.actual_frequency = 50.0f;
+    do_frequency_transition(GLOBAL_STATE, BM1373_send_hash_frequency);
+    if (frequency_write_failed) {
+        return 0;
+    }
+
+    if (!_write_broadcast(BM1372_REGISTER_HASH_COUNTING_NUMBER,
+                          BM1372_HASH_COUNTING_NUMBER_S21_PRO)) {
+        ESP_LOGE(TAG, "Failed to configure nonce space");
+        return 0;
+    }
+
+    uint32_t versions_to_roll = STRATUM_DEFAULT_VERSION_MASK >> 13;
+    if (!_write_broadcast(BM1372_REGISTER_VERSION_ROLLING,
+                          0x90000000 | (versions_to_roll & 0xFFFF))) {
+        ESP_LOGE(TAG, "Failed to configure version rolling");
+        return 0;
+    }
+
+    return detected_chip_count;
+}
+
+int BM1373_set_default_baud(void)
+{
+    // BM1372/BM1373 returns to 115200 only through a hardware reset.
+    return UART_FREQ;
+}
+
+int BM1373_set_max_baud(void)
+{
+    ESP_LOGI(TAG, "Setting ASIC UART to %d baud", BM1372_ASIC_BAUD);
+
+    if (!_write_broadcast(BM1372_REGISTER_AUTO_WORK_CONFIGURATION,
+                          BM1372_AUTO_WORK_CONFIGURATION) ||
+        !_write_broadcast(BM1372_REGISTER_FAST_UART_CONFIGURATION,
+                          BM1372_FAST_UART_3M)) {
+        return 0;
+    }
+
+    return BM1372_ASIC_BAUD;
+}
+
+static uint8_t id = 0;
+
+void BM1373_send_work(GlobalState * GLOBAL_STATE, bm_job * next_bm_job)
+{
+    BM1373_job job;
+    id = (id + 24) % 128;
+    job.job_id = id;
+    job.num_midstates = 0x01;
+    memcpy(&job.starting_nonce, &next_bm_job->starting_nonce, 4);
+    memcpy(&job.nbits, &next_bm_job->target, 4);
+    memcpy(&job.ntime, &next_bm_job->ntime, 4);
+    memcpy(job.merkle_root, next_bm_job->merkle_root, 32);
+    memcpy(job.prev_block_hash, next_bm_job->prev_block_hash, 32);
+    memcpy(&job.version, &next_bm_job->version, 4);
+
+    if (GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] != NULL) {
+        free_bm_job(GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id]);
+    }
+
+    GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job.job_id] = next_bm_job;
+
+    pthread_mutex_lock(&GLOBAL_STATE->valid_jobs_lock);
+    GLOBAL_STATE->valid_jobs[job.job_id] = 1;
+    pthread_mutex_unlock(&GLOBAL_STATE->valid_jobs_lock);
+
+    //debug sent jobs - this can get crazy if the interval is short
+    #if BM1373_DEBUG_JOBS
+    ESP_LOGI(TAG, "Send Job: %02X", job.job_id);
+    #endif
+
+    _send_BM1373((TYPE_JOB | GROUP_SINGLE | CMD_WRITE), (uint8_t *)&job, sizeof(BM1373_job), BM1373_DEBUG_WORK);
+}
+
+task_result * BM1373_process_work(GlobalState * GLOBAL_STATE)
+{
+    bm1373_asic_result_t asic_result = {0};
+
+    memset(&result, 0, sizeof(task_result));
+
+    if (receive_work((uint8_t *)&asic_result, sizeof(asic_result), &result.timestamp_us) == ESP_FAIL) {
+        return NULL;
+    }
+
+    if (!asic_result.is_job_response) {
+        result.register_type = REGISTER_MAP[asic_result.cmd.register_address];
+        if (result.register_type == REGISTER_INVALID) {
+            ESP_LOGW(TAG, "Unknown register read: %02x", asic_result.cmd.register_address);
+            return NULL;
+        }
+        result.asic_nr = asic_result.cmd.asic_address / chip_response_address_interval;
+        result.value = ntohl(asic_result.cmd.value);
+
+        return &result;
+    }
+
+    // uint8_t job_id = asic_result.job_id;
+    // uint8_t rx_job_id = ((int8_t)job_id & 0xf0) >> 1;
+    // ESP_LOGI(TAG, "Job ID: %02X, RX: %02X", job_id, rx_job_id);
+
+    // uint8_t job_id = asic_result.job_id & 0xf8;
+    // ESP_LOGI(TAG, "Job ID: %02X, Core: %01X", job_id, asic_result.job_id & 0x07);
+
+    uint8_t job_id = (asic_result.job.id & 0xf0) >> 1;
+    uint32_t nonce_h = ntohl(asic_result.job.nonce);
+    uint8_t asic_nr = (uint8_t)((nonce_h >> 17) & 0xff) / chip_nonce_address_interval;
+    uint8_t core_id = (uint8_t)((nonce_h >> 25) & 0x7f);
+    uint8_t small_core_id = asic_result.job.id & 0x0f;
+    uint32_t version_bits = (ntohs(asic_result.job.version) << 13);
+
+    if (GLOBAL_STATE->valid_jobs[job_id] == 0) {
+        ESP_LOGW(TAG, "Invalid job nonce found, 0x%02X", job_id);
+        return NULL;
+    }
+
+    uint32_t rolled_version = GLOBAL_STATE->ASIC_TASK_MODULE.active_jobs[job_id]->version | version_bits;
+
+    result.job_id = job_id;
+    result.nonce = asic_result.job.nonce;
+    result.rolled_version = rolled_version;
+    result.asic_nr = asic_nr;
+    result.core_id = core_id;
+    result.small_core_id = small_core_id;
+
+    return &result;
+}
+
+void BM1373_read_registers(void)
+{
+    int size = sizeof(REGISTER_MAP) / sizeof(REGISTER_MAP[0]);
+    for (int reg = 0; reg < size; reg++) {
+        if (REGISTER_MAP[reg] != REGISTER_INVALID) {
+            _send_BM1373((TYPE_CMD | GROUP_ALL | CMD_READ), (uint8_t[]){0x00, reg}, 2, BM1373_SERIALTX_DEBUG);
+            vTaskDelay(1 / portTICK_PERIOD_MS);
+        }
+    }
+}

--- a/components/asic/include/asic_common.h
+++ b/components/asic/include/asic_common.h
@@ -42,6 +42,7 @@ int _next_power_of_two(int num);
 void clear_asic_chain_error(void);
 const char *get_asic_chain_error(void);
 int count_asic_chips(uint16_t asic_count, uint16_t chip_id, int chip_id_response_length);
+int count_asic_chips_with_id_alias(uint16_t asic_count, uint16_t chip_id, uint16_t chip_id_alias, int chip_id_response_length);
 esp_err_t receive_work(uint8_t * buffer, int buffer_size, uint64_t *out_timestamp_us);
 void get_difficulty_mask(double difficulty, uint8_t *job_difficulty_mask);
 double calculate_bm_timeout_ms(float frequency_mhz, size_t asic_count, size_t small_cores, size_t cores, size_t version_size, float timeout_percent, double default_time_ms);

--- a/components/asic/include/bm1373.h
+++ b/components/asic/include/bm1373.h
@@ -1,0 +1,36 @@
+#ifndef BM1373_H_
+#define BM1373_H_
+
+#include "asic_common.h"
+
+typedef struct GlobalState GlobalState;
+typedef struct bm_job bm_job;
+
+#define BM1373_SERIALTX_DEBUG false
+#define BM1373_SERIALRX_DEBUG false
+#define BM1373_DEBUG_WORK false //causes insane amount of debug output
+#define BM1373_DEBUG_JOBS false //causes insane amount of debug output
+
+typedef struct __attribute__((__packed__))
+{
+    uint8_t job_id;
+    uint8_t num_midstates;
+    uint8_t starting_nonce[4];
+    uint8_t nbits[4];
+    uint8_t ntime[4];
+    uint8_t merkle_root[32];
+    uint8_t prev_block_hash[32];
+    uint8_t version[4];
+} BM1373_job;
+
+uint8_t BM1373_init(GlobalState * GLOBAL_STATE);
+void BM1373_send_work(GlobalState * GLOBAL_STATE, bm_job * next_bm_job);
+void BM1373_set_version_mask(uint32_t version_mask);
+int BM1373_set_max_baud(void);
+int BM1373_set_default_baud(void);
+float BM1373_send_hash_frequency(float frequency);
+task_result * BM1373_process_work(GlobalState * GLOBAL_STATE);
+void BM1373_read_registers(void);
+void BM1373_set_nonce_space(double nonce_percent, float frequency, uint16_t asic_count, uint16_t cores);
+
+#endif /* BM1373_H_ */

--- a/components/asic/serial.c
+++ b/components/asic/serial.c
@@ -78,7 +78,7 @@ int16_t SERIAL_rx(uint8_t *buf, uint16_t size, uint16_t timeout_ms)
 {
     int16_t bytes_read = uart_read_bytes(UART_NUM_1, buf, size, timeout_ms / portTICK_PERIOD_MS);
 
-    #if BM1397_SERIALRX_DEBUG || BM1366_SERIALRX_DEBUG || BM1368_SERIALRX_DEBUG || BM1370_SERIALRX_DEBUG
+    #if BM1397_SERIALRX_DEBUG || BM1366_SERIALRX_DEBUG || BM1368_SERIALRX_DEBUG || BM1370_SERIALRX_DEBUG || BM1373_SERIALRX_DEBUG
     size_t buff_len = 0;
     if (bytes_read > 0) {
         uart_get_buffered_data_len(UART_NUM_1, &buff_len);

--- a/main/device_config.h
+++ b/main/device_config.h
@@ -15,6 +15,7 @@ typedef enum
     BM1366,
     BM1368,
     BM1370,
+    BM1373,
 } Asic;
 
 typedef struct AsicConfig {
@@ -84,25 +85,29 @@ static const uint16_t BM1397_FREQUENCY_OPTIONS[]   = {400, 425, 450, 475, 485, 5
 static const uint16_t BM1366_FREQUENCY_OPTIONS[]   = {400, 425, 450, 475, 485, 500, 525, 550, 575,      0};
 static const uint16_t BM1368_FREQUENCY_OPTIONS[]   = {400, 425, 450, 475, 485, 490, 500, 525, 550, 575, 0};
 static const uint16_t BM1370_FREQUENCY_OPTIONS[]   = {400, 490, 525, 550, 600, 625,                     0};
+static const uint16_t BM1373_FREQUENCY_OPTIONS[]   = {327, 350, 375, 380, 400, 410,                     0};
 static const uint16_t BM1370_FRQUENCY_XP_OPTIONS[] = {350, 375, 380, 400, 410,                        0};
 
 static const uint16_t BM1397_VOLTAGE_OPTIONS[] = {1100, 1150, 1200, 1250, 1300, 1350, 1400, 1450, 1500, 0};
 static const uint16_t BM1366_VOLTAGE_OPTIONS[] = {1100, 1150, 1200, 1250, 1300,                         0};
 static const uint16_t BM1368_VOLTAGE_OPTIONS[] = {1100, 1150, 1166, 1200, 1250, 1300,                   0};
 static const uint16_t BM1370_VOLTAGE_OPTIONS[] = {1000, 1060, 1100, 1150, 1200, 1250,                   0};
+static const uint16_t BM1373_VOLTAGE_OPTIONS[] = {1000, 1060, 1100, 1150, 1200, 1250,                   0};
 
 static const AsicConfig ASIC_BM1397 = { .id = BM1397, .name = "BM1397", .chip_id = 1397, .default_frequency_mhz = 425, .frequency_options = BM1397_FREQUENCY_OPTIONS, .default_voltage_mv = 1400, .voltage_options = BM1397_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 168, .small_core_count =  672, .hash_domains = 1, .hashrate_test_percentage_target = 0.85, .default_asic_timeout = 20};
 static const AsicConfig ASIC_BM1366 = { .id = BM1366, .name = "BM1366", .chip_id = 1366, .default_frequency_mhz = 485, .frequency_options = BM1366_FREQUENCY_OPTIONS, .default_voltage_mv = 1200, .voltage_options = BM1366_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 112, .small_core_count =  894, .hash_domains = 4, .hashrate_test_percentage_target = 0.85, .default_asic_timeout = 2000};
 static const AsicConfig ASIC_BM1368 = { .id = BM1368, .name = "BM1368", .chip_id = 1368, .default_frequency_mhz = 490, .frequency_options = BM1368_FREQUENCY_OPTIONS, .default_voltage_mv = 1166, .voltage_options = BM1368_VOLTAGE_OPTIONS, .difficulty = 256, .core_count =  80, .small_core_count = 1276, .hash_domains = 4, .hashrate_test_percentage_target = 0.80, .default_asic_timeout = 500};
 static const AsicConfig ASIC_BM1370 = { .id = BM1370, .name = "BM1370", .chip_id = 1370, .default_frequency_mhz = 525, .frequency_options = BM1370_FREQUENCY_OPTIONS, .default_voltage_mv = 1150, .voltage_options = BM1370_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 128, .small_core_count = 2040, .hash_domains = 4, .hashrate_test_percentage_target = 0.85, .default_asic_timeout = 500};
 static const AsicConfig ASIC_BM1370XP = { .id = BM1370, .name = "BM1370", .chip_id = 1370, .default_frequency_mhz = 400, .frequency_options = BM1370_FRQUENCY_XP_OPTIONS, .default_voltage_mv = 1150, .voltage_options = BM1370_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 128, .small_core_count = 2040, .hash_domains = 4, .hashrate_test_percentage_target = 0.85, .default_asic_timeout = 500};
+static const AsicConfig ASIC_BM1373 = { .id = BM1373, .name = "BM1372/BM1373", .chip_id = 1372, .default_frequency_mhz = 327, .frequency_options = BM1373_FREQUENCY_OPTIONS, .default_voltage_mv = 1000, .voltage_options = BM1373_VOLTAGE_OPTIONS, .difficulty = 256, .core_count = 128, .small_core_count = 6725, .hash_domains = 4, .hashrate_test_percentage_target = 0.85, .default_asic_timeout = 500};
 
 static const AsicConfig default_asic_configs[] = {
     ASIC_BM1397,
     ASIC_BM1366,
     ASIC_BM1368,
     ASIC_BM1370,
-    ASIC_BM1370XP
+    ASIC_BM1370XP,
+    ASIC_BM1373
 };
 
 static const FamilyConfig FAMILY_MAX         = { .id = MAX,         .name = "Max",        .asic = ASIC_BM1397,   .asic_count = 1, .max_power =  25, .power_offset = 5,  .nominal_voltage = 5,  .voltage_domains = 1, .swarm_color = "red",      };

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -712,6 +712,7 @@ components:
             - BM1366
             - BM1368
             - BM1370
+            - BM1373
             - BM1397
           examples:
             - "BM1366"


### PR DESCRIPTION
## Summary

- add BM1372 and BM1373 ASIC model support
- add the BM1373 ASIC driver and register initialization
- add device and API configuration support for the new ASIC models

This is the foundation PR for the Naja Duo 1201 series. It contains no board-specific display or self-test code.

## Validation

- full ESP-IDF 6.0.2 firmware builds pass on both downstream integration branches
- `git diff --check` passes
- regular hashrate-monitor calculations are unchanged