### PR TITLE
Fix memory leaks in inactive tabs

### DIFF
--- a/main/http_server/axe-os/src/app/components/chart/app-chart.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/chart/app-chart.component.spec.ts
@@ -1,0 +1,100 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SimpleChange } from '@angular/core';
+import { AppChartComponent } from './app-chart.component';
+
+describe('AppChartComponent', () => {
+  let component: AppChartComponent;
+  let fixture: ComponentFixture<AppChartComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppChartComponent]
+    });
+    fixture = TestBed.createComponent(AppChartComponent);
+    component = fixture.componentInstance;
+    component.data = {
+      labels: ['1', '2'],
+      datasets: [{ data: [10, 20] }]
+    };
+    component.options = { responsive: true, animation: false };
+    fixture.detectChanges();
+    component.refresh();
+  });
+
+  afterEach(() => {
+    component.ngOnDestroy();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize chart when visible', () => {
+    expect(component.chart).toBeTruthy();
+  });
+
+  it('should not update chart when hidden and should mark pendingUpdate', () => {
+    expect(component.chart).toBeTruthy();
+    const updateSpy = spyOn(component.chart!, 'update');
+
+    spyOnProperty(document, 'visibilityState', 'get').and.returnValue('hidden');
+
+    component.data = {
+      labels: ['1', '2', '3'],
+      datasets: [{ data: [10, 20, 30] }]
+    };
+    component.ngOnChanges({
+      data: new SimpleChange(null, component.data, false)
+    });
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(component['pendingUpdate']).toBeTrue();
+  });
+
+  it('should update chart with "none" mode when visible', () => {
+    expect(component.chart).toBeTruthy();
+    const updateSpy = spyOn(component.chart!, 'update');
+
+    spyOnProperty(document, 'visibilityState', 'get').and.returnValue('visible');
+
+    component.data = {
+      labels: ['1', '2', '3'],
+      datasets: [{ data: [10, 20, 30] }]
+    };
+    component.ngOnChanges({
+      data: new SimpleChange(null, component.data, false)
+    });
+
+    expect(updateSpy).toHaveBeenCalledWith('none');
+    expect(component['pendingUpdate']).toBeFalse();
+  });
+
+  it('should execute pending update when visibility changes to visible', () => {
+    expect(component.chart).toBeTruthy();
+    const updateSpy = spyOn(component.chart!, 'update');
+
+    // Simulate tab hidden
+    let currentVisibility: DocumentVisibilityState = 'hidden';
+    spyOnProperty(document, 'visibilityState', 'get').and.callFake(() => currentVisibility);
+
+    component.ngOnChanges({
+      data: new SimpleChange(null, component.data, false)
+    });
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(component['pendingUpdate']).toBeTrue();
+
+    // Tab becomes visible again
+    currentVisibility = 'visible';
+    component.onVisibilityChange();
+
+    expect(updateSpy).toHaveBeenCalledWith('none');
+    expect(component['pendingUpdate']).toBeFalse();
+  });
+
+  it('should destroy chart on ngOnDestroy', () => {
+    const destroySpy = spyOn(component.chart!, 'destroy').and.callThrough();
+    component.ngOnDestroy();
+    expect(destroySpy).toHaveBeenCalled();
+    expect(component.chart).toBeNull();
+  });
+});

