### PR TITLE
Fix DS4432U DAC code overflow that overvolts the ASIC below ~989mV

### DIFF
--- a/main/power/DS4432U.c
+++ b/main/power/DS4432U.c
@@ -18,7 +18,13 @@
 #define BITAXE_RB 3320.0       // R15
 #define BITAXE_VNOM 1.451   // this is with the current DAC set to 0. Should be pretty close to (VFB*(RA+RB))/RB
 #define BITAXE_VMAX 2.39
-#define BITAXE_VMIN 0.046
+// The DAC magnitude is only 7 bits (bit 7 is the direction flag), so the lowest
+// voltage this resistor network can actually reach is the one that needs a code
+// of exactly 127, which works out to ~0.9886V. Asking for less used to overflow
+// the code, wrap into the direction bit and drive the core to roughly BITAXE_VNOM
+// (~1.45V) instead - i.e. a request to undervolt produced a large overvolt.
+#define BITAXE_DAC_MAX_CODE 127
+#define BITAXE_VMIN 0.989
 
 #define TPS40305_VFB 0.6
 
@@ -53,12 +59,23 @@ esp_err_t DS4432U_set_voltage(float vout) {
 
     // make sure the requested voltage is in within range of BITAXE_VMIN and BITAXE_VMAX
     if (vout > BITAXE_VMAX || vout < BITAXE_VMIN) {
+        ESP_LOGE(TAG, "Requested voltage %.3fV is outside the reachable range %.3fV - %.3fV", vout, (float) BITAXE_VMIN, (float) BITAXE_VMAX);
         return ESP_FAIL;
     }
 
     // this is the transfer function. comes from the DS4432U+ datasheet
     change = fabs((((TPS40305_VFB / BITAXE_RB) - ((vout - TPS40305_VFB) / BITAXE_RA)) / BITAXE_IFS) * 127);
-    reg = (uint8_t)ceil(change);
+
+    // Only 7 bits are available for the magnitude; bit 7 selects the direction.
+    // Refuse rather than let the cast wrap, which would invert the direction bit
+    // and apply a completely different (much higher) voltage than requested.
+    int code = (int) ceil(change);
+    if (code > BITAXE_DAC_MAX_CODE) {
+        ESP_LOGE(TAG, "DAC code %d for %.3fV exceeds the 7-bit maximum of %d", code, vout, BITAXE_DAC_MAX_CODE);
+        return ESP_FAIL;
+    }
+
+    reg = (uint8_t) code;
 
     // Set the MSB high if the requested voltage is BELOW nominal
     if (vout < BITAXE_VNOM) {


### PR DESCRIPTION
## Problem

`DS4432U_set_voltage()` computes a current-DAC code and casts it straight to `uint8_t`:

```c
change = fabs((((TPS40305_VFB / BITAXE_RB) - ((vout - TPS40305_VFB) / BITAXE_RA)) / BITAXE_IFS) * 127);
reg = (uint8_t)ceil(change);
if (vout < BITAXE_VNOM) reg |= 0x80;
```

Only the low 7 bits are the magnitude; bit 7 selects direction. With the Bitaxe network (`RA = 4750`, `RB = 3320`, `VFB = 0.6`, `IFS = 98.921uA`) the code stays inside 7 bits only down to about **988.6 mV**:

| Vout | change | ceil | reg | magnitude | |
|---|---|---|---|---|---|
| 1166 mV | 79.04 | 80 | `0xD0` | 80 | |
| 1100 mV | 96.88 | 97 | `0xE1` | 97 | |
| 1000 mV | 123.91 | 124 | `0xFC` | 124 | |
| 990 mV | 126.61 | 127 | `0xFF` | 127 | last valid point |
| 988 mV | 127.15 | 128 | `0x80` | 0 | **overflow** |
| 950 mV | 137.42 | 138 | `0x8A` | 10 | **overflow** |

Below that threshold the cast wraps into the direction bit and the magnitude collapses, so the DAC sinks little or no current and the output rises toward `BITAXE_VNOM` (~1.451 V). **A request to undervolt produces a substantial overvolt** — asking for 950 mV yields roughly 1.41 V.

The existing range check does not catch this because `BITAXE_VMIN` is declared as `0.046`, a voltage this resistor network cannot reach at all.

## Why this is reachable

- `NVS_CONFIG_ASIC_VOLTAGE` is bounded `.min = 1, .max = UINT16_MAX`, and the web UI permits arbitrary values once overclock mode is enabled, so a user attempting to undervolt can enter a value in the overflow region directly.
- The overheat recovery path in `POWER_MANAGEMENT_task` subtracts a flat `ASIC_REDUCTION` of 100 mV. Any configured voltage between 1001 mV and 1088 mV therefore lands in the overflow region **while the chip is already overheating**.

## Change

- Correct `BITAXE_VMIN` to the reachable minimum (0.989 V) and document why the old value was meaningless for this network.
- Compute the code as an `int`, validate it against the 7-bit maximum, and return `ESP_FAIL` with a log line instead of letting it wrap.

Callers already propagate the error, so the regulator is left at its previous setting rather than being driven to the wrong voltage — a safe failure instead of a silent overvolt.

Rounding behaviour is deliberately unchanged (`ceil` is kept) so every existing operating point resolves to exactly the same DAC code as before. This is intended to be a no-op for all currently reachable configurations and only changes behaviour in the region that was previously broken.

For reference, this network gives `RA * IFS / 127` = **3.70 mV per DAC LSB**.

## Testing

- Builds with ESP-IDF v6.0.2 for `esp32s3`, no new warnings.
- Running on a Bitaxe Supra (board 401, BM1368 @ 500 MHz): boots, ASIC detected, pool connected, mining, no `DS4432U` errors at the normal operating voltage — i.e. the new range check does not false-trip in ordinary use.
- The overflow table above was derived from the transfer function rather than measured. I deliberately did not drive a real ASIC into the overvolt condition to confirm it empirically; if a maintainer wants that verified on a scrap board, the reproduction is simply setting `coreVoltage` to 950 with overclock mode enabled and measuring Vcore.
