### PR TITLE
Fix fan PID handover so the fan does not drop at ASIC startup

### DIFF
--- a/main/tasks/fan_controller_task.c
+++ b/main/tasks/fan_controller_task.c
@@ -106,8 +106,16 @@ void FAN_CONTROLLER_task(void * pvParameters)
                     
                     // Initialize PID on first valid temperature reading
                     if (pid_get_mode(&pid) == MANUAL) {
+                        // pid_initialize() seeds the integrator from *output to hand
+                        // over without a bump, but pid_output has never been written
+                        // at this point -- the startup fan speed went straight to the
+                        // fan, not through the PID. Without seeding it here the
+                        // integrator starts from 0, is clamped up to the minimum fan
+                        // speed, and the fan drops from the startup value to that
+                        // minimum just as the ASIC reaches full power.
+                        pid_output = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.fan_perc;
                         pid_set_mode(&pid, AUTOMATIC);
-                        ESP_LOGI(TAG, "PID initialized at %.1f°C (P:%.1f I:%.1f D:%.1f", pid_input, pid.dispKp, pid.dispKi, pid.dispKd);
+                        ESP_LOGI(TAG, "PID initialized at %.1f°C, output %.1f%% (P:%.1f I:%.1f D:%.1f", pid_input, pid_output, pid.dispKp, pid.dispKi, pid.dispKd);
                     }
                     
                     pid_compute(&pid);


### PR DESCRIPTION
## Problem

Before the ASIC is initialised, `Thermal_get_chip_temp()` returns `-1`, so `FAN_CONTROLLER_task` runs the fan open loop:

```c
} else {
    update_fan_speed(GLOBAL_STATE, 70.0f, "Startup");
}
```

Once a valid temperature appears, the PID is switched to `AUTOMATIC`. `pid_set_mode()` calls `pid_initialize()`, which performs the bumpless transfer by seeding the integrator from the current output:

```c
void pid_initialize(PIDController *pid) {
    pid->outputSum = *(pid->output);
    ...
    else if (pid->outputSum < pid->outMin) pid->outputSum = pid->outMin;
}
```

But `*output` is `pid_output`, declared `float pid_output = 0;` and **never written before this point** — the 70% startup value went straight to the fan via `update_fan_speed()`, not through the PID.

So `outputSum` initialises to 0, is clamped up to `pid_output_min` (`minFanSpeed`, default 25), and **the fan steps down from 70% to 25% at exactly the moment the ASIC begins hashing at full power.**

## Why it matters

Recovery from that dip is slow. `Ki = 0.1` becomes `ki = Ki * sampleTime = 0.01` per 100 ms sample, so the integrator moves about 0.1% of fan output per second per degree of error. Climbing from `minFanSpeed` to a realistic steady state takes on the order of a minute, during which the ASIC runs at full power on minimum airflow.

The proportional term does respond, but at `Kp = 5` it needs a large error to substitute for the missing integrator — roughly 9 °C of overshoot to supply 45 points of output on its own.

## Change

Seed `pid_output` from the fan percentage that is actually applied before handing over, which is what `pid_initialize()` expects:

```c
pid_output = GLOBAL_STATE->POWER_MANAGEMENT_MODULE.fan_perc;
pid_set_mode(&pid, AUTOMATIC);
```

`fan_perc` holds whatever `update_fan_speed()` last commanded, so the startup value carries into the integrator and the transfer becomes genuinely bumpless.

This can only raise the starting integrator value, never lower it. If the PID goes automatic before any startup fan speed was applied, `fan_perc` is still 0 and `pid_initialize()` clamps to `outMin` exactly as it does today — so the change is a no-op in that path rather than a regression.

The handover output is now logged too, which makes the transfer visible:

```
fan_controller: PID initialized at 47.0°C, output 70.0% (P:5.0 I:0.1 D:2.0
```

## Testing

- Builds with ESP-IDF v6.0.2 for `esp32s3`, no new warnings.
- Verified alongside three other small fixes on a Bitaxe Supra (board 401, BM1368 @ 500 MHz / 1166 mV): boots, ASIC detected, pool connected, mining, no errors.

I should be straightforward about provenance: **this was found by reading the code, not from an observed failure.** The board I have was running its fan in manual mode, so the PID path was not exercised on hardware and I have not instrumented the startup transient to measure the dip directly. The reasoning above is from the source; the fix is conservative by construction because it can only increase the initial fan output.

Anyone able to watch `fanspeed` across a cold boot with `autofanspeed` enabled could confirm the dip in a couple of minutes — before this change it should fall from 70% to `minFanSpeed`, after it should hold.

## Context

I ran into this while investigating fan behaviour more broadly; the duty-cycle scaling issue in `EMC2101_set_fan_speed()` is filed separately as an issue since it needs a migration decision. This change stands on its own and is independent of it.
