### PR TITLE
Guard EMC2101 fan RPM conversion against a zero tach reading

### DIFF
--- a/main/thermal/EMC2101.c
+++ b/main/thermal/EMC2101.c
@@ -102,6 +102,13 @@ uint16_t EMC2101_get_fan_speed(void)
     // ESP_LOGI(TAG, "Raw Fan Speed = %02X %02X", tach_msb, tach_lsb);
 
     reading = tach_lsb | (tach_msb << 8);
+
+    // A zero tach count would raise an integer divide-by-zero exception and
+    // panic the ESP32, so treat it the same as "no fan detected".
+    if (reading == 0) {
+        return 0;
+    }
+
     RPM = 5400000 / reading;
 
     // ESP_LOGI(TAG, "Fan Speed = %d RPM", RPM);


### PR DESCRIPTION
## Problem

`EMC2101_get_fan_speed()` converts the tach counter to RPM with no check on the divisor:

```c
reading = tach_lsb | (tach_msb << 8);
RPM = 5400000 / reading;
```

On the ESP32-S3, integer division by zero raises a divide-by-zero exception and panics. A single zero tach reading would therefore reboot the miner rather than report a missing fan.

## Scope

This is defensive, not a fix for an observed crash. A stopped or absent fan normally reads `0xFFFF`, which the existing `RPM == 82` sentinel already handles. But nothing guarantees a zero can't be read — a partial or glitched I2C transaction, or the registers being read before the first tach conversion completes — and the failure mode is a panic rather than a bad reading.

## Change

Treat a zero count the same as no fan detected and return 0 RPM.

## Testing

- Builds with ESP-IDF v6.0.2 for `esp32s3`, no new warnings.
- Running on a Bitaxe Supra (board 401, BM1368 @ 500 MHz): fan RPM continues to report correctly across manual fan settings from 53% to 63% (5137 to 6033 rpm), so the added branch doesn't interfere with normal readings.

## Related

The identical pattern exists in `EMC2103_get_fan_speed()`:

```c
reading >>= 3;
RPM = 7864320 / reading;
```

and in `EMC2302_get_fan_speed()`:

```c
uint16_t tach_counter = (tach_data[0] << 5) | (tach_data[1] >> 3);
uint32_t rpm = 3932160UL * multiplier / tach_counter;
```

The EMC2302 path has an early return when `tach_data[0] == 0xFF` but can still reach a zero divisor if the counter bits are all zero. I've left both alone to keep this change to a single driver — happy to extend it to all three if that's preferred.