--- a/main/http_server/axe-os/src/app/components/chart/app-chart.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/chart/app-chart.component.spec.ts
@@ -72,6 +72,8 @@ describe('AppChartComponent', () => {
   it('should execute pending update when visibility changes to visible', () => {
     expect(component.chart).toBeTruthy();
     const updateSpy = spyOn(component.chart!, 'update');
+    const resizeSpy = spyOn(component.chart!, 'resize');
+    spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => { cb(0); return 1; });
 
     // Simulate tab hidden
     let currentVisibility: DocumentVisibilityState = 'hidden';
@@ -87,8 +89,21 @@ describe('AppChartComponent', () => {
     currentVisibility = 'visible';
     component.onVisibilityChange();
 
+    expect(resizeSpy).toHaveBeenCalled();
     expect(updateSpy).toHaveBeenCalledWith('none');
     expect(component['pendingUpdate']).toBeFalse();
+  });
+
+  it('should schedule resize when visible without pending update', () => {
+    expect(component.chart).toBeTruthy();
+    const resizeSpy = spyOn(component.chart!, 'resize');
+    spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => { cb(0); return 1; });
+
+    spyOnProperty(document, 'visibilityState', 'get').and.returnValue('visible');
+    component['pendingUpdate'] = false;
+    component.onVisibilityChange();
+
+    expect(resizeSpy).toHaveBeenCalled();
   });
 
   it('should destroy chart on ngOnDestroy', () => {

--- a/main/http_server/axe-os/src/app/components/chart/app-chart.component.ts
+++ b/main/http_server/axe-os/src/app/components/chart/app-chart.component.ts
@@ -25,14 +25,19 @@ export class AppChartComponent implements OnChanges, OnDestroy {
 
   public chart: Chart | null = null;
   private pendingUpdate = false;
+  private rafId: number | null = null;
 
   constructor(private ngZone: NgZone) {}
 
   @HostListener('document:visibilitychange')
   onVisibilityChange() {
-    if (document.visibilityState === 'visible' && this.pendingUpdate) {
-      this.pendingUpdate = false;
-      this.updateChart();
+    if (document.visibilityState === 'visible') {
+      if (this.pendingUpdate) {
+        this.pendingUpdate = false;
+        this.scheduleRender();
+      } else if (this.chart) {
+        this.scheduleRender(true);
+      }
     }
   }
 
@@ -43,7 +48,15 @@ export class AppChartComponent implements OnChanges, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.cancelScheduledRender();
     this.destroyChart();
+  }
+
+  private cancelScheduledRender() {
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
   }
 
   private destroyChart() {
@@ -71,10 +84,32 @@ export class AppChartComponent implements OnChanges, OnDestroy {
         if (this.options) {
           this.chart.options = this.options;
         }
+        this.chart.resize();
         this.chart.update('none');
       } else {
         this.initChart();
       }
+    });
+  }
+
+  private scheduleRender(resizeOnly = false) {
+    this.ngZone.runOutsideAngular(() => {
+      this.cancelScheduledRender();
+      this.rafId = requestAnimationFrame(() => {
+        this.rafId = null;
+        if (this.chart) {
+          if (!resizeOnly) {
+            this.chart.data = this.data;
+            if (this.options) {
+              this.chart.options = this.options;
+            }
+          }
+          this.chart.resize();
+          this.chart.update('none');
+        } else if (!resizeOnly) {
+          this.initChart();
+        }
+      });
     });
   }
 

--- a/main/http_server/axe-os/src/app/components/chart/app-chart.component.ts
+++ b/main/http_server/axe-os/src/app/components/chart/app-chart.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, NgZone, OnChanges, OnDestroy, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, ElementRef, HostListener, Input, NgZone, OnChanges, OnDestroy, SimpleChanges, ViewChild } from '@angular/core';
 import { Chart, registerables } from 'chart.js';
 
 Chart.register(...registerables);
@@ -24,8 +24,17 @@ export class AppChartComponent implements OnChanges, OnDestroy {
   @ViewChild('canvas', { static: true }) canvas!: ElementRef<HTMLCanvasElement>;
 
   public chart: Chart | null = null;
+  private pendingUpdate = false;
 
   constructor(private ngZone: NgZone) {}
+
+  @HostListener('document:visibilitychange')
+  onVisibilityChange() {
+    if (document.visibilityState === 'visible' && this.pendingUpdate) {
+      this.pendingUpdate = false;
+      this.updateChart();
+    }
+  }
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['data'] || changes['options'] || changes['type']) {
@@ -49,13 +58,20 @@ export class AppChartComponent implements OnChanges, OnDestroy {
   private updateChart() {
     if (!this.canvas) return;
 
+    if (document.visibilityState === 'hidden') {
+      this.pendingUpdate = true;
+      return;
+    }
+
+    this.pendingUpdate = false;
+
     this.ngZone.runOutsideAngular(() => {
       if (this.chart) {
         this.chart.data = this.data;
         if (this.options) {
           this.chart.options = this.options;
         }
-        this.chart.update();
+        this.chart.update('none');
       } else {
         this.initChart();
       }

--- a/main/http_server/axe-os/src/app/components/home/home.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.spec.ts
@@ -240,5 +240,51 @@ describe('HomeComponent', () => {
       expect(component.systemInfoError$.value.startTime).toBeNull();
       expect(component['lastMessageTime']).toBeGreaterThan(initialTime);
     });
+
+    it('should not update chartData reference when hidden in limitDataPoints', () => {
+      spyOnProperty(document, 'visibilityState', 'get').and.returnValue('hidden');
+      component['statsLimit'] = 2;
+      component.dataLabel = [1000, 2000, 3000];
+      component.hashrateData = [100, 100, 100];
+      component.powerData = [10, 10, 10];
+      component.chartDatasets = {};
+      const originalChartData = { labels: [], datasets: [] };
+      component.chartData = originalChartData;
+
+      component.limitDataPoints(30);
+
+      expect(component.chartData).toBe(originalChartData);
+      expect(component.dataLabel.length).toBe(2);
+    });
+
+    it('should update chartData reference when visible in limitDataPoints', () => {
+      spyOnProperty(document, 'visibilityState', 'get').and.returnValue('visible');
+      component['statsLimit'] = 2;
+      component.dataLabel = [1000, 2000, 3000];
+      component.hashrateData = [100, 100, 100];
+      component.powerData = [10, 10, 10];
+      component.chartDatasets = {};
+      const originalChartData = { labels: [], datasets: [] };
+      component.chartData = originalChartData;
+
+      component.limitDataPoints(30);
+
+      expect(component.chartData).not.toBe(originalChartData);
+      expect(component.dataLabel.length).toBe(2);
+    });
+
+    it('should clear flash timeouts on destroy', () => {
+      component['shareAcceptedTimeout'] = setTimeout(() => {}, 10000) as any;
+      component['shareRejectedTimeout'] = setTimeout(() => {}, 10000) as any;
+      component['workReceivedTimeout'] = setTimeout(() => {}, 10000) as any;
+
+      spyOn(window, 'clearTimeout').and.callThrough();
+
+      component.ngOnDestroy();
+
+      expect(clearTimeout).toHaveBeenCalledWith(component['shareAcceptedTimeout']);
+      expect(clearTimeout).toHaveBeenCalledWith(component['shareRejectedTimeout']);
+      expect(clearTimeout).toHaveBeenCalledWith(component['workReceivedTimeout']);
+    });
   });
 });

--- a/main/http_server/axe-os/src/app/components/home/home.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.spec.ts
@@ -241,6 +241,38 @@ describe('HomeComponent', () => {
       expect(component['lastMessageTime']).toBeGreaterThan(initialTime);
     });
 
+    it('should call loadPreviousData and not prematurely updateChart when awayTime exceeds threshold', () => {
+      spyOnProperty(document, 'visibilityState', 'get').and.returnValue('visible');
+      const loadSpy = spyOn<any>(component, 'loadPreviousData');
+      const updateChartSpy = spyOn<any>(component, 'updateChart');
+
+      component.dataLabel = [Date.now() - 30000];
+      component['lastHiddenTime'] = Date.now() - 30000;
+      component['lastStatsFrequency'] = 10;
+
+      component.onVisibilityChange();
+
+      expect(loadSpy).toHaveBeenCalledWith(false);
+      expect(updateChartSpy).not.toHaveBeenCalled();
+      expect(component['lastHiddenTime']).toBe(0);
+    });
+
+    it('should call updateChart immediately when awayTime is below threshold', () => {
+      spyOnProperty(document, 'visibilityState', 'get').and.returnValue('visible');
+      const loadSpy = spyOn<any>(component, 'loadPreviousData');
+      const updateChartSpy = spyOn<any>(component, 'updateChart');
+
+      component.dataLabel = [Date.now() - 1000];
+      component['lastHiddenTime'] = Date.now() - 2000;
+      component['lastStatsFrequency'] = 10;
+
+      component.onVisibilityChange();
+
+      expect(loadSpy).not.toHaveBeenCalled();
+      expect(updateChartSpy).toHaveBeenCalledWith(undefined, true);
+      expect(component['lastHiddenTime']).toBe(0);
+    });
+
     it('should not update chartData reference when hidden in limitDataPoints', () => {
       spyOnProperty(document, 'visibilityState', 'get').and.returnValue('hidden');
       component['statsLimit'] = 2;

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -318,9 +318,6 @@ export class HomeComponent implements OnInit, OnDestroy {
     }
 
     if (document.visibilityState === 'visible') {
-      // Immediately refresh the chart to display the accumulated data points and avoid a stale visual state
-      this.updateChart(undefined, true);
-
       // Reset lastMessageTime to prevent stale data warning immediately after wake up
       if (this.lastMessageTime > 0) {
         this.lastMessageTime = Date.now();
@@ -337,6 +334,8 @@ export class HomeComponent implements OnInit, OnDestroy {
 
       if (awayTime > threshold || !lastPoint || (Date.now() - lastPoint > threshold)) {
         this.loadPreviousData(false);
+      } else {
+        this.updateChart(undefined, true);
       }
       this.lastHiddenTime = 0;
     }

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -293,7 +293,9 @@ export class HomeComponent implements OnInit, OnDestroy {
 
     this.form = this.fb.group(parsedConfig);
 
-    this.form.valueChanges.subscribe(() => {
+    this.form.valueChanges.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(() => {
       this.storageService.setItem(HOME_CHART_DATA_SOURCES, JSON.stringify(this.form.getRawValue()));
       this.loadPreviousData();
     });
@@ -351,6 +353,9 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     clearTimeout(this.resizeTimer);
+    clearTimeout(this.shareAcceptedTimeout);
+    clearTimeout(this.shareRejectedTimeout);
+    clearTimeout(this.workReceivedTimeout);
     clearInterval(this.staleCheckInterval);
     this.dashboardEditService.isActive$.next(false);
     this.dashboardEditService.editMode$.next(false);
@@ -1397,7 +1402,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       });
     }
 
-    if (this.chartData) {
+    if (this.chartData && document.visibilityState !== 'hidden') {
       this.chartData = { ...this.chartData };
     }
   }

--- a/main/http_server/axe-os/src/app/layout/app.layout.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.layout.component.ts
@@ -49,11 +49,13 @@ export class AppLayoutComponent implements OnDestroy {
             }
         });
 
-        this.router.events.pipe(filter(event => event instanceof NavigationEnd))
-            .subscribe(() => {
-                this.hideMenu();
-                this.hideProfileMenu();
-            });
+        this.router.events.pipe(
+            filter(event => event instanceof NavigationEnd),
+            takeUntil(this.destroy$)
+        ).subscribe(() => {
+            this.hideMenu();
+            this.hideProfileMenu();
+        });
     }
 
     hideMenu() {

--- a/main/http_server/axe-os/src/app/layout/app.menuitem.component.ts
+++ b/main/http_server/axe-os/src/app/layout/app.menuitem.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, Host, HostBinding, Input, OnDestroy, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { Subscription } from 'rxjs';
+import { Subscription, Subject, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { MenuService } from './app.menu.service';
 import { LayoutService } from './service/app.layout.service';
@@ -41,6 +41,8 @@ export class AppMenuitemComponent implements OnInit, OnDestroy {
 
     key: string = "";
 
+    private destroy$ = new Subject<void>();
+
     constructor(public layoutService: LayoutService, private cd: ChangeDetectorRef, public router: Router, private menuService: MenuService) {
         this.menuSourceSubscription = this.menuService.menuSource$.subscribe(value => {
             Promise.resolve(null).then(() => {
@@ -59,12 +61,14 @@ export class AppMenuitemComponent implements OnInit, OnDestroy {
             this.active = false;
         });
 
-        this.router.events.pipe(filter(event => event instanceof NavigationEnd))
-            .subscribe(params => {
-                if (this.item.routerLink) {
-                    this.updateActiveStateFromRoute();
-                }
-            });
+        this.router.events.pipe(
+            filter(event => event instanceof NavigationEnd),
+            takeUntil(this.destroy$)
+        ).subscribe(params => {
+            if (this.item.routerLink) {
+                this.updateActiveStateFromRoute();
+            }
+        });
     }
 
     ngOnInit() {
@@ -113,6 +117,9 @@ export class AppMenuitemComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
+        this.destroy$.next();
+        this.destroy$.complete();
+
         if (this.menuSourceSubscription) {
             this.menuSourceSubscription.unsubscribe();
         }


### PR DESCRIPTION
One of my inactive Axe-OS tabs had 6GB of memory allocated, triggering the oomkiller.

Chartdata was bypassing visibility check
Some listeners were not properly destroyed
Disable animations on chart update