### PR TITLE
Fix dashboard pool dropdown after automatic failover

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.spec.ts
@@ -1,7 +1,7 @@
 import 'chartjs-adapter-moment';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HomeComponent } from './home.component';
-import { provideHttpClient } from '@angular/common/http';
+import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
 import { provideToastr } from 'ngx-toastr';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -11,7 +11,7 @@ import { AppChartComponent } from 'src/app/components/chart/app-chart.component'
 import { TooltipDirective } from 'src/app/directives/tooltip.directive';
 import { DropdownComponent } from 'src/app/components/dropdown/dropdown.component';
 import { ProgressbarComponent } from 'src/app/components/progressbar/progressbar.component';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 
 import { HashSuffixPipe } from 'src/app/pipes/hash-suffix.pipe';
 import { DiffSuffixPipe } from 'src/app/pipes/diff-suffix.pipe';
@@ -38,6 +38,48 @@ import { LayoutService } from 'src/app/layout/service/app.layout.service';
 import { SystemInfo as ISystemInfo, SystemStatistics as ISystemStatistics } from 'src/app/generated/models';
 
 const mockSystemInfo: ISystemInfo = {
+  ASICModel: 'BM1370',
+  apEnabled: 0,
+  autofanspeed: 1,
+  blockSignals: [],
+  coinbaseValueUserSatoshis: 0,
+  display: 'SSD1306',
+  displayTimeout: 0,
+  errorPercentage: 0,
+  expectedHashrate: 500,
+  frequency: 600,
+  hostname: 'bitaxe',
+  invertscreen: 0,
+  isPSRAMAvailable: 1,
+  manualFanSpeed: 80,
+  minFanSpeed: 20,
+  miningPaused: false,
+  overclockEnabled: 0,
+  overheat_mode: 0,
+  partitions: [],
+  pools: [],
+  primaryPoolIndex: 0,
+  resetReason: 'Power on',
+  rotation: 0,
+  runningPartition: 'ota_0',
+  secondaryPoolIndex: 1,
+  sharesRejectedReasons: [],
+  smallCoreCount: 1,
+  statsFrequency: 5,
+  statsLimit: 720,
+  stratumCert: '',
+  stratumDecodeCoinbase: true,
+  stratumExtranonceSubscribe: false,
+  stratumSuggestedDifficulty: 1000,
+  stratumTLS: false,
+  stratumV2AuthorityPubkey: '',
+  fallbackStratumCert: '',
+  fallbackStratumDecodeCoinbase: true,
+  fallbackStratumExtranonceSubscribe: false,
+  fallbackStratumSuggestedDifficulty: 1000,
+  fallbackStratumTLS: false,
+  temptarget: 60,
+  useCustomWWW: 0,
   power_fault: '',
   blockFound: 0,
   sharesAccepted: 100,
@@ -106,9 +148,9 @@ const mockSystemInfo: ISystemInfo = {
   fallbackStratumUser: 'worker.fallback',
   fallbackStratumPort: 3333,
   fallbackStratumProtocol: 'SV1',
-  isUsingFallbackStratum: false,
+  isUsingFallbackStratum: 0,
   useFallbackStratum: 0
-} as any;
+};
 
 const mockSystemStatistics: ISystemStatistics = {
   labels: ['timestamp', 'hashrate', 'power'],
@@ -117,7 +159,7 @@ const mockSystemStatistics: ISystemStatistics = {
     [Date.now(), 500, 15]
   ],
   currentTimestamp: Date.now()
-} as any;
+};
 
 const mockLiveDataService = {
   info$: new BehaviorSubject<ISystemInfo>(mockSystemInfo),
@@ -126,7 +168,7 @@ const mockLiveDataService = {
 
 const mockSystemApiService = {
   getStatistics: () => of(mockSystemStatistics),
-  updateSystem: () => of(null),
+  updateSystem: (_uri: string, _update: Pick<ISystemInfo, 'useFallbackStratum'>) => of(null),
   restart: () => of(null),
   dismissBlockFound: () => of(null)
 };
@@ -149,6 +191,7 @@ describe('HomeComponent', () => {
   let fixture: ComponentFixture<HomeComponent>;
 
   beforeEach(() => {
+    mockLiveDataService.info$ = new BehaviorSubject<ISystemInfo>(structuredClone(mockSystemInfo));
     TestBed.configureTestingModule({
       declarations: [
         HomeComponent,
@@ -203,6 +246,109 @@ describe('HomeComponent', () => {
     const element = fixture.nativeElement;
     // Verify that the dropdowns inside *ngIf are rendered
     expect(element.querySelector('app-dropdown')).toBeTruthy();
+  });
+
+  describe('pool selection', () => {
+    function emitPoolInfo(changes: Partial<ISystemInfo>): void {
+      mockLiveDataService.info$.next({ ...mockLiveDataService.info$.value, ...changes });
+    }
+
+    async function expectSelectedPool(label: 'Primary' | 'Fallback'): Promise<void> {
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const selectedLabel = fixture.nativeElement.querySelector('[gs-id="pool"] app-dropdown span');
+      expect(selectedLabel.textContent.trim()).toBe(label);
+    }
+
+    async function selectPool(label: 'Primary' | 'Fallback'): Promise<void> {
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const dropdown: HTMLElement = fixture.nativeElement.querySelector('[gs-id="pool"] app-dropdown');
+      dropdown.querySelector<HTMLElement>('[tabindex]')!.click();
+      fixture.detectChanges();
+      const option = Array.from(dropdown.querySelectorAll('li'))
+        .find(item => item.textContent?.trim() === label)!;
+      option.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    }
+
+    it('should follow automatic failover and recovery while primary remains preferred', async () => {
+      const updateSpy = spyOn(mockSystemApiService, 'updateSystem').and.callThrough();
+      await expectSelectedPool('Primary');
+
+      emitPoolInfo({ useFallbackStratum: 0, isUsingFallbackStratum: 1 });
+      await expectSelectedPool('Fallback');
+      expect(component.activePoolURL).toBe(mockSystemInfo.fallbackStratumURL);
+      expect(component.activePoolUser).toBe(mockSystemInfo.fallbackStratumUser);
+
+      emitPoolInfo({ useFallbackStratum: 0, isUsingFallbackStratum: 0 });
+      await expectSelectedPool('Primary');
+      expect(component.activePoolURL).toBe(mockSystemInfo.stratumURL);
+      expect(component.activePoolUser).toBe(mockSystemInfo.stratumUser);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should show primary when fallback is preferred but primary is active', async () => {
+      emitPoolInfo({ useFallbackStratum: 1, isUsingFallbackStratum: 0 });
+
+      await expectSelectedPool('Primary');
+      expect(component.activePoolURL).toBe(mockSystemInfo.stratumURL);
+    });
+
+    for (const target of ['Primary', 'Fallback'] as const) {
+      it(`should preserve a pending manual switch to ${target} until the preference is acknowledged`, async () => {
+        const targetFallback = Number(target === 'Fallback');
+        const initialFallback = 1 - targetFallback;
+        emitPoolInfo({ useFallbackStratum: initialFallback, isUsingFallbackStratum: initialFallback });
+        const response = new Subject<null>();
+        const updateSpy = spyOn(mockSystemApiService, 'updateSystem').and.returnValue(response);
+        const restartSpy = spyOn(mockSystemApiService, 'restart').and.callThrough();
+
+        await selectPool(target);
+        expect(updateSpy.calls.mostRecent().args).toEqual(['', { useFallbackStratum: targetFallback }]);
+        emitPoolInfo({ useFallbackStratum: initialFallback, isUsingFallbackStratum: initialFallback });
+        await expectSelectedPool(target);
+
+        response.next(null);
+        response.complete();
+        emitPoolInfo({ useFallbackStratum: targetFallback, isUsingFallbackStratum: targetFallback });
+        await expectSelectedPool(target);
+
+        // Once acknowledged, subsequent status changes must follow the active pool again.
+        emitPoolInfo({ isUsingFallbackStratum: initialFallback });
+        await expectSelectedPool(target === 'Fallback' ? 'Primary' : 'Fallback');
+        expect(updateSpy).toHaveBeenCalledTimes(1);
+        expect(restartSpy).not.toHaveBeenCalled();
+      });
+    }
+
+    it('should show the active pool if the saved manual preference has not become active', async () => {
+      spyOn(mockSystemApiService, 'updateSystem').and.returnValue(of(null));
+      await selectPool('Fallback');
+
+      emitPoolInfo({ useFallbackStratum: 1, isUsingFallbackStratum: 0 });
+
+      await expectSelectedPool('Primary');
+      expect(component.activePoolURL).toBe(mockSystemInfo.stratumURL);
+    });
+
+    it('should release a failed manual selection and follow subsequent pool status', async () => {
+      const response = new Subject<null>();
+      spyOn(mockSystemApiService, 'updateSystem').and.returnValue(response);
+      await selectPool('Fallback');
+      await expectSelectedPool('Fallback');
+
+      response.error(new HttpErrorResponse({ status: 500, statusText: 'Pool update failed' }));
+      emitPoolInfo({ useFallbackStratum: 0, isUsingFallbackStratum: 0 });
+      await expectSelectedPool('Primary');
+
+      emitPoolInfo({ isUsingFallbackStratum: 1 });
+      await expectSelectedPool('Fallback');
+    });
   });
 
   describe('stale data and visibility state', () => {

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -952,21 +952,17 @@ export class HomeComponent implements OnInit, OnDestroy {
         this.networkDifficultyPercentage = this.getNetworkDifficultyPercentage(info);
         this.payoutPercentage = this.getPayoutPercentage(info);
 
-        if (this.targetPoolLabel !== null) {
-          const targetMatches = (this.targetPoolLabel === 'Fallback')
-            ? (info.useFallbackStratum === 1)
-            : (info.useFallbackStratum === 0);
-          if (targetMatches) {
-            this.targetPoolLabel = null;
-          }
+        const preferredPool: PoolLabel = info.useFallbackStratum === 1 ? 'Fallback' : 'Primary';
+        const activePool: PoolLabel = info.isUsingFallbackStratum === 1 ? 'Fallback' : 'Primary';
+
+        // Keep a manual selection until its preference is acknowledged by the device.
+        if (this.targetPoolLabel === preferredPool) {
+          this.targetPoolLabel = null;
         }
 
-        if (this.targetPoolLabel !== null) {
-          this.activePoolLabel = this.targetPoolLabel;
-        } else {
-          this.activePoolLabel = info.useFallbackStratum === 1 ? 'Fallback' : 'Primary';
-        }
-        const isCurrentlyFallback = info.isUsingFallbackStratum === 1;
+        // Automatic failover changes the active pool without changing the preference.
+        this.activePoolLabel = this.targetPoolLabel ?? activePool;
+        const isCurrentlyFallback = activePool === 'Fallback';
         this.activePoolURL = isCurrentlyFallback ? info.fallbackStratumURL : info.stratumURL;
         this.activePoolUser = isCurrentlyFallback ? info.fallbackStratumUser : info.stratumUser;
         this.activePoolPort = isCurrentlyFallback ? info.fallbackStratumPort : info.stratumPort;


### PR DESCRIPTION
Fixes a regression from #1897: the dropdown stayed on Primary after failover. It now follows the active pool.

Adds six tests for failover, recovery, and manual switching. All 74 frontend tests and the production build pass locally.
