### PR TITLE
Validate mining.notify fields before use

### DIFF
--- a/components/stratum/mining.c
+++ b/components/stratum/mining.c
@@ -21,7 +21,16 @@ void calculate_coinbase_tx_hash(const char *coinbase_1, const char *coinbase_2, 
 
     size_t coinbase_tx_bin_len = (len1 + len2 + len3 + len4) / 2;
 
-    uint8_t coinbase_tx_bin[coinbase_tx_bin_len];
+    // This length is derived from pool-supplied strings, so it must not size a
+    // stack allocation. A variable length array here put an unbounded amount of
+    // attacker-influenced data on the caller's 8 KB task stack, and with the
+    // canary-based overflow check the corruption is only noticed at the next
+    // context switch. Use the heap, as calculate_coinbase_tx_hash_bin() does.
+    uint8_t *coinbase_tx_bin = malloc(coinbase_tx_bin_len);
+    if (coinbase_tx_bin == NULL) {
+        memset(dest, 0, 32);
+        return;
+    }
 
     size_t bin_offset = 0;
     bin_offset += hex2bin(coinbase_1, coinbase_tx_bin + bin_offset, coinbase_tx_bin_len - bin_offset);
@@ -30,6 +39,8 @@ void calculate_coinbase_tx_hash(const char *coinbase_1, const char *coinbase_2, 
     bin_offset += hex2bin(coinbase_2, coinbase_tx_bin + bin_offset, coinbase_tx_bin_len - bin_offset);
 
     double_sha256_bin(coinbase_tx_bin, coinbase_tx_bin_len, dest);
+
+    free(coinbase_tx_bin);
 }
 
 void calculate_coinbase_tx_hash_bin(const uint8_t *prefix, size_t prefix_len,

--- a/components/stratum/stratum_api.c
+++ b/components/stratum/stratum_api.c
@@ -24,6 +24,10 @@
 #define TRANSPORT_TIMEOUT_MS 5000
 #define BUFFER_SIZE 1024
 #define MAX_EXTRANONCE_2_LEN 32
+// Upper bound on each coinbase half, in hex characters. Real coinbase transactions
+// run a few hundred characters; this is generous headroom while keeping the derived
+// binary buffer bounded.
+#define MAX_COINBASE_HEX_LEN 8192
 static const char * TAG = "stratum_api";
 
 static char * json_rpc_buffer = NULL;
@@ -265,6 +269,21 @@ static stratum_method parse_method(const cJSON *method_json)
     return METHOD_UNKNOWN;
 }
 
+// mining.notify fields are pool-controlled. cJSON leaves valuestring NULL for any
+// item that is not a string, and strdup()/hex2bin()/strtoul() all dereference their
+// argument immediately, so every field has to be type-checked before use.
+static const char *require_string_param(cJSON *params, int index, const char *name)
+{
+    cJSON *item = cJSON_GetArrayItem(params, index);
+
+    if (!cJSON_IsString(item) || item->valuestring == NULL) {
+        ESP_LOGE(TAG, "mining.notify params[%d] (%s) is not a string", index, name);
+        return NULL;
+    }
+
+    return item->valuestring;
+}
+
 static bool parse_mining_notify(cJSON *json, StratumApiV1Message *message)
 {
     cJSON *params = cJSON_GetObjectItem(json, "params");
@@ -278,56 +297,79 @@ static bool parse_mining_notify(cJSON *json, StratumApiV1Message *message)
         return false;
     }
 
+    // Every field below is attacker-controlled. cJSON leaves valuestring NULL for
+    // any item that is not a string, and both strdup() and hex2bin() dereference
+    // their argument immediately, so an unchecked field is a NULL dereference.
+    const char *job_id_str      = require_string_param(params, 0, "job_id");
+    const char *prev_hash_str   = require_string_param(params, 1, "prev_block_hash");
+    const char *coinbase_1_str  = require_string_param(params, 2, "coinbase_1");
+    const char *coinbase_2_str  = require_string_param(params, 3, "coinbase_2");
+    const char *version_str     = require_string_param(params, 5, "version");
+    const char *target_str      = require_string_param(params, 6, "nbits");
+    const char *ntime_str       = require_string_param(params, 7, "ntime");
+
+    if (!job_id_str || !prev_hash_str || !coinbase_1_str || !coinbase_2_str ||
+        !version_str || !target_str || !ntime_str) {
+        return false;
+    }
+
+    // The coinbase halves size a buffer downstream. Real coinbase transactions are
+    // a few hundred hex characters; anything approaching this bound is a protocol
+    // violation rather than a large block template.
+    if (strlen(coinbase_1_str) > MAX_COINBASE_HEX_LEN || strlen(coinbase_2_str) > MAX_COINBASE_HEX_LEN) {
+        ESP_LOGE(TAG, "Coinbase too long in mining.notify (limit %d hex chars)", MAX_COINBASE_HEX_LEN);
+        return false;
+    }
+
+    cJSON *merkle_branch = cJSON_GetArrayItem(params, 4);
+    if (!merkle_branch || !cJSON_IsArray(merkle_branch)) {
+        ESP_LOGE(TAG, "Invalid merkle_branch in mining.notify");
+        return false;
+    }
+    size_t n_merkle_branches = cJSON_GetArraySize(merkle_branch);
+    if (n_merkle_branches > MAX_MERKLE_BRANCHES) {
+        ESP_LOGE(TAG, "Too many Merkle branches: %zu", n_merkle_branches);
+        return false;
+    }
+    for (size_t i = 0; i < n_merkle_branches; i++) {
+        cJSON *branch = cJSON_GetArrayItem(merkle_branch, i);
+        if (!cJSON_IsString(branch) || branch->valuestring == NULL) {
+            ESP_LOGE(TAG, "Merkle branch %zu is not a string", i);
+            return false;
+        }
+    }
+
+    // Everything is validated; allocate only now so there is a single failure path.
     mining_notify *new_work = calloc(1, sizeof(mining_notify));
     if (!new_work) {
         ESP_LOGE(TAG, "Memory allocation failed for mining_notify");
         return false;
     }
 
-    cJSON *job_id_item = cJSON_GetArrayItem(params, 0);
-    if (!job_id_item || !cJSON_IsString(job_id_item)) {
-        ESP_LOGE(TAG, "Invalid job_id in mining.notify");
-        free(new_work);
+    new_work->job_id = strdup(job_id_str);
+    new_work->prev_block_hash = strdup(prev_hash_str);
+    new_work->coinbase_1 = strdup(coinbase_1_str);
+    new_work->coinbase_2 = strdup(coinbase_2_str);
+    new_work->n_merkle_branches = n_merkle_branches;
+    new_work->merkle_branches = n_merkle_branches ? malloc(HASH_SIZE * n_merkle_branches) : NULL;
+
+    if (!new_work->job_id || !new_work->prev_block_hash || !new_work->coinbase_1 ||
+        !new_work->coinbase_2 || (n_merkle_branches && !new_work->merkle_branches)) {
+        ESP_LOGE(TAG, "Memory allocation failed for mining.notify fields");
+        STRATUM_V1_free_mining_notify(new_work);
         return false;
     }
 
-    new_work->job_id = strdup(job_id_item->valuestring);
-    new_work->prev_block_hash = strdup(cJSON_GetArrayItem(params, 1)->valuestring);
-    new_work->coinbase_1 = strdup(cJSON_GetArrayItem(params, 2)->valuestring);
-    new_work->coinbase_2 = strdup(cJSON_GetArrayItem(params, 3)->valuestring);
-
-    cJSON *merkle_branch = cJSON_GetArrayItem(params, 4);
-    if (!merkle_branch || !cJSON_IsArray(merkle_branch)) {
-        ESP_LOGE(TAG, "Invalid merkle_branch in mining.notify");
-        free(new_work->job_id);
-        free(new_work->prev_block_hash);
-        free(new_work->coinbase_1);
-        free(new_work->coinbase_2);
-        free(new_work);
-        return false;
-    }
-    new_work->n_merkle_branches = cJSON_GetArraySize(merkle_branch);
-    if (new_work->n_merkle_branches > MAX_MERKLE_BRANCHES) {
-        ESP_LOGE(TAG, "Too many Merkle branches: %zu", new_work->n_merkle_branches);
-        free(new_work->job_id);
-        free(new_work->prev_block_hash);
-        free(new_work->coinbase_1);
-        free(new_work->coinbase_2);
-        free(new_work);
-        return false;
-    }
-    new_work->merkle_branches = malloc(HASH_SIZE * new_work->n_merkle_branches);
-    for (size_t i = 0; i < new_work->n_merkle_branches; i++) {
+    for (size_t i = 0; i < n_merkle_branches; i++) {
         hex2bin(cJSON_GetArrayItem(merkle_branch, i)->valuestring, new_work->merkle_branches + HASH_SIZE * i, HASH_SIZE);
     }
 
-    new_work->version = strtoul(cJSON_GetArrayItem(params, 5)->valuestring, NULL, 16);
-    new_work->target = strtoul(cJSON_GetArrayItem(params, 6)->valuestring, NULL, 16);
-    new_work->ntime = strtoul(cJSON_GetArrayItem(params, 7)->valuestring, NULL, 16);
+    new_work->version = strtoul(version_str, NULL, 16);
+    new_work->target = strtoul(target_str, NULL, 16);
+    new_work->ntime = strtoul(ntime_str, NULL, 16);
 
     // params can be variable length
-    int paramsLength = cJSON_GetArraySize(params);
-    int value = cJSON_IsTrue(cJSON_GetArrayItem(params, paramsLength - 1));
+    int value = cJSON_IsTrue(cJSON_GetArrayItem(params, params_count - 1));
     new_work->clean_jobs = value;
 
     message->mining_notification = new_work;

--- a/components/stratum/test/test_stratum_json.c
+++ b/components/stratum/test/test_stratum_json.c
@@ -1,5 +1,71 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "unity.h"
 #include "stratum_api.h"
+
+// A mining.notify with 8 params, so it passes the params_count check, but with one
+// field replaced by a non-string. cJSON leaves valuestring NULL for those, and the
+// parser used to hand that straight to strdup()/strtoul()/hex2bin(), which
+// dereference immediately. Each of these crashed the device before validation was
+// added; they must now be rejected cleanly.
+TEST_CASE("Parse stratum mining.notify rejects non-string params", "[stratum]")
+{
+    const char *cases[] = {
+        // params[1] prev_block_hash is a number
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":"
+        "[\"job\",1,\"00\",\"00\",[],\"20000004\",\"1705c739\",\"64495522\",false]}",
+        // params[2] coinbase_1 is a number
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":"
+        "[\"job\",\"00\",2,\"00\",[],\"20000004\",\"1705c739\",\"64495522\",false]}",
+        // params[3] coinbase_2 is null
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":"
+        "[\"job\",\"00\",\"00\",null,[],\"20000004\",\"1705c739\",\"64495522\",false]}",
+        // params[5] version is a bool
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":"
+        "[\"job\",\"00\",\"00\",\"00\",[],true,\"1705c739\",\"64495522\",false]}",
+        // params[6] nbits is an object
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":"
+        "[\"job\",\"00\",\"00\",\"00\",[],\"20000004\",{},\"64495522\",false]}",
+        // params[7] ntime is an array
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":"
+        "[\"job\",\"00\",\"00\",\"00\",[],\"20000004\",\"1705c739\",[],false]}",
+        // a merkle branch entry is a number
+        "{\"id\":null,\"method\":\"mining.notify\",\"params\":"
+        "[\"job\",\"00\",\"00\",\"00\",[7],\"20000004\",\"1705c739\",\"64495522\",false]}",
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        StratumApiV1Message msg = {};
+        TEST_ASSERT_FALSE_MESSAGE(STRATUM_V1_parse(&msg, cases[i]), cases[i]);
+        TEST_ASSERT_NULL(msg.mining_notification);
+    }
+}
+
+// The coinbase halves size a buffer downstream, so an absurd length has to be
+// rejected at the parser rather than propagated.
+TEST_CASE("Parse stratum mining.notify rejects oversized coinbase", "[stratum]")
+{
+    const size_t oversized = 9000; // above MAX_COINBASE_HEX_LEN (8192)
+    const char *prefix = "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"job\",\"00\",\"";
+    const char *suffix = "\",\"00\",[],\"20000004\",\"1705c739\",\"64495522\",false]}";
+
+    char *json = malloc(strlen(prefix) + oversized + strlen(suffix) + 1);
+    TEST_ASSERT_NOT_NULL(json);
+
+    char *p = json;
+    p += sprintf(p, "%s", prefix);
+    memset(p, 'a', oversized);
+    p += oversized;
+    sprintf(p, "%s", suffix);
+
+    StratumApiV1Message msg = {};
+    TEST_ASSERT_FALSE(STRATUM_V1_parse(&msg, json));
+    TEST_ASSERT_NULL(msg.mining_notification);
+
+    free(json);
+}
 
 TEST_CASE("Parse stratum method", "[stratum]")
 {


### PR DESCRIPTION
I run a Supra 401 and went digging through the stratum parser this weekend. Turns out a single malformed `mining.notify` reboots the miner. No big payload needed, no timing trick.

`parse_mining_notify()` checks `params[0]` properly but then just uses the rest :

```c
cJSON *job_id_item = cJSON_GetArrayItem(params, 0);
if (!job_id_item || !cJSON_IsString(job_id_item)) { ... return false; }   // checked

new_work->prev_block_hash = strdup(cJSON_GetArrayItem(params, 1)->valuestring);
new_work->coinbase_1      = strdup(cJSON_GetArrayItem(params, 2)->valuestring);
new_work->coinbase_2      = strdup(cJSON_GetArrayItem(params, 3)->valuestring);
...
hex2bin(cJSON_GetArrayItem(merkle_branch, i)->valuestring, ...);
new_work->version = strtoul(cJSON_GetArrayItem(params, 5)->valuestring, NULL, 16);
new_work->target  = strtoul(cJSON_GetArrayItem(params, 6)->valuestring, NULL, 16);
new_work->ntime   = strtoul(cJSON_GetArrayItem(params, 7)->valuestring, NULL, 16);
```

cJSON sets `valuestring` to NULL for anything that is not a string, and `strdup`, `strtoul` and `hex2bin` all dereference straight away. The `params_count < 8` check only tells you the items are there, not that they are strings. So a notify with 8 params where one of those is a number or a bool or null goes and reads address 0.

I compiled a small thing against `managed_components/espressif__cjson` to be sure I was not imagining it :

```
params 1-3 = numbers      params_count=8  (passes the <8 guard)
   param[1]: item=non-NULL IsString=0  valuestring=*** NULL ***
   param[2]: item=non-NULL IsString=0  valuestring=*** NULL ***
   param[3]: item=non-NULL IsString=0  valuestring=*** NULL ***
```

Same thing with `null`, `true`, `{}`.

The test cases I added crash current master. Built test-ci and ran it in QEMU :

```
Running Parse stratum mining.notify rejects non-string params...
Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.
Backtrace: 0x400556d2:0x3fc96fe0 0x4201166f:0x3fc96ff0 0x4200cce2:0x3fc97020 ...
Rebooting...
```

LoadProhibited is the NULL read. If you want to see it yourself :

```bash
cd test-ci && idf.py build
cd build && esptool --chip esp32s3 merge-bin --pad-to-size 16MB -o flash_image.bin @flash_args
qemu-system-xtensa -machine esp32s3 -monitor none -nographic -no-reboot \
  -watchdog-action shutdown -drive file=flash_image.bin,if=mtd,format=raw -m 4 -serial stdio
```

While I was in there I noticed `calculate_coinbase_tx_hash()` builds a VLA out of the same unchecked strings :

```c
size_t coinbase_tx_bin_len = (len1 + len2 + len3 + len4) / 2;
uint8_t coinbase_tx_bin[coinbase_tx_bin_len];
```

Nothing bounds the coinbase anywhere. `realloc_json_buffer()` keeps growing until malloc fails, and with `CONFIG_SPIRAM_USE_MALLOC=y` and `ALWAYSINTERNAL=16384` the big allocations go to PSRAM, so those strings can end up much bigger than the 8 KB stack of `create_jobs_task`. The canary is only checked at a context switch and `WATCHPOINT_END_OF_STACK` is off, so you would corrupt DRAM before anything complains. This one needs a hostile or really broken pool, so it is less urgent than the NULL read, but it sits in the same function. `calculate_coinbase_tx_hash_bin()` a few lines below already does it the right way with malloc and a NULL check, so I just made the V1 path match.

What I changed :

- a small `require_string_param()` helper, used for all seven string fields, same as `params[0]` was already doing
- type check on the merkle branch entries before `hex2bin`
- cap each coinbase half at `MAX_COINBASE_HEX_LEN` (8192 hex chars). solo.ckpool.org sends me 116 and 290, so 406 combined, which leaves plenty of room
- coinbase buffer to the heap with a NULL check
- validation now happens before any allocation, which let me drop the four repeated `free()` blocks and their one shared exit path

No change to rounding, byte order or hashing. Only validation.

Tests in `test_stratum_json.c` cover a non-string at each position (1, 2, 3, 5, 6, 7), a non-string merkle entry, and an oversized coinbase. All of them panic before the patch and pass after. 74 tests, 0 failures, and the 27 existing parser tests plus the `test_mining` ones still pass so moving to the heap did not change any results.

Builds clean on ESP-IDF v6.0.2 for esp32s3, no new warnings, and it has been running on my 401 at 500 MHz against solo.ckpool with no rejects.

Two things I did not do : I never set up a hostile pool to actually trigger the VLA on hardware, and I only own the one board so I have not tried this on a Hex or a Gamma. Also `MAX_COINBASE_HEX_LEN` is a guess on my side, if someone knows a pool with a bigger coinbase that number should change.
