### PR TITLE
Fix swarm for local domains

### DIFF
--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.spec.ts
@@ -4,7 +4,8 @@ import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { provideToastr } from 'ngx-toastr';
 import { of } from 'rxjs';
 
-import { SwarmComponent } from './swarm.component';
+import { FormControl } from '@angular/forms';
+import { addressValidator, SwarmComponent } from './swarm.component';
 import { ModalComponent } from '../modal/modal.component';
 import { TooltipTextIconComponent } from 'src/app/components/tooltip-text-icon/tooltip-text-icon.component';
 import { DropdownComponent } from 'src/app/components/dropdown/dropdown.component';
@@ -93,5 +94,77 @@ describe('SwarmComponent', () => {
     // Verify that components inside *ngIf are rendered
     expect(element.querySelector('app-slider')).toBeTruthy();
     expect(element.querySelector('app-modal')).toBeTruthy();
+  });
+
+  describe('addressValidator', () => {
+    it('should allow valid IPv4 addresses', () => {
+      expect(addressValidator(new FormControl('192.168.1.1'))).toBeNull();
+      expect(addressValidator(new FormControl('10.0.0.1'))).toBeNull();
+      expect(addressValidator(new FormControl('172.16.0.50'))).toBeNull();
+    });
+
+    it('should allow bare hostnames', () => {
+      expect(addressValidator(new FormControl('bitaxe'))).toBeNull();
+      expect(addressValidator(new FormControl('bitaxe-gamma-1'))).toBeNull();
+      expect(addressValidator(new FormControl('miner01'))).toBeNull();
+    });
+
+    it('should allow hostnames with .local, .lan, .home.arpa, .internal, and other TLDs', () => {
+      expect(addressValidator(new FormControl('bitaxe-1.local'))).toBeNull();
+      expect(addressValidator(new FormControl('bitaxe-gamma-1.lan'))).toBeNull();
+      expect(addressValidator(new FormControl('miner.home.arpa'))).toBeNull();
+      expect(addressValidator(new FormControl('sub.corp.internal'))).toBeNull();
+      expect(addressValidator(new FormControl('node-1.custom.domain'))).toBeNull();
+    });
+
+    it('should reject invalid addresses and hostnames', () => {
+      expect(addressValidator(new FormControl('192.168.1.256'))).toEqual({ invalidAddress: true });
+      expect(addressValidator(new FormControl('192.168.1'))).toEqual({ invalidAddress: true });
+      expect(addressValidator(new FormControl('-bitaxe'))).toEqual({ invalidAddress: true });
+      expect(addressValidator(new FormControl('bitaxe-'))).toEqual({ invalidAddress: true });
+      expect(addressValidator(new FormControl('bitaxe..local'))).toEqual({ invalidAddress: true });
+      expect(addressValidator(new FormControl('bitaxe space.lan'))).toEqual({ invalidAddress: true });
+      expect(addressValidator(new FormControl('bitaxe_1.lan'))).toEqual({ invalidAddress: true });
+    });
+
+    it('should return null for empty input', () => {
+      expect(addressValidator(new FormControl(''))).toBeNull();
+      expect(addressValidator(new FormControl(null))).toBeNull();
+    });
+  });
+
+  describe('getDeviceLink', () => {
+    const mockDevice: any = {
+      address: 'bitaxe-gamma-1.local',
+      hostname: 'bitaxe-gamma-1',
+      fullHostname: 'bitaxe-gamma-1.local',
+      ipv4: '192.168.1.51',
+      connectionAddress: '192.168.1.51'
+    };
+
+    it('should link via IP when dashboard is accessed via IP', () => {
+      spyOn(component, 'getCurrentHostname').and.returnValue('192.168.1.50');
+      expect(component.getDeviceLink(mockDevice)).toBe('192.168.1.51');
+    });
+
+    it('should link via .local when dashboard is accessed via .local', () => {
+      spyOn(component, 'getCurrentHostname').and.returnValue('bitaxe-gamma-0.local');
+      expect(component.getDeviceLink(mockDevice)).toBe('bitaxe-gamma-1.local');
+    });
+
+    it('should link via .lan when dashboard is accessed via .lan', () => {
+      spyOn(component, 'getCurrentHostname').and.returnValue('bitaxe-gamma-0.lan');
+      expect(component.getDeviceLink(mockDevice)).toBe('bitaxe-gamma-1.lan');
+    });
+
+    it('should link via .home.arpa when dashboard is accessed via .home.arpa', () => {
+      spyOn(component, 'getCurrentHostname').and.returnValue('bitaxe-gamma-0.home.arpa');
+      expect(component.getDeviceLink(mockDevice)).toBe('bitaxe-gamma-1.home.arpa');
+    });
+
+    it('should link via bare hostname when dashboard is accessed via bare hostname', () => {
+      spyOn(component, 'getCurrentHostname').and.returnValue('bitaxe-gamma-0');
+      expect(component.getDeviceLink(mockDevice)).toBe('bitaxe-gamma-1');
+    });
   });
 });

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -15,20 +15,31 @@ const SWARM_REFRESH_TIME = 'SWARM_REFRESH_TIME';
 const SWARM_SORTING = 'SWARM_SORTING';
 const SWARM_GRID_VIEW = 'SWARM_GRID_VIEW';
 
