### PR TITLE
Keep saved fan mode in sync after reboot

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.spec.ts
@@ -1,10 +1,12 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { EditComponent } from './edit.component';
 import { provideHttpClient } from '@angular/common/http';
 import { provideToastr } from 'ngx-toastr';
 import { provideRouter } from '@angular/router';
 import { FormControl, FormGroup } from '@angular/forms';
+import { of } from 'rxjs';
+import { SystemApiService } from 'src/app/services/system.service';
 
 describe('EditComponent', () => {
   let component: EditComponent;
@@ -17,7 +19,6 @@ describe('EditComponent', () => {
     });
     fixture = TestBed.createComponent(EditComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
@@ -35,4 +36,37 @@ describe('EditComponent', () => {
 
     expect(component.isDisplayConfigurable).toBeFalse();
   });
+
+  it('should load persisted fan mode directly from the system API', fakeAsync(() => {
+    const systemService = TestBed.inject(SystemApiService);
+    const getInfo = spyOn(systemService, 'getInfo').and.returnValue(of({
+      display: 'NONE',
+      rotation: 0,
+      invertscreen: 0,
+      displayTimeout: -1,
+      coreVoltage: 1150,
+      frequency: 500,
+      autofanspeed: 0,
+      minFanSpeed: 25,
+      manualFanSpeed: 65,
+      temptarget: 60,
+      overheat_mode: 0,
+      statsFrequency: 30,
+      statsLimit: 720,
+      overclockEnabled: 0
+    } as any));
+    spyOn(systemService, 'getAsicSettings').and.returnValue(of({
+      defaultFrequency: 500,
+      frequencyOptions: [500],
+      defaultVoltage: 1150,
+      voltageOptions: [1150]
+    } as any));
+
+    component.ngOnInit();
+    tick();
+
+    expect(getInfo).toHaveBeenCalledWith('');
+    expect(component.form.controls['autofanspeed'].value).toBeFalse();
+    expect(component.form.controls['manualFanSpeed'].value).toBe(65);
+  }));
 });

--- a/main/http_server/axe-os/src/app/components/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.ts
@@ -3,9 +3,8 @@ import { getHttpErrorMessage } from 'src/app/utils/error-handler';
 import { Component, Input, OnInit, OnDestroy, OnChanges, SimpleChanges } from '@angular/core';
 import { FormBuilder, FormGroup, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
-import { forkJoin, startWith, Subject, takeUntil, pairwise, BehaviorSubject, Observable, first } from 'rxjs';
+import { forkJoin, startWith, Subject, takeUntil, pairwise, BehaviorSubject, Observable } from 'rxjs';
 import { LoadingService } from 'src/app/services/loading.service';
-import { LiveDataService } from 'src/app/services/live-data.service';
 import { SystemApiService } from 'src/app/services/system.service';
 import { ActivatedRoute } from '@angular/router';
 import { DateAgoPipe } from 'src/app/pipes/date-ago.pipe';
@@ -64,7 +63,6 @@ export class EditComponent implements OnInit, OnDestroy, OnChanges {
   constructor(
     private fb: FormBuilder,
     private systemService: SystemApiService,
-    private liveDataService: LiveDataService,
     private toastr: ToastrService,
     private loadingService: LoadingService,
     private route: ActivatedRoute,
@@ -141,9 +139,9 @@ export class EditComponent implements OnInit, OnDestroy, OnChanges {
   private loadDeviceSettings(): void {
     const deviceUri = this.uri || '';
 
-    const info$ = deviceUri
-      ? this.systemService.getInfo(deviceUri)
-      : this.liveDataService.info$.pipe(first());
+    // Settings must reflect persisted values. The live-data stream is replayed and
+    // can briefly contain pre-save values while the miner reconnects after reboot.
+    const info$ = this.systemService.getInfo(deviceUri);
 
     // Fetch both system info and ASIC settings in parallel
     forkJoin({


### PR DESCRIPTION
## Summary

- Load the Settings form from the persisted system configuration API.
- Keep the Automatic Fan Control checkbox synchronized with the saved fan mode after a miner reboot.
- Preserve the saved manual fan-speed value when automatic control is disabled.

## Validation

- Confirmed on a live miner that manual mode and a 65% fan setting persist across reboot.
- Added a regression test for loading the persisted manual fan state.
- All 57 AxeOS tests pass.
- AxeOS production build passes.
- Full ESP32-S3 firmware build passes with 35% of the smallest application partition free.
