### PR TITLE
Adapt download assets message in update page

### DIFF
--- a/main/http_server/axe-os/src/app/components/update/update.component.html
+++ b/main/http_server/axe-os/src/app/components/update/update.component.html
@@ -30,23 +30,16 @@
               <a style="text-decoration: underline;" target="_blank"
               [href]="latestRelease.html_url">{{latestRelease.name}}</a>
             </h3>
-            <div class="text-orange-500 mb-3">Download both files for update!</div>
-            @for (asset of latestRelease.assets; track asset) {
-              <div>
-                @if (asset.name == 'esp-miner.bin') {
-                  <div>
-                    <a style="text-decoration: underline;" target="_blank"
-                    [href]="asset.browser_download_url">esp-miner.bin</a>
-                  </div>
-                }
-                @if (asset.name == 'www.bin') {
-                  <div>
-                    <a style="text-decoration: underline;" target="_blank"
-                    [href]="asset.browser_download_url">www.bin</a>
-                  </div>
-                }
-              </div>
-            }
+            @if (latestEspMinerAsset$ | async; as asset) {
+                <div>
+                  <a style="text-decoration: underline;" target="_blank"
+                [href]="asset.browser_download_url">esp-miner.bin</a>
+                </div>
+            } @else {
+                <span class="text-orange-500 mb-3">
+                  Firmware binaries are not yet available for this release. Please check back shortly.
+                </span>
+              }
             <a class="text-secondary underline block mt-3 cursor-pointer" (click)="releaseNotesModal.isVisible = true">
               Release Notes
             </a>

--- a/main/http_server/axe-os/src/app/components/update/update.component.ts
+++ b/main/http_server/axe-os/src/app/components/update/update.component.ts
@@ -25,6 +25,7 @@ export class UpdateComponent {
 
   public checkLatestRelease: boolean = false;
   public latestRelease$: Observable<any>;
+  public latestEspMinerAsset$: Observable<any>;
 
   public info$: Observable<SystemInfo>;
 
@@ -50,6 +51,10 @@ export class UpdateComponent {
     this.latestRelease$ = this.githubUpdateService.getReleases().pipe(map(releases => {
       return (releases as any)[0];
     }));
+
+    this.latestEspMinerAsset$ = this.latestRelease$.pipe(
+      map((release: any) => release?.assets?.find((asset: any) => asset.name === 'esp-miner.bin'))
+    );
 
     this.info$ = this.liveDataService.info$;
 


### PR DESCRIPTION
# Summary

- Remove obsolete release files download UI message and download link for www.bin on assets download.
- Add a warning text in case the esp-miner.bin update asset is still missing in the latest release.

# Why

The new version of `esp-miner.bin` includes the UI update file as well, so the user does not have to download an additional `www.bin` file anymore. After checking for a new version by clicking the `Check` button in the Update section of the UI, the message "Download both files for update!" is still printed regardless if the user is running an old version requiring both files to be downloaded or the newer one.

<img width="545" height="285" alt="image" src="https://github.com/user-attachments/assets/fa8979ec-2f27-4b71-8746-afbab125985c" />

# Impact

The UI behaves accordingly to the current version of the software.

# Validation

 - git diff --check

