### PR TITLE
fix(axe-os): derive low-frequency warnings from device presets

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.spec.ts
@@ -167,6 +167,7 @@ const mockLiveDataService = {
 };
 
 const mockSystemApiService = {
+  getAsicSettings: () => of({ frequencyOptions: [400, 490, 525] }),
   getStatistics: () => of(mockSystemStatistics),
   updateSystem: (_uri: string, _update: Pick<ISystemInfo, 'useFallbackStratum'>) => of(null),
   restart: () => of(null),
@@ -239,6 +240,38 @@ describe('HomeComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('uses the device presets for frequency messages', () => {
+    const info = { ...mockSystemInfo, frequency: 327 };
+    const error = { duration: 0, startTime: null };
+    component.handleSystemMessages(info, error, [327, 350, 410]);
+    expect(component.messages.some(message => message.type === 'FREQUENCY_LOW')).toBeFalse();
+    component.handleSystemMessages({ ...info, frequency: 326 }, error, [327, 350, 410]);
+    expect(component.messages.some(message => message.type === 'FREQUENCY_LOW')).toBeTrue();
+    component.handleSystemMessages(info, error, [327, 350, 410]);
+    expect(component.messages.some(message => message.type === 'FREQUENCY_LOW')).toBeFalse();
+  });
+
+  it('keeps telemetry and messages live while settings load and after settings fail', () => {
+    fixture.destroy();
+    const settings = new Subject<{ frequencyOptions: number[] }>();
+    spyOn(mockSystemApiService, 'getAsicSettings').and.returnValue(settings);
+    mockLiveDataService.info$.next({ ...mockSystemInfo, frequency: 327 });
+    fixture = TestBed.createComponent(HomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.messages.some(message => message.type === 'FREQUENCY_LOW')).toBeFalse();
+    expect(component['latestInfo']?.frequency).toBe(327);
+    settings.next({ frequencyOptions: [327, 350, 410] });
+    mockLiveDataService.info$.next({ ...mockSystemInfo, frequency: 326 });
+    expect(component.messages.some(message => message.type === 'FREQUENCY_LOW')).toBeTrue();
+
+    settings.error(new Error('Settings unavailable'));
+    expect(component.messages.some(message => message.type === 'FREQUENCY_LOW')).toBeFalse();
+    mockLiveDataService.info$.next({ ...mockSystemInfo, frequency: 0 });
+    expect(component.messages.some(message => message.type === 'FREQUENCY_LOW')).toBeTrue();
   });
 
   it('should render the dashboard widgets and dropdowns when info is loaded', () => {

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit, ViewChild, Input, OnDestroy, ElementRef, HostListener, effect, NgZone, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
-import { map, Observable, shareReplay, Subscription, switchMap, tap, first, Subject, takeUntil, BehaviorSubject, filter, combineLatest, finalize } from 'rxjs';
+import { map, Observable, shareReplay, Subscription, switchMap, tap, first, Subject, takeUntil, BehaviorSubject, filter, combineLatest, finalize, catchError, of, startWith } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { getHttpErrorMessage } from 'src/app/utils/error-handler';
+import { isFrequencyLow } from 'src/app/utils/frequency-warning';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
 import { DateAgoPipe } from 'src/app/pipes/date-ago.pipe';
@@ -1072,10 +1073,15 @@ export class HomeComponent implements OnInit, OnDestroy {
       shareReplay({ refCount: true, bufferSize: 1 })
     );
 
-    this.infoSubscription = combineLatest([this.info$, this.systemInfoError$])
+    const asicSettings$ = this.systemService.getAsicSettings().pipe(
+      catchError(() => of(undefined)),
+      startWith(undefined)
+    );
+
+    this.infoSubscription = combineLatest([this.info$, this.systemInfoError$, asicSettings$])
       .pipe(takeUntil(this.destroy$))
-      .subscribe(([info, systemInfoError]) => {
-        this.handleSystemMessages(info, systemInfoError);
+      .subscribe(([info, systemInfoError, asicSettings]) => {
+        this.handleSystemMessages(info, systemInfoError, asicSettings?.frequencyOptions);
         this.setTitle(info, systemInfoError);
         this.cd.markForCheck();
       });
@@ -1205,7 +1211,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     return -1;
   }
 
-  public handleSystemMessages(info: ISystemInfo, systemInfoError: ISystemInfoError) {
+  public handleSystemMessages(info: ISystemInfo, systemInfoError: ISystemInfoError, frequencyOptions?: number[]) {
     const updateMessage = (
       condition: boolean,
       type: MessageType,
@@ -1235,7 +1241,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     updateMessage(!!info.overheat_mode, 'DEVICE_OVERHEAT', 'error', 'Device has overheated - See settings');
     updateMessage(!!info.power_fault, 'POWER_FAULT', 'error', `${info.power_fault} Check your Power Supply.`);
     updateMessage(!!info.hardware_fault, 'HARDWARE_FAULT', 'error', `${info.hardware_fault}`);
-    updateMessage(!info.frequency || info.frequency < 400, 'FREQUENCY_LOW', 'warn', 'Device frequency is set low - See settings');
+    updateMessage(isFrequencyLow(info.frequency, frequencyOptions), 'FREQUENCY_LOW', 'warn', 'Device frequency is set low - See settings');
     updateMessage(info.isUsingFallbackStratum === 1 && info.useFallbackStratum === 0, 'FALLBACK_STRATUM', 'warn', 'Primary pool unreachable - operating on fallback pool.');
     if (info.coinbaseOutputs && info.coinbaseOutputs.length > 0) {
       let percentage = this.getPayoutPercentage(info);

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.spec.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.spec.ts
@@ -64,6 +64,20 @@ describe('SwarmComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('uses each peer\'s own presets, including different BM1370 boards', () => {
+    expect(component.getDeviceNotification({ frequency: 327, frequencyOptions: [327, 350, 410] })).toBeUndefined();
+    expect(component.getDeviceNotification({ ASICModel: 'BM1370', frequency: 350, frequencyOptions: [350, 375, 400] })).toBeUndefined();
+    expect(component.getDeviceNotification({ ASICModel: 'BM1370', frequency: 490, frequencyOptions: [400, 490, 525] })).toBeUndefined();
+    expect(component.getDeviceNotification({ ASICModel: 'BM1370', frequency: 490, frequencyOptions: [500, 525, 600] })?.msg).toBe('Frequency Low');
+  });
+
+  it('does not guess a minimum for a legacy peer or hide higher-priority faults', () => {
+    expect(component.getDeviceNotification({ frequency: 327 })).toBeUndefined();
+    expect(component.getDeviceNotification({ frequency: 0 })?.msg).toBe('Frequency Low');
+    expect(component.getDeviceNotification({ frequency: 100, frequencyOptions: [327], overheat_mode: 1 })?.msg).toBe('Overheated');
+    expect(component.getDeviceNotification({ frequency: 100, frequencyOptions: [327], miningPaused: true })?.msg).toBe('Paused');
+  });
+
   it('should render swarm list details and custom components when devices are present', () => {
     component.swarm = [
       {

--- a/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/components/swarm/swarm.component.ts
@@ -1,4 +1,5 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { isFrequencyLow } from 'src/app/utils/frequency-warning';
 import { Component, OnDestroy, OnInit, ViewChild, HostListener } from '@angular/core';
 import { AbstractControl, FormBuilder, FormGroup, Validators, FormControl, ValidationErrors } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
@@ -717,7 +718,7 @@ return this.swarm.filter(axe =>
         return { color: 'red', msg: 'Overheated' };
       case !!axe.power_fault:
         return { color: 'red', msg: 'Power Fault' };
-      case !axe.frequency || axe.frequency < 400:
+      case isFrequencyLow(axe.frequency, axe.frequencyOptions):
         return { color: 'orange', msg: 'Frequency Low' };
       case axe.isUsingFallbackStratum === 1:
         return { color: 'orange', msg: 'Fallback Pool' };

--- a/main/http_server/axe-os/src/app/utils/frequency-warning.spec.ts
+++ b/main/http_server/axe-os/src/app/utils/frequency-warning.spec.ts
@@ -1,0 +1,53 @@
+import { isFrequencyLow } from './frequency-warning';
+
+describe('isFrequencyLow', () => {
+  // Device presets, not a lookup used by production code. BM1370 alone does not
+  // distinguish Gamma, Gamma Duo, Gamma Hex, and NerdQAxe++ operating points.
+  const devices = [
+    { name: 'Max', defaultFrequency: 425, options: [400, 425, 450, 475, 485, 500, 525, 550, 575, 600] },
+    { name: 'Ultra / Hex', defaultFrequency: 485, options: [400, 425, 450, 475, 485, 500, 525, 550, 575] },
+    { name: 'Supra / Supra Hex', defaultFrequency: 490, options: [400, 425, 450, 475, 485, 490, 500, 525, 550, 575] },
+    { name: 'Gamma / GT', defaultFrequency: 525, options: [400, 490, 525, 550, 600, 625, 690] },
+    { name: 'Gamma Duo', defaultFrequency: 400, options: [350, 375, 380, 400, 410] },
+    { name: 'Gamma Hex', defaultFrequency: 690, options: [400, 490, 525, 550, 600, 625, 690] },
+    { name: 'Naja Duo', defaultFrequency: 327, options: [327, 350, 375, 380, 400, 410] },
+    { name: 'NerdQAxe+', defaultFrequency: 490, options: [400, 425, 450, 475, 490, 500, 525, 550, 575] },
+    { name: 'NerdQAxe++', defaultFrequency: 600, options: [500, 515, 525, 550, 575, 590, 600] }
+  ];
+
+  for (const device of devices) {
+    it(`accepts the default and all presets for ${device.name}`, () => {
+      for (const frequency of [device.defaultFrequency, ...device.options]) {
+        expect(isFrequencyLow(frequency, device.options)).withContext(`${frequency} MHz`).toBeFalse();
+      }
+    });
+
+    it(`warns below the lowest preset for ${device.name}`, () => {
+      expect(isFrequencyLow(Math.min(...device.options) - 0.5, device.options)).toBeTrue();
+    });
+  }
+
+  it('accepts custom frequencies between presets and above the preset range', () => {
+    expect(isFrequencyLow(333.3, [327, 350, 410])).toBeFalse();
+    expect(isFrequencyLow(600, [327, 350, 410])).toBeFalse();
+  });
+
+  it('ignores invalid options and does not assume sorted presets', () => {
+    const options = [410, null, 0, -1, NaN, Infinity, '100', 327, 350];
+    expect(isFrequencyLow(327, options)).toBeFalse();
+    expect(isFrequencyLow(326, options)).toBeTrue();
+  });
+
+  it('does not guess a threshold for missing, malformed, or empty metadata', () => {
+    for (const options of [undefined, null, [], {}, '400', [0, -1, null, NaN, Infinity, '327']]) {
+      expect(isFrequencyLow(327, options)).toBeFalse();
+    }
+  });
+
+  it('warns about missing or invalid frequency even without metadata', () => {
+    for (const frequency of [undefined, null, 0, -1, NaN, Infinity, '327']) {
+      expect(isFrequencyLow(frequency, undefined)).toBeTrue();
+      expect(isFrequencyLow(frequency, [327, 350])).toBeTrue();
+    }
+  });
+});

--- a/main/http_server/axe-os/src/app/utils/frequency-warning.ts
+++ b/main/http_server/axe-os/src/app/utils/frequency-warning.ts
@@ -1,0 +1,19 @@
+/** Compare the configured frequency with this device's presets, not its ASIC name.
+ * Presets are advisory: they are not hardware limits, and custom values are allowed.
+ */
+export function isFrequencyLow(frequency: unknown, frequencyOptions: unknown): boolean {
+  if (typeof frequency !== 'number' || !Number.isFinite(frequency) || frequency <= 0) {
+    return true;
+  }
+
+  // Older/fork firmware may omit settings. Do not invent a minimum in that case.
+  if (!Array.isArray(frequencyOptions)) return false;
+
+  let minimum = Infinity;
+  for (const option of frequencyOptions) {
+    if (typeof option === 'number' && Number.isFinite(option) && option > 0) {
+      minimum = Math.min(minimum, option);
+    }
+  }
+  return Number.isFinite(minimum) && frequency < minimum;
+}


### PR DESCRIPTION
## Problem and solution

Naja Duo’s valid 327 MHz default was being flagged as “low frequency” because AxeOS used one global 400 MHz threshold. This PR makes the advisory device-aware by deriving the minimum from that miner’s advertised presets, so valid Naja settings stay clear while genuinely below-preset or invalid values still warn.

Fixes #1902.

## Overview

AxeOS currently treats any frequency below 400 MHz as low, regardless of the device. That produces a false warning on Naja Duo at its normal 327 MHz setting and can affect other devices whose supported presets begin below 400 MHz. The same hard-coded threshold is used on both the Home dashboard and Swarm view.

This change makes the warning device-aware. AxeOS now compares the configured frequency with the lowest valid preset advertised by that specific device. A normal Naja Duo at 327 MHz therefore stays clear, while a genuinely missing, invalid, or below-preset frequency still produces the warning. Home and Swarm use the same shared check so their behavior remains consistent.

This only changes when the existing advisory appears. It does not change mining settings, firmware safety limits, backend APIs, or dependencies.

The behavior was also exercised against local Bitaxe Supra, Bitaxe Gamma, and NerdQAxe++ miners. Each stayed clear at its own minimum preset, showed the warning below that preset, and returned to a clear state after its original setting was restored.

## Implementation details

- Read the minimum from each device's `frequencyOptions` instead of using a global threshold.
- Preserve warnings for missing, zero, negative, and otherwise invalid frequency values.
- Skip the advisory when compatible ASIC preset metadata is unavailable instead of inventing a device threshold.
- Keep Home telemetry and other notifications live while ASIC settings load or if that request fails.
- Share the helper through `utils/common-functions.ts`.
- Test low/normal frequency behavior with synthetic presets rather than copying device preset catalogs into frontend tests.

## Verification

Hardware-confirmed:

- Physical Naja Duo at 327 MHz: the false low-frequency warning no longer appears.
- Physical Naja Duo at a custom 320 MHz, below its advertised 327 MHz minimum preset: Home showed `Device frequency is set low`, and Swarm showed `Frequency Low`.
- Restoring the original frequency cleared both warnings. The check changed frequency only; voltage, fan, and pool settings were unchanged.

Hardware-backed UI checks:

- The Home view was rendered against live local Bitaxe Supra and Bitaxe Gamma APIs at 400/375 MHz. The Swarm view was tested with a mixed Bitaxe Supra, Bitaxe Gamma, and NerdQAxe++ group, including NerdQAxe++ at 500/490 MHz.
- Bitaxe Supra, Bitaxe Gamma, and NerdQAxe++ each stayed clear at its own minimum preset, warned below that preset, and cleared again after restoration.
- All temporary frequency changes were restored; accepted shares advanced during the successful test stages.

Software/build checks:

- 26 focused Home, Swarm, and shared-helper tests pass in Chrome Headless.
- Production AxeOS build passes.
- Full ESP-IDF firmware build from this commit passes with clean ESP-IDF v6.0.2.
- `git diff --check` passes.

Current-head physical validation (2026-09-17):

- Built and OTA-tested the exact PR commit `955915a` on a physical Naja Duo (board 1201, two ASICs).
- Both Home and Swarm were clear at 475 MHz and at the advertised 327 MHz minimum, warned at 320 MHz, and cleared after restoring 475 MHz: eight rendered UI checks.
- Accepted shares advanced at every stage; voltage, fan, pool, and display settings were preserved.
- Returned the miner to its original known-good firmware slot and original operating settings after the temporary test; verified mining and accepted-share advancement again.
- Application SHA256: `f68d42c264672f7dc0f660e31f89784c2d326e9e84a254ea0e5a4961e199a427`. All 12 built UI assets were verified embedded in the tested application.

The earlier Supra/Gamma/NerdQAxe++ checks above are historical hardware-backed UI checks, not fresh flashes of this revision.


CI reporting follow-up: #1985 handles missing artifacts in the results publisher. That workflow-only correction is separate from this merged firmware/UI fix.
