### PR TITLE
fix: prevent reconnect storms from slow clients

### DIFF
--- a/main/http_server/axe-os/src/app/services/live-data.service.ts
+++ b/main/http_server/axe-os/src/app/services/live-data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, Subject, EMPTY, timer, merge, fromEvent } from 'rxjs';
-import { catchError, retry, share, tap, switchMap, startWith, scan, shareReplay, map, timeout, bufferTime, filter, distinctUntilChanged } from 'rxjs/operators';
+import { catchError, retry, share, tap, switchMap, startWith, scan, shareReplay, map, timeout, bufferTime, filter, distinctUntilChanged, exhaustMap } from 'rxjs/operators';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 import { SystemInfo as ISystemInfo } from 'src/app/generated/models';
 import { SystemApiService } from './system.service';
@@ -40,7 +40,7 @@ export class LiveDataService {
       switchMap(state => {
         const interval = state === 'visible' ? 3000 : 60000; // 3s when visible, 60s when hidden
         return timer(0, interval).pipe(
-          switchMap(() => {
+          exhaustMap(() => {
             // Only poll if not connected OR if backgrounded (to keep data fresh)
             if (this.connectedSubject.value && state === 'visible') return EMPTY;
             return this.systemService.getInfo().pipe(
@@ -116,14 +116,14 @@ export class LiveDataService {
     });
 
     return this.socket$.pipe(
-      timeout(5000),
+      timeout(10000),
       tap(msg => {
         this.lastMessageAt = Date.now();
         if (msg.event === 'update' && msg.data) {
           this.updates$.next(msg.data);
         }
       }),
-      retry({ delay: 2000 }),
+      retry({ delay: 5000 }),
       share({ resetOnRefCountZero: false })
     );
   }

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -1855,6 +1855,7 @@ esp_err_t start_rest_server(GlobalState * global_state)
     config.max_uri_handlers = 25;
     config.close_fn = websocket_close_fn;
     config.lru_purge_enable = true;
+    config.keep_alive_enable = true;
 
     ESP_LOGI(TAG, "Starting HTTP Server");
     REST_CHECK(httpd_start(&server, &config) == ESP_OK, "Start server failed", err_start);


### PR DESCRIPTION
### Problem

When the live WebSocket became unavailable, AxeOS used `/api/system/info` as a fallback.

Visible fallback polling runs every three seconds and previously used `switchMap`. If a request took longer than the polling interval, the next tick cancelled it and immediately created another request. Slow, suspended, or overloaded clients could therefore generate repeated aborted TCP connections.

The WebSocket also timed out after five seconds and retried after two seconds, creating additional connection pressure during temporary browser or network interruptions.

This could contribute to repeated HTTPD messages such as:

```
httpd_accept_conn: error in accept (113)
httpd_server: error accepting new connection
```

### Solution

- Use `exhaustMap` so only one fallback `/api/system/info` request can be active at a time.
- Ignore polling ticks while the current request is running instead of cancelling it.
- Increase the WebSocket inactivity timeout from 5 to 10 seconds.
- Increase the WebSocket retry delay from 2 to 5 seconds.
- Enable HTTPD TCP keepalive to improve cleanup of stale client connections.

### Result

Slow fallback requests can now finish normally, and temporary WebSocket interruptions produce fewer reconnect attempts. This reduces connection churn while preserving existing polling intervals and connection-state behavior.