### PR TITLE
Store scoreboard unordered to limit NVS writes

### DIFF
--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -1623,8 +1623,11 @@ static esp_err_t GET_scoreboard(httpd_req_t * req)
     cJSON * root = cJSON_CreateArray();
 
     if (xSemaphoreTake(scoreboard->mutex, portMAX_DELAY) == pdTRUE) {
-        for (int i = 0; i < scoreboard->count; i++) {
+        for (int i = 0; i < MAX_SCOREBOARD; i++) {
             const ScoreboardEntry *e = &scoreboard->entries[i];
+            if (e->difficulty <= 0.0) {
+                break;
+            }
             cJSON *entry = cJSON_CreateObject();
 
             char nonce_str[9], version_bits_str[9];

--- a/main/tasks/scoreboard.c
+++ b/main/tasks/scoreboard.c
@@ -3,6 +3,7 @@
 #include "esp_log.h"
 #include <stdio.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 static const char * TAG = "scoreboard";
 
@@ -23,8 +24,9 @@ esp_err_t scoreboard_init(Scoreboard *scoreboard)
         return ESP_FAIL;
     }
 
+    memset(scoreboard->entries, 0, sizeof(scoreboard->entries));
+
     for (int i = 0; i < MAX_SCOREBOARD; i++) {
-        memset(&scoreboard->entries[i], 0, sizeof(ScoreboardEntry));
         scoreboard->entries[i].nvs_slot = i;
 
         char *entry_str = nvs_config_get_string_indexed(NVS_CONFIG_SCOREBOARD, i);
@@ -34,7 +36,7 @@ esp_err_t scoreboard_init(Scoreboard *scoreboard)
         }
 
         ScoreboardEntry entry;
-        if (sscanf(entry_str, "%lf;%31[^;];%31[^;];%lu;%lu;%lu", 
+        if (sscanf(entry_str, "%lf;%31[^;];%31[^;];%" SCNu32 ";%" SCNu32 ";%" SCNu32, 
                    &entry.difficulty, 
                    entry.job_id, 
                    entry.extranonce2, 
@@ -83,7 +85,7 @@ esp_err_t scoreboard_add(Scoreboard *scoreboard, double difficulty, const char *
         strncpy(new_entry.extranonce2, extranonce2, sizeof(new_entry.extranonce2) - 1);
         new_entry.extranonce2[sizeof(new_entry.extranonce2) - 1] = '\0';
         snprintf(new_entry.nvs_entry, sizeof(new_entry.nvs_entry),
-            "%.1f;%s;%s;%lu;%lu;%lu", 
+            "%.1f;%s;%s;%" PRIu32 ";%" PRIu32 ";%" PRIu32, 
             new_entry.difficulty, 
             new_entry.job_id, 
             new_entry.extranonce2,
@@ -108,8 +110,8 @@ esp_err_t scoreboard_add(Scoreboard *scoreboard, double difficulty, const char *
             }
         }
 
-        ESP_LOGI(TAG, "New #%d: Difficulty: %.1f, Job ID: %s, extranonce2: %s, ntime: %lu, nonce: %08lX, version_bits: %08lX",
-            rank, new_entry.difficulty, new_entry.job_id, new_entry.extranonce2, (unsigned long)new_entry.ntime, (unsigned long)new_entry.nonce, (unsigned long)new_entry.version_bits);
+        ESP_LOGI(TAG, "New #%d: Difficulty: %.1f, Job ID: %s, extranonce2: %s, ntime: %" PRIu32 ", nonce: %08" PRIX32 ", version_bits: %08" PRIX32,
+            rank, new_entry.difficulty, new_entry.job_id, new_entry.extranonce2, new_entry.ntime, new_entry.nonce, new_entry.version_bits);
     } else {
         ESP_LOGE(TAG, "Failed to take mutex");
         return ESP_FAIL;

--- a/main/tasks/scoreboard.c
+++ b/main/tasks/scoreboard.c
@@ -2,8 +2,18 @@
 #include "nvs_config.h"
 #include "esp_log.h"
 #include <stdio.h>
+#include <stdbool.h>
 
 static const char * TAG = "scoreboard";
+
+static int compare_scoreboard_entries(const void *a, const void *b)
+{
+    const ScoreboardEntry *ea = (const ScoreboardEntry *)a;
+    const ScoreboardEntry *eb = (const ScoreboardEntry *)b;
+    if (eb->difficulty > ea->difficulty) return 1;
+    if (eb->difficulty < ea->difficulty) return -1;
+    return 0;
+}
 
 esp_err_t scoreboard_init(Scoreboard *scoreboard)
 {
@@ -15,10 +25,13 @@ esp_err_t scoreboard_init(Scoreboard *scoreboard)
     }
 
     for (int i = 0; i < MAX_SCOREBOARD; i++) {
+        memset(&scoreboard->entries[i], 0, sizeof(ScoreboardEntry));
+        scoreboard->entries[i].nvs_slot = i;
+
         char *entry_str = nvs_config_get_string_indexed(NVS_CONFIG_SCOREBOARD, i);
         if (entry_str == NULL || entry_str[0] == '\0') {
             free(entry_str);
-            break;
+            continue;
         }
 
         ScoreboardEntry entry;
@@ -31,12 +44,17 @@ esp_err_t scoreboard_init(Scoreboard *scoreboard)
                    &entry.version_bits) == 6) {
             strncpy(entry.nvs_entry, entry_str, sizeof(entry.nvs_entry) - 1);
             entry.nvs_entry[sizeof(entry.nvs_entry) - 1] = '\0';
-            scoreboard->entries[scoreboard->count++] = entry;
+            entry.nvs_slot = i;
+            scoreboard->entries[i] = entry;
+            scoreboard->count++;
         } else {
             ESP_LOGW(TAG, "Failed to parse scoreboard entry from NVS: %s", entry_str);
         }
         free(entry_str);
     }
+
+    qsort(scoreboard->entries, MAX_SCOREBOARD, sizeof(ScoreboardEntry), compare_scoreboard_entries);
+
     return ESP_OK;
 }
 
@@ -47,53 +65,60 @@ static void scoreboard_save(int i, ScoreboardEntry *entry)
 
 esp_err_t scoreboard_add(Scoreboard *scoreboard, double difficulty, const char *job_id, const char *extranonce2, uint32_t ntime, uint32_t nonce, uint32_t version_bits)
 {
-    if (scoreboard->mutex == NULL) return ESP_OK;
-
-    int i = (scoreboard->count < MAX_SCOREBOARD) ? scoreboard->count : MAX_SCOREBOARD - 1;
-
-    if (scoreboard->count == MAX_SCOREBOARD && i >= 0 && difficulty <= scoreboard->entries[i].difficulty) {
-        return ESP_OK;
-    }
-
-    ScoreboardEntry new_entry = {
-        .difficulty = difficulty,
-        .ntime = ntime,
-        .nonce = nonce,
-        .version_bits = version_bits,
-    };
-    strncpy(new_entry.job_id, job_id, sizeof(new_entry.job_id) - 1);
-    new_entry.job_id[sizeof(new_entry.job_id) - 1] = '\0';
-    strncpy(new_entry.extranonce2, extranonce2, sizeof(new_entry.extranonce2) - 1);
-    new_entry.extranonce2[sizeof(new_entry.extranonce2) - 1] = '\0';
-    snprintf(new_entry.nvs_entry, sizeof(new_entry.nvs_entry),
-        "%.1f;%s;%s;%lu;%lu;%lu", 
-        new_entry.difficulty, 
-        new_entry.job_id, 
-        new_entry.extranonce2,
-        new_entry.ntime,
-        new_entry.nonce,
-        new_entry.version_bits);
+    if (scoreboard->mutex == NULL || difficulty <= 0.0) return ESP_OK;
 
     if (xSemaphoreTake(scoreboard->mutex, portMAX_DELAY) == pdTRUE) {
-        while (i > 0 && difficulty > scoreboard->entries[i - 1].difficulty) {
-            scoreboard->entries[i] = scoreboard->entries[i - 1];
-            scoreboard_save(i, &scoreboard->entries[i]);
-            i--;
+        if (difficulty <= scoreboard->entries[MAX_SCOREBOARD - 1].difficulty) {
+            xSemaphoreGive(scoreboard->mutex);
+            return ESP_OK;
         }
-    
-        scoreboard->entries[i] = new_entry;
-        scoreboard_save(i, &new_entry);
+
+        ScoreboardEntry new_entry = {
+            .difficulty = difficulty,
+            .ntime = ntime,
+            .nonce = nonce,
+            .version_bits = version_bits,
+            .nvs_slot = scoreboard->entries[MAX_SCOREBOARD - 1].nvs_slot,
+        };
+        strncpy(new_entry.job_id, job_id, sizeof(new_entry.job_id) - 1);
+        new_entry.job_id[sizeof(new_entry.job_id) - 1] = '\0';
+        strncpy(new_entry.extranonce2, extranonce2, sizeof(new_entry.extranonce2) - 1);
+        new_entry.extranonce2[sizeof(new_entry.extranonce2) - 1] = '\0';
+        snprintf(new_entry.nvs_entry, sizeof(new_entry.nvs_entry),
+            "%.1f;%s;%s;%lu;%lu;%lu", 
+            new_entry.difficulty, 
+            new_entry.job_id, 
+            new_entry.extranonce2,
+            new_entry.ntime,
+            new_entry.nonce,
+            new_entry.version_bits);
+
+        scoreboard->entries[MAX_SCOREBOARD - 1] = new_entry;
         if (scoreboard->count < MAX_SCOREBOARD) {
             scoreboard->count++;
         }
+
+        qsort(scoreboard->entries, MAX_SCOREBOARD, sizeof(ScoreboardEntry), compare_scoreboard_entries);
+
+        scoreboard_save(new_entry.nvs_slot, &new_entry);
+
         xSemaphoreGive(scoreboard->mutex);
+
+        // Determine rank for log output
+        int rank = 1;
+        for (int i = 0; i < scoreboard->count; i++) {
+            if (scoreboard->entries[i].nvs_slot == new_entry.nvs_slot) {
+                rank = i + 1;
+                break;
+            }
+        }
+
+        ESP_LOGI(TAG, "New #%d: Difficulty: %.1f, Job ID: %s, extranonce2: %s, ntime: %lu, nonce: %08lX, version_bits: %08lX",
+            rank, new_entry.difficulty, new_entry.job_id, new_entry.extranonce2, (unsigned long)new_entry.ntime, (unsigned long)new_entry.nonce, (unsigned long)new_entry.version_bits);
     } else {
         ESP_LOGE(TAG, "Failed to take mutex");
         return ESP_FAIL;
     }
-    
-    ESP_LOGI(TAG, "New #%d: Difficulty: %.1f, Job ID: %s, extranonce2: %s, ntime: %d, nonce: %08X, version_bits: %08X",
-        i+1, new_entry.difficulty, new_entry.job_id, new_entry.extranonce2, new_entry.ntime, (unsigned int)new_entry.nonce, (unsigned int)new_entry.version_bits);
 
     return ESP_OK;
 }

--- a/main/tasks/scoreboard.c
+++ b/main/tasks/scoreboard.c
@@ -17,7 +17,6 @@ static int compare_scoreboard_entries(const void *a, const void *b)
 
 esp_err_t scoreboard_init(Scoreboard *scoreboard)
 {
-    scoreboard->count = 0;
     scoreboard->mutex = xSemaphoreCreateMutex();
     if (scoreboard->mutex == NULL) {
         ESP_LOGE(TAG, "Failed to create mutex");
@@ -46,7 +45,6 @@ esp_err_t scoreboard_init(Scoreboard *scoreboard)
             entry.nvs_entry[sizeof(entry.nvs_entry) - 1] = '\0';
             entry.nvs_slot = i;
             scoreboard->entries[i] = entry;
-            scoreboard->count++;
         } else {
             ESP_LOGW(TAG, "Failed to parse scoreboard entry from NVS: %s", entry_str);
         }
@@ -94,9 +92,6 @@ esp_err_t scoreboard_add(Scoreboard *scoreboard, double difficulty, const char *
             new_entry.version_bits);
 
         scoreboard->entries[MAX_SCOREBOARD - 1] = new_entry;
-        if (scoreboard->count < MAX_SCOREBOARD) {
-            scoreboard->count++;
-        }
 
         qsort(scoreboard->entries, MAX_SCOREBOARD, sizeof(ScoreboardEntry), compare_scoreboard_entries);
 
@@ -106,7 +101,7 @@ esp_err_t scoreboard_add(Scoreboard *scoreboard, double difficulty, const char *
 
         // Determine rank for log output
         int rank = 1;
-        for (int i = 0; i < scoreboard->count; i++) {
+        for (int i = 0; i < MAX_SCOREBOARD; i++) {
             if (scoreboard->entries[i].nvs_slot == new_entry.nvs_slot) {
                 rank = i + 1;
                 break;

--- a/main/tasks/scoreboard.h
+++ b/main/tasks/scoreboard.h
@@ -19,6 +19,7 @@ typedef struct {
     uint32_t nonce;
     uint32_t version_bits;
     char nvs_entry[128];
+    int nvs_slot;
 } ScoreboardEntry;
 
 typedef struct {

--- a/main/tasks/scoreboard.h
+++ b/main/tasks/scoreboard.h
@@ -24,7 +24,6 @@ typedef struct {
 
 typedef struct {
     ScoreboardEntry entries[MAX_SCOREBOARD];
-    int count;
     SemaphoreHandle_t mutex;
 } Scoreboard;
 


### PR DESCRIPTION
Review comments on #1896 showed a contention point where a new high-score shifts down all lower entries, creating a bulk NVS update, up to 20 writes. This could exhaust the NVS dispatch queue. This PR switches the scoreboard to an unordered list with in-memory sorting, so every new high score table entry results in a single NVS write.