### PR TITLE
Reject SV2 job messages that do not match the negotiated channel

### DIFF
--- a/main/tasks/stratum_v2_task.c
+++ b/main/tasks/stratum_v2_task.c
@@ -1003,11 +1003,22 @@ void stratum_v2_task(void *pvParameters)
             sv2_parse_frame_header(hdr_buf, &hdr);
 
             switch (hdr.msg_type) {
+                // Job messages must match the channel we negotiated. Consumers pick
+                // the job struct type from the channel type, so accepting the wrong
+                // message here would have them read and free the wrong type.
                 case SV2_MSG_NEW_MINING_JOB:
+                    if (conn->channel_type != SV2_CHANNEL_STANDARD) {
+                        ESP_LOGW(TAG, "Ignoring NewMiningJob received on an extended channel");
+                        break;
+                    }
                     stratum_v2_handle_new_mining_job(GLOBAL_STATE, conn, recv_buf, hdr.msg_length);
                     break;
 
                 case SV2_MSG_NEW_EXTENDED_MINING_JOB:
+                    if (conn->channel_type != SV2_CHANNEL_EXTENDED) {
+                        ESP_LOGW(TAG, "Ignoring NewExtendedMiningJob received on a standard channel");
+                        break;
+                    }
                     stratum_v2_handle_new_extended_mining_job(GLOBAL_STATE, conn, recv_buf, hdr.msg_length);
                     break;
 


### PR DESCRIPTION
The SV2 receive loop dispatches job messages purely on `msg_type`, while every consumer picks the job struct type from the negotiated channel type. The stratum queue holds `void *` items, so a pool that negotiated an extended channel but sends `NewMiningJob` gets an 84-byte `sv2_job_t` enqueued that `create_jobs_task` then casts to a ~700-byte `sv2_ext_job_t`. The out-of-bounds reads are bad enough, but `sv2_ext_job_free()` also frees pointers read from that out-of-bounds memory. The reverse direction (`NewExtendedMiningJob` on a standard channel) misreads the same way.

Fix: check the incoming job message against `conn->channel_type` at the dispatch switch and drop mismatched job messages with a warning, before any allocation happens. A conforming pool never sends these, so there is no behavior change for normal operation.

This is the SV2 analog of the SV1 `mining.notify` type confusion fixed in #1880, and sits alongside the other SV2 hardening in #1854 (extranonce bound) and #1855 (work-queue epochs) on this same path. It is not present in v2.15.0rc1.

Built against ESP-IDF 6.0.2.