-function addressValidator(control: AbstractControl): ValidationErrors | null {
+export function addressValidator(control: AbstractControl): ValidationErrors | null {
   const value = control.value;
   if (!value) return null;
-  const parts = value.split('.');
-  switch (parts.length) {
-    case 1: // Bare hostname (e.g. "bitaxe")
-      return /^[a-zA-Z0-9-]+$/.test(parts[0]) ? null : { invalidAddress: true };
-    case 2: // mDNS hostname (e.g. "bitaxe.local")
-      if (parts[1].toLowerCase() === 'local' && /^[a-zA-Z0-9-]+$/.test(parts[0])) return null;
-      break;
-    case 4: // IP Address (e.g. "192.168.1.1")
-      if (parts.every((part: string) => /^\d+$/.test(part) && Number(part) >= 0 && Number(part) <= 255)) return null;
-      break;
+
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) return null;
+
+  const parts = trimmed.split('.');
+
+  // If input is an IPv4 address (4 numeric octets 0-255)
+  if (parts.length === 4 && parts.every(part => /^\d+$/.test(part) && Number(part) >= 0 && Number(part) <= 255)) {
+    return null;
   }
+
+  // If all parts are numeric or the last part (TLD) is numeric, it is a malformed IP / invalid TLD
+  if (parts.some(part => part === '') || /^\d+$/.test(parts[parts.length - 1])) {
+    return { invalidAddress: true };
+  }
+
+  // RFC 1123 Hostname / FQDN format check (each label 1-63 chars, alphanum & hyphens, cannot start/end with hyphen)
+  const labelRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
+  if (trimmed.length <= 253 && parts.every(part => labelRegex.test(part))) {
+    return null;
+  }
+
   return { invalidAddress: true };
 }
 
@@ -239,19 +250,33 @@ private isIpAddress(value: string): boolean {
     return device.displayName || device.address;
   }
 
+  public getCurrentHostname(): string {
+    return window.location.hostname;
+  }
+
   // Utility method to get the link URL for a device
-  // Follows the current device's access method (IP, hostname.local, or bare hostname)
+  // Follows the current device's access method (IP, hostname.local, bare hostname, or custom domain suffix like .lan)
   public getDeviceLink(device: SwarmDevice): string {
-    const currentHost = window.location.hostname;
+    const currentHost = this.getCurrentHostname();
     const isIP = this.isIpAddress(currentHost);
     if (isIP) {
       // Accessing via IP — link to device IP
       return device['ipv4'] || device.connectionAddress || device.address || '';
     }
-    if (currentHost.endsWith('.local')) {
-      // Accessing via mDNS — link to device's .local hostname
-      return device['fullHostname'] || device.connectionAddress || device.address || '';
+
+    const dotIndex = currentHost.indexOf('.');
+    if (dotIndex !== -1) {
+      // Accessing via domain (e.g. .local, .lan, .home.arpa) — link using the same domain suffix
+      const domainSuffix = currentHost.substring(dotIndex);
+      if (domainSuffix.toLowerCase() === '.local' && device['fullHostname']) {
+        return device['fullHostname'];
+      }
+      const baseName = (device['hostname'] || device.address || '').replace(/\.local$/i, '');
+      if (baseName) {
+        return `${baseName}${domainSuffix}`;
+      }
     }
+
     // Accessing via bare hostname — link to device's bare hostname
     return device['hostname'] || device.connectionAddress || device.address || '';
   }

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -238,6 +238,9 @@ private isIpAddress(value: string): boolean {
     if (ipv4) {
       return of(ipv4);
     }
+    if (this.isIpAddress(address)) {
+      return of(address);
+    }
     return this.httpClient.get(`http://${address}/api/ap/info`).pipe(
       timeout(3000),
       map((ap: any) => this.deviceIpv4(ap)),
@@ -325,19 +328,20 @@ private isIpAddress(value: string): boolean {
 
   private performNetworkScan(ips: string[]) {
     this.getAllDeviceInfo(ips, () => of(null)).subscribe({
-      next: (result) => {
-        // Filter out null items first
-        const validResults = result.filter((item): item is SwarmDevice => item !== null);
-        // Merge new results with existing swarm entries
-        const existingAddresses = new Set([...this.swarm.map(item => item.address), ...this.swarm.map(item => item.connectionAddress)]);
-        const newItems = validResults.filter(item => {
-          const isDuplicate = existingAddresses.has(item['hostname']) || existingAddresses.has(item['ipv4']);
-          return !isDuplicate;
-        });
-        this.swarm = [...this.swarm, ...newItems];
-        this.sortSwarm();
-        this.saveSwarmData();
-        this.calculateTotals();
+      next: (device) => {
+        if (device) {
+          const isDuplicate = this.swarm.some(item =>
+            (item.connectionAddress && item.connectionAddress === device.connectionAddress) ||
+            (item['ipv4'] && item['ipv4'] === device['ipv4']) ||
+            (item['hostname'] && item['hostname'] === device['hostname'])
+          );
+          if (!isDuplicate) {
+            this.swarm = [...this.swarm, device];
+            this.sortSwarm();
+            this.saveSwarmData();
+            this.calculateTotals();
+          }
+        }
       },
       complete: () => {
         this.scanning = false;
@@ -346,65 +350,80 @@ private isIpAddress(value: string): boolean {
     });
   }
 
-  private getAllDeviceInfo(addresses: string[], errorHandler: (error: any, address: string) => Observable<SwarmDevice[] | null>, fetchAsic: boolean = true) {
-    return from(addresses).pipe(
-      mergeMap(address => forkJoin({
-        info: this.httpClient.get(`http://${address}/api/system/info`).pipe(catchError(() => of(null))),
-        asic: fetchAsic ? this.httpClient.get(`http://${address}/api/system/asic`).pipe(catchError(() => of({}))) : of({})
-      }).pipe(
-        mergeMap(({ info, asic }) => info === null
-          ? of(null)
-          : this.fetchDeviceIpv4(address, info).pipe(map(ipv4 => ({ info, asic, ipv4 })))
-        ),
-        map(bundle => {
-          if (bundle === null) {
-            return null;
-          }
-          const { info, asic, ipv4 } = bundle;
+  private buildSwarmDevice(address: string, info: any, asic: any, ipv4?: string): SwarmDevice {
+    const existingDevice = this.swarm.find(device => device.connectionAddress === address);
+    const result = {
+      address: info?.['fullHostname'] || info?.['hostname'] || address,
+      displayName: info?.['hostname'] ? info['hostname'].replace(/\.local$/i, '') : address,
+      connectionAddress: address,
+      ...(existingDevice ? existingDevice : {}),
+      ...info,
+      ...asic,
+      ...this.numerizeDeviceBestDiffs(info as ISystemInfo),
+      ipv4: ipv4 ?? existingDevice?.['ipv4']
+    };
+    return this.fallbackDeviceModel(result);
+  }
 
-          const existingDevice = this.swarm.find(device => device.connectionAddress === address);
-          const result = {
-            address: (info as any)['fullHostname'] || (info as any)['hostname'] || address,
-            displayName: (info as any)['hostname'] ? (info as any)['hostname'].replace(/\.local$/i, '') : address,
-            connectionAddress: address,
-            ...(existingDevice ? existingDevice : {}),
-            ...info,
-            ...asic,
-            ...this.numerizeDeviceBestDiffs(info as ISystemInfo),
-            ipv4: ipv4 ?? existingDevice?.['ipv4']
-          };
-          return this.fallbackDeviceModel(result);
-        }),
+  private fetchDevice(address: string, fetchAsic: boolean = true): Observable<SwarmDevice | null> {
+    return this.httpClient.get<any>(`http://${address}/api/system/info`).pipe(
+      mergeMap(info => {
+        if (!info) {
+          return of(null);
+        }
+        const asic$ = fetchAsic
+          ? this.httpClient.get<any>(`http://${address}/api/system/asic`).pipe(timeout(1000), catchError(() => of({})))
+          : of({});
+
+        return forkJoin({
+          asic: asic$,
+          ipv4: this.fetchDeviceIpv4(address, info)
+        }).pipe(
+          map(({ asic, ipv4 }) => this.buildSwarmDevice(address, info, asic, ipv4))
+        );
+      })
+    );
+  }
+
+  private getAllDeviceInfo(addresses: string[], errorHandler: (error: any, address: string) => Observable<SwarmDevice | null>, fetchAsic: boolean = true): Observable<SwarmDevice | null> {
+    return from(addresses).pipe(
+      mergeMap(address => this.fetchDevice(address, fetchAsic).pipe(
         timeout(5000),
         catchError(error => errorHandler(error, address))
-      ),
-        128
-      ),
-      toArray()
-    ).pipe(take(1));
+      ), 128)
+    );
   }
 
   public add() {
     const address = this.form.value.manualAddAddress;
 
-    forkJoin({
-      info: this.httpClient.get<any>(`http://${address}/api/system/info`).pipe(catchError(error => {
+    this.httpClient.get<any>(`http://${address}/api/system/info`).pipe(
+      catchError(error => {
         if (error.status === 401 || error.status === 0) {
           this.toastr.warning(`Potential swarm peer detected at ${address} - upgrade its firmware to be able to add it.`);
           return of({ _corsError: 401 });
         }
-        throw error;
-      })),
-      asic: this.httpClient.get<any>(`http://${address}/api/system/asic`).pipe(catchError(() => of({})))
-    }).pipe(
-      mergeMap(({ info, asic }) => {
-        if ((info as any)._corsError === 401) {
-          return of(null); // Already showed warning
-        }
-        if (!info.ASICModel || !asic.ASICModel) {
+        if (error.name === 'TimeoutError') {
+          this.toastr.error(`Request timed out - device at ${address} did not respond.`, `Device at ${address}`);
           return of(null);
         }
-        return this.fetchDeviceIpv4(address, info).pipe(map(ipv4 => ({ info, asic, ipv4 })));
+        throw error;
+      }),
+      mergeMap(info => {
+        if (!info || (info as any)._corsError === 401) {
+          return of(null); // Already showed warning or timed out
+        }
+        return forkJoin({
+          asic: this.httpClient.get<any>(`http://${address}/api/system/asic`).pipe(timeout(1000), catchError(() => of({}))),
+          ipv4: this.fetchDeviceIpv4(address, info)
+        }).pipe(
+          map(({ asic, ipv4 }) => {
+            if (!info.ASICModel || !asic.ASICModel) {
+              return null;
+            }
+            return { info, asic, ipv4 };
+          })
+        );
       })
     ).subscribe(result => {
       if (result === null) {
@@ -511,12 +530,19 @@ private isIpAddress(value: string): boolean {
     this.isRefreshing = true;
 
     this.getAllDeviceInfo(addresses, this.refreshErrorHandler, fetchAsic).subscribe({
-      next: (result) => {
-        this.swarm = result;
-        this.sortSwarm();
-        this.saveSwarmData();
-        this.calculateTotals();
-        this.isRefreshing = false;
+      next: (device) => {
+        if (device) {
+          const index = this.swarm.findIndex(item => item.connectionAddress === device.connectionAddress);
+          if (index !== -1) {
+            this.swarm[index] = device;
+            this.swarm = [...this.swarm];
+          } else {
+            this.swarm = [...this.swarm, device];
+          }
+          this.sortSwarm();
+          this.saveSwarmData();
+          this.calculateTotals();
+        }
       },
       complete: () => {
         this.isRefreshing = false;

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -307,6 +307,39 @@ static void normalize_hostname(char *hostname, size_t max_len) {
     }
 }
 
+// Helper function to check if a hostname is a local network or reserved private domain
+static bool is_local_network_hostname(const char *host_str) {
+    if (host_str == NULL || *host_str == '\0') {
+        return false;
+    }
+
+    // Bare hostname (no dots, only resolvable on local network)
+    if (strchr(host_str, '.') == NULL) {
+        return true;
+    }
+
+    // Reserved / non-routable private local domain suffixes
+    static const char *local_suffixes[] = {
+        ".local",       // RFC 6762 (mDNS)
+        ".lan",         // Common router private LAN domain
+        ".home.arpa",   // RFC 8375 (IETF Home Network)
+        ".internal",    // ICANN-reserved private use
+        ".localdomain", // RFC 6761
+        ".home",        // Common router default
+        ".localhost"    // RFC 6761
+    };
+
+    size_t host_len = strlen(host_str);
+    for (size_t i = 0; i < sizeof(local_suffixes) / sizeof(local_suffixes[0]); i++) {
+        size_t suffix_len = strlen(local_suffixes[i]);
+        if (host_len > suffix_len && strcasecmp(host_str + host_len - suffix_len, local_suffixes[i]) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 esp_err_t is_network_allowed(httpd_req_t * req)
 {
     if (GLOBAL_STATE->SYSTEM_MODULE.ap_enabled == true) {
@@ -380,16 +413,10 @@ esp_err_t is_network_allowed(httpd_req_t * req)
                 strncpy(host_str, host_start, host_len);
                 host_str[host_len] = '\0';
 
-                // Allow any .local hostname (mDNS, inherently local network)
-                size_t hlen = strlen(host_str);
-                if (hlen > 6 && strcasecmp(host_str + hlen - 6, ".local") == 0) {
+                // Allow local network hostnames (bare, .local, .lan, .home.arpa, .internal, etc.)
+                if (is_local_network_hostname(host_str)) {
                     is_local_hostname = true;
-                    ESP_LOGD(CORS_TAG, "Origin host '%s' is a .local mDNS hostname - allowing", host_str);
-                }
-                // Allow any bare hostname (no dots, only resolvable on local network)
-                else if (strchr(host_str, '.') == NULL) {
-                    is_local_hostname = true;
-                    ESP_LOGD(CORS_TAG, "Origin host '%s' is a bare local hostname - allowing", host_str);
+                    ESP_LOGD(CORS_TAG, "Origin host '%s' is a local network hostname - allowing", host_str);
                 }
             }
         }


### PR DESCRIPTION
Accepts standard local network domains. besides `.local`:

```
        ".local",       // RFC 6762 (mDNS)
        ".lan",         // Common router private LAN domain
        ".home.arpa",   // RFC 8375 (IETF Home Network)
        ".internal",    // ICANN-reserved private use
        ".localdomain", // RFC 6761
        ".home",        // Common router default
        ".localhost"    // RFC 6761
```

Fixes #1903