### PR TITLE
Clamp the remaining ASIC job interval at zero in create_jobs_task

### DIFF
--- a/main/tasks/create_jobs_task.c
+++ b/main/tasks/create_jobs_task.c
@@ -90,6 +90,14 @@ void create_jobs_task(void *pvParameters)
         void *new_work = queue_dequeue_timeout(&GLOBAL_STATE->stratum_queue, timeout_ms);
         timeout_ms -= (esp_timer_get_time() - start_time) / 1000;
 
+        // A run of non-clean notifies takes the `continue` path below without
+        // resetting timeout_ms, so the remaining budget can go negative. That
+        // turns the next dequeue into a non-blocking poll and lets jobs be
+        // pushed to the ASIC in a burst, so floor it at zero.
+        if (timeout_ms < 0) {
+            timeout_ms = 0;
+        }
+
         if (new_work != NULL) {
             active_protocol = GLOBAL_STATE->stratum_protocol;
 


### PR DESCRIPTION
## Problem

`create_jobs_task()` tracks how much of the ASIC job interval is left after a blocking dequeue:

```c
uint64_t start_time = esp_timer_get_time();
void *new_work = queue_dequeue_timeout(&GLOBAL_STATE->stratum_queue, timeout_ms);
timeout_ms -= (esp_timer_get_time() - start_time) / 1000;
```

When a `mining.notify` arrives with `clean_jobs` false, the loop takes the `continue` path without generating work and without resetting `timeout_ms`. The remaining budget keeps shrinking across iterations and can go negative.

`queue_dequeue_timeout()` then builds an absolute `timespec` in the past, `pthread_cond_timedwait()` returns `ETIMEDOUT` immediately, and the interval stops being rate limited.

## Impact

Not a hang — the loop recovers on the next pass because generating work resets the timeout. The visible effect is that a run of non-clean notifies can push several jobs to the ASIC back to back instead of one per interval, adding avoidable UART traffic and job churn.

## Change

Floor the remaining budget at zero so a dequeue never degenerates into a busy poll.

## Testing

- Builds with ESP-IDF v6.0.2 for `esp32s3`, no new warnings.
- Running on a Bitaxe Supra (board 401, BM1368 @ 500 MHz) against solo.ckpool.org: normal job flow, `ASIC Job Interval: 500 ms` respected, shares accepted.

The negative-budget path depends on pool notify behaviour, so I have not contrived a reproduction that forces a long run of non-clean notifies; the reasoning above is from the code rather than from an observed incident.
