### PR TITLE
Support coinbase decoding for eCash(XEC) and improve web ui display of eCash addresses

### DIFF
--- a/components/stratum/CMakeLists.txt
+++ b/components/stratum/CMakeLists.txt
@@ -6,6 +6,8 @@ SRCS
     "stratum_socket.c"
     "coinbase_decoder.c"
     "segwit_addr.c"
+    "ecash.c"
+    "cashaddr.c"
     "base58.c"
     "miner_job.c"
 

--- a/components/stratum/cashaddr.c
+++ b/components/stratum/cashaddr.c
@@ -1,0 +1,146 @@
+#include "cashaddr.h"
+#include "esp_log.h"
+#include "utils.h"
+#include <stdlib.h>
+#include <stddef.h>
+
+static const char *TAG = "cashaddr";
+
+static const int CASHADDR_CHECKSUM_SIZE = 8;
+
+// Charset containing the 32 symbols used in the base32 encoding.
+static const char CHARSET[] = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+static void cashaddr_base32enc(char *output, const uint8_t* data, size_t length) {
+    for (size_t i = 0; i < length; ++i) {
+        output[i] = CHARSET[data[i]];
+    }
+    output[length] = '\0';
+}
+
+static uint64_t cashaddr_polymod(uint8_t *data, size_t data_len)
+{
+    const uint64_t GENERATOR[] = {
+        0x98f2bc8e61ULL,
+        0x79b76d99e2ULL,
+        0xf33e5fb3c4ULL,
+        0xae2eabe2a8ULL,
+        0x1e4f43e470ULL
+    };
+    uint64_t checksum = 1;
+
+    for (size_t i = 0; i < data_len; i++) {
+        uint64_t value = data[i];
+        uint64_t topBits = checksum >> 35;
+
+        checksum = ((checksum & 0x07ffffffffULL) << 5) ^ value;
+
+        for (size_t j = 0; j < 5; j++) {
+            if ((topBits >> j) & 1) {
+                checksum ^= GENERATOR[j];
+            }
+        }
+    }
+    return checksum ^ 1;
+}
+
+static void checksum_to_uint5_array(uint8_t output[CASHADDR_CHECKSUM_SIZE], uint64_t checksum)
+{
+    for (int i = 0; i < CASHADDR_CHECKSUM_SIZE; ++i) {
+        // Extract the least significant 5 bits (31 is 11111 in binary and 1f in hexadecimal)
+        output[CASHADDR_CHECKSUM_SIZE - 1 - i] = (uint8_t)(checksum & 0x1f);
+        // Shift right by 5 bits
+        checksum >>= 5;
+    }
+}
+
+
+static int8_t cashaddr_get_hash_size_bits(size_t hash_length)
+{
+    switch (hash_length * 8) {
+        case 160: return 0;
+        case 192: return 1;
+        case 224: return 2;
+        case 256: return 3;
+        case 320: return 4;
+        case 384: return 5;
+        case 448: return 6;
+        case 512: return 7;
+        default: return -1;
+    }
+
+}
+
+bool cashaddr_encode(const uint8_t *addr, size_t addr_len, AddressType type, char *output, size_t output_len, const char *bech32_hrp) {
+    uint8_t type_bits = (type == P2SH) ? 8 : 0;
+
+    int8_t hash_size_bits = cashaddr_get_hash_size_bits(addr_len);
+    if (hash_size_bits < 0) {
+        ESP_LOGE(TAG, "Invalid address length: %u", addr_len);
+        return false;
+    }
+
+    uint8_t *payload_data_8b = malloc(addr_len+1);
+    if (!payload_data_8b) {
+        ESP_LOGE(TAG, "payload_data_8b malloc failed");
+        return false;
+    }
+    // type_bits + has_size_bits = versionByte
+    payload_data_8b[0] = type_bits + hash_size_bits;
+    memcpy(payload_data_8b+1, addr, addr_len);
+
+    uint8_t *payload_data_5b = malloc(addr_len*2);
+    if (!payload_data_5b) {
+        ESP_LOGE(TAG, "payload_data_5b malloc failed");
+        return false;
+    }
+
+    size_t payload_data_5b_len = 0;
+    // convert payload data from 8bits base to 5bits base
+    convert_bits(payload_data_5b, &payload_data_5b_len, 5, payload_data_8b, addr_len + 1, 8, 1);
+
+    size_t prefix_len = strlen(bech32_hrp);
+    size_t checksum_len = prefix_len + 1 + payload_data_5b_len + CASHADDR_CHECKSUM_SIZE;
+
+    uint8_t *checksum_data = malloc(checksum_len);
+    if (!checksum_data) {
+        ESP_LOGE(TAG, "checksum malloc failed");
+        return false;
+    }
+    // Copy the hrp as a 5bits base into checksum_data
+    for (int i = 0 ; i < prefix_len ; i++) {
+        checksum_data[i] = (uint8_t)(bech32_hrp[i]) & 0x1f;
+    }
+    checksum_data[prefix_len] = 0;
+    memcpy(checksum_data+prefix_len+1, payload_data_5b, payload_data_5b_len);
+    memset(checksum_data+prefix_len+1+payload_data_5b_len, 0, CASHADDR_CHECKSUM_SIZE);
+
+    uint64_t checksum = cashaddr_polymod(checksum_data, checksum_len);
+    uint8_t *checksum_array = malloc(CASHADDR_CHECKSUM_SIZE);
+    if (!checksum_array) {
+        ESP_LOGE(TAG, "checksum_array malloc failed");
+        return false;
+    }
+    checksum_to_uint5_array(checksum_array, checksum);
+
+    size_t payload_len = payload_data_5b_len + CASHADDR_CHECKSUM_SIZE;
+    uint8_t *payload = malloc(payload_len);
+    if (!payload) {
+        ESP_LOGE(TAG, "payload malloc failed");
+        return false;
+    }
+    // Concat payload_data_5b and checksum_array into payload
+    memcpy(payload, payload_data_5b, payload_data_5b_len);
+    memcpy(payload+payload_data_5b_len, checksum_array, CASHADDR_CHECKSUM_SIZE);
+
+    // base32 encode the payload into the output
+    cashaddr_base32enc(output, payload, payload_len);
+
+    free(payload);
+    free(payload_data_5b);
+    free(payload_data_8b);
+    free(checksum_data);
+    free(checksum_array);
+
+    return true;
+}

--- a/components/stratum/coinbase_decoder.c
+++ b/components/stratum/coinbase_decoder.c
@@ -1,3 +1,4 @@
+#include "ecash.h"
 #include "coinbase_decoder.h"
 #include "stratum_api.h"
 #include "utils.h"
@@ -79,6 +80,9 @@ void coinbase_decode_address_from_scriptpubkey(const uint8_t *script, size_t scr
     // P2PKH: OP_DUP OP_HASH160 <20 bytes> OP_EQUALVERIFY OP_CHECKSIG
     if (script_len == 25 && script[0] == OP_DUP && script[1] == OP_HASH160 && 
         script[2] == OP_PUSHDATA_20 && script[23] == OP_EQUALVERIFY && script[24] == OP_CHECKSIG) {
+        if (ecash_check_encode(script, script_len, P2PKH, output, output_len, bech32_hrp)) {
+            return;
+        }
         size_t b58sz = output_len;
         if (b58check_enc(output, &b58sz, p2pkh_version, script + 3, 20)) {
             return;
@@ -91,6 +95,9 @@ void coinbase_decode_address_from_scriptpubkey(const uint8_t *script, size_t scr
     
     // P2SH: OP_HASH160 <20 bytes> OP_EQUAL
     if (script_len == 23 && script[0] == OP_HASH160 && script[1] == OP_PUSHDATA_20 && script[22] == OP_EQUAL) {
+        if (ecash_check_encode(script, script_len, P2SH, output, output_len, bech32_hrp)) {
+            return;
+        }
         size_t b58sz = output_len;
         if (b58check_enc(output, &b58sz, p2sh_version, script + 2, 20)) {
             return;
@@ -288,6 +295,8 @@ esp_err_t coinbase_process_miner_job(const miner_job_t *job,
         } else if (user_address[0] == 'm' || user_address[0] == 'n' || user_address[0] == '2') {
             bech32_hrp = "tb";
             is_testnet = true;
+        } else if (strncmp(user_address, "ecash:", 6) == 0) {
+            bech32_hrp = "ecash";
         }
     }
 

--- a/components/stratum/ecash.c
+++ b/components/stratum/ecash.c
@@ -1,0 +1,21 @@
+#include "cashaddr.h"
+#include <stdio.h>
+#include <string.h>
+
+
+static bool is_ecash_hrp(const char *bech32_hrp) {
+    return (strncmp(bech32_hrp, "ecash", 5) == 0) || (strncmp(bech32_hrp, "ectest", 6) == 0);
+}
+
+bool ecash_check_encode(const uint8_t *addr, size_t addr_len, AddressType type, char *output, size_t output_len, const char *bech32_hrp) {
+    if (!is_ecash_hrp(bech32_hrp)) return false;
+
+    snprintf(output, 7, "ecash:");
+    switch (type) {
+        case P2PKH:
+            return cashaddr_encode(addr+3, 20, type, output+6, output_len-6, bech32_hrp);
+        case P2SH:
+            return cashaddr_encode(addr+2, 20, type, output+6, output_len-6, bech32_hrp);
+    }
+    return false;
+}

--- a/components/stratum/include/cashaddr.h
+++ b/components/stratum/include/cashaddr.h
@@ -1,0 +1,13 @@
+#ifndef CASHADDR_H
+#define CASHADDR_H
+
+#include <stdlib.h>
+typedef enum
+{
+    P2SH,
+    P2PKH,
+} AddressType;
+
+bool cashaddr_encode(const uint8_t *addr, size_t addr_len, AddressType type, char *output, size_t output_len, const char *bech32_hrp);
+
+#endif

--- a/components/stratum/include/ecash.h
+++ b/components/stratum/include/ecash.h
@@ -1,0 +1,9 @@
+#ifndef ECASH_H
+#define ECASH_H
+
+#include "cashaddr.h"
+#include <stdint.h>
+
+bool ecash_check_encode(const uint8_t *addr, size_t addr_len, AddressType type, char *output, size_t output_len, const char *bech32_hrp);
+
+#endif

--- a/components/stratum/include/utils.h
+++ b/components/stratum/include/utils.h
@@ -57,6 +57,8 @@ void url_decode(char *dst, const char *src);
 
 char *strdup_psram(const char *str);
 
+int convert_bits(uint8_t* out, size_t* outlen, int outbits, const uint8_t* in, size_t inlen, int inbits, int pad);
+
 // BIP320 16-bit version rolling mask (bits 13..28: 0x1fffe000).
 // BM13xx ASICs program version rolling as a 16-bit field shifted by 13 (version_mask >> 13).
 // This is a strict hardware-compatible subset of the BIP323 mask.

--- a/components/stratum/segwit_addr.c
+++ b/components/stratum/segwit_addr.c
@@ -24,6 +24,7 @@
 #include <string.h>
 
 #include "segwit_addr.h"
+#include "utils.h"
 
 static uint32_t bech32_polymod_step(uint32_t pre) {
     uint8_t b = pre >> 25;
@@ -151,28 +152,6 @@ bech32_encoding bech32_decode(char* hrp, uint8_t *data, size_t *data_len, const 
     } else {
         return BECH32_ENCODING_NONE;
     }
-}
-
-static int convert_bits(uint8_t* out, size_t* outlen, int outbits, const uint8_t* in, size_t inlen, int inbits, int pad) {
-    uint32_t val = 0;
-    int bits = 0;
-    uint32_t maxv = (((uint32_t)1) << outbits) - 1;
-    while (inlen--) {
-        val = (val << inbits) | *(in++);
-        bits += inbits;
-        while (bits >= outbits) {
-            bits -= outbits;
-            out[(*outlen)++] = (val >> bits) & maxv;
-        }
-    }
-    if (pad) {
-        if (bits) {
-            out[(*outlen)++] = (val << (outbits - bits)) & maxv;
-        }
-    } else if (((val << (outbits - bits)) & maxv) || bits >= inbits) {
-        return 0;
-    }
-    return 1;
 }
 
 int segwit_addr_encode(char *output, const char *hrp, int witver, const uint8_t *witprog, size_t witprog_len) {

--- a/components/stratum/test/test_cashaddr.c
+++ b/components/stratum/test/test_cashaddr.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <string.h>
+#include "unity.h"
+#include "cashaddr.h"
+
+TEST_CASE("Cashaddr P2PKH encode", "[cashaddr]")
+{
+    uint8_t hash[20] = {
+        0x10, 0x71, 0x4e, 0xe3, 0xf0, 0x4b, 0x34, 0xf2,
+        0x4d, 0x46, 0x3a, 0xe1, 0x6c, 0x19, 0xaa, 0x94,
+        0x1b, 0xf6, 0x11, 0x0b
+    };
+    char output[48];
+    bool result = cashaddr_encode(hash, 20, P2PKH, output, 48, "ecash");
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_STRING("qqg8znhr7p9nfujdgcawzmqe422phas3pv4ydym5su", output);
+}
+
+TEST_CASE("Cashaddr P2SH encode", "[cashaddr]")
+{
+    uint8_t hash[20] = {
+        0xd3, 0x7c, 0x4c, 0x80, 0x9f, 0xe9, 0x84, 0xe,
+        0x7b, 0xfa, 0x77, 0xb8, 0x6b, 0xd4, 0x71, 0x63,
+        0xf6, 0xfb, 0x6c, 0x60
+    };
+    char output[48];
+
+    bool result = cashaddr_encode(hash, 20, P2SH, output, 48, "ecash");
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_STRING("prfhcnyqnl5cgrnmlfmms675w93ld7mvvqd0y8lz07", output);
+}

--- a/components/stratum/utils.c
+++ b/components/stratum/utils.c
@@ -381,3 +381,25 @@ char *strdup_psram(const char *str)
     }
     return strdup(str);
 }
+
+int convert_bits(uint8_t* out, size_t* outlen, int outbits, const uint8_t* in, size_t inlen, int inbits, int pad) {
+    uint32_t val = 0;
+    int bits = 0;
+    uint32_t maxv = (((uint32_t)1) << outbits) - 1;
+    while (inlen--) {
+        val = (val << inbits) | *(in++);
+        bits += inbits;
+        while (bits >= outbits) {
+            bits -= outbits;
+            out[(*outlen)++] = (val >> bits) & maxv;
+        }
+    }
+    if (pad) {
+        if (bits) {
+            out[(*outlen)++] = (val << (outbits - bits)) & maxv;
+        }
+    } else if (((val << (outbits - bits)) & maxv) || bits >= inbits) {
+        return 0;
+    }
+    return 1;
+}

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -547,7 +547,7 @@
                 <tooltip-text-icon text="Value" tooltip="Total value of transaction outputs in BTC. For non-bitcoin chains, disable 'Decode Coinbase Tx' in Advanced Pool Options." />
               </div>
               @if (info.coinbaseValueTotalSatoshis && info.coinbaseValueTotalSatoshis > 0) {
-                {{ info.coinbaseValueTotalSatoshis | sats }}
+                {{ info.coinbaseValueTotalSatoshis | sats:currencyTicker:currencyDecimalPlaces:currencyDivider }}
               }
             </div>
             <div class="flex flex-nowrap items-baseline">
@@ -563,7 +563,7 @@
                       } @else {
                         <span class="font-mono text-sm" appTooltip="{{ output.address }}" tooltipPosition="top">{{ output.address | address }}</span>
                       }
-                      <span class="text-sm">{{ output.value | sats }}</span>
+                      <span class="text-sm">{{ output.value | sats:currencyTicker:currencyDecimalPlaces:currencyDivider }}</span>
                     } @else {
                       <span class="font-mono text-xs">{{ output.address }}</span>
                     }
@@ -576,7 +576,7 @@
               <div class="w-24 shrink-0 text-secondary">
                 Amount
               </div>
-              {{ info.coinbaseValueTotalSatoshis / 100_000_000 }}
+              {{ info.coinbaseValueTotalSatoshis / currencyDivider }}
             </div>
           }
         </div>

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -184,8 +184,12 @@ export class HomeComponent implements OnInit, OnDestroy {
   public efficiency: number = 0;
   public efficiencyAverage: number = 0;
   public expectedEfficiency: number = 0;
+  public activePoolUserPrefixPart: string = '';
   public activePoolUserAddressPart: string = '';
   public activePoolUserSuffixPart: string = '';
+  public currencyDecimalPlaces: number = 8;
+  public currencyDivider: number = 100_000_000;
+  public currencyTicker: string = 'BTC';
   public sortedRejectionReasons: Array<{ message: string; count: number; percentage: number }> = [];
   public networkDifficultyPercentage: string = '0';
   public payoutPercentage: number = -1;
@@ -274,7 +278,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
     let dataSources = this.storageService.getItem(HOME_CHART_DATA_SOURCES);
     let parsedConfig: any = { chartY1Unit: 'hashrate', chartY2Unit: 'temperature' };
-    
+
     if (dataSources !== null) {
       try {
         const stored = JSON.parse(dataSources);
@@ -440,7 +444,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     const chartDef = WIDGET_DEFAULTS.find(d => d.id === 'chart');
     if (!chartDef) return WIDGET_DEFAULTS;
 
-    // The old layout set the chart height to 40vh. In gridstack, you need to set the height of 
+    // The old layout set the chart height to 40vh. In gridstack, you need to set the height of
     // the card, so there's 100px to compensate for the dropdowns and padding.
     const CHART_CHROME_PX = 100;
     const targetPx = (window.innerHeight * 0.40) + CHART_CHROME_PX;
@@ -532,8 +536,8 @@ export class HomeComponent implements OnInit, OnDestroy {
 
     return labels.filter(label => this.isSensorSupported(label, this.latestInfo)).map((labelKey, index) => {
       const label = chartLabelValue(labelKey) || labelKey;
-      const borderColor = index === 0 
-        ? baseColor 
+      const borderColor = index === 0
+        ? baseColor
         : `color-mix(in srgb, ${baseColor} ${100 - index * 15}%, ${mixColor} ${index * 15}%)`;
       const backgroundColor = `color-mix(in srgb, ${borderColor}, transparent 81%)`;
 
@@ -708,7 +712,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
             const ticks = [];
             const start = new Date(axis.min);
-            
+
             // Align start to the unit boundary (human readable)
             start.setMilliseconds(0);
             if (this.currentInterval.unit === 'second') {
@@ -975,6 +979,7 @@ export class HomeComponent implements OnInit, OnDestroy {
         }
         this.responseTime = info.responseTime;
 
+        this.activePoolUserPrefixPart = this.getHumanReadablePart(this.activePoolUser);
         this.activePoolUserAddressPart = this.getAddressPart(this.activePoolUser);
         this.activePoolUserSuffixPart = this.getSuffixPart(this.activePoolUser);
 
@@ -1379,13 +1384,13 @@ export class HomeComponent implements OnInit, OnDestroy {
 
     while (this.dataLabel.length > limit) {
       // Option B: Chart is crowded. Binary search for the densest region.
-      // We initialize search range from index 1 to length - 2 to protect the oldest point (index 0) 
+      // We initialize search range from index 1 to length - 2 to protect the oldest point (index 0)
       // and newest point (index length - 1) from being deleted, preserving chart boundaries.
       let low = 1;
       let high = this.dataLabel.length - 2;
       while (high - low > 1) {
         const midTime = (this.dataLabel[low] + this.dataLabel[high]) / 2;
-        
+
         let split = low;
         for (let i = low; i <= high; i++) {
           if (this.dataLabel[i] >= midTime) {
@@ -1407,7 +1412,7 @@ export class HomeComponent implements OnInit, OnDestroy {
            low = split;
         }
       }
-      
+
       // Remove point at index 'low'.
       this.dataLabel.splice(low, 1);
       this.hashrateData.splice(low, 1);
@@ -1428,9 +1433,9 @@ export class HomeComponent implements OnInit, OnDestroy {
     const totalSpanMs = this.dataLabel[this.dataLabel.length - 1] - this.dataLabel[0];
     const maxTicks = Math.min(16, Math.max(3, Math.floor(this.chartWidth / 80)));
 
-    this.currentInterval = HomeComponent.ADAPTIVE_TICK_INTERVALS.find(i => totalSpanMs / i.ms < maxTicks + 1) || 
+    this.currentInterval = HomeComponent.ADAPTIVE_TICK_INTERVALS.find(i => totalSpanMs / i.ms < maxTicks + 1) ||
                            HomeComponent.ADAPTIVE_TICK_INTERVALS[HomeComponent.ADAPTIVE_TICK_INTERVALS.length - 1];
-    
+
     const xAxis = (this.chartOptions.scales as any).x;
     if (xAxis.time.unit !== this.currentInterval.unit || xAxis.time.stepSize !== this.currentInterval.step) {
       xAxis.time.unit = this.currentInterval.unit;
@@ -1522,6 +1527,11 @@ export class HomeComponent implements OnInit, OnDestroy {
         const settings = HomeComponent.getSettingsForLabel(datasetLabel);
         return value.toLocaleString(undefined, { useGrouping: false, maximumFractionDigits: args?.tickmark ? undefined : settings.precision }) + settings.suffix;
     }
+  }
+
+  getHumanReadablePart(user: string): string {
+    const colonIndex = user.indexOf(':');
+    return colonIndex !== -1 ? user.substring(0, colonIndex) : '';
   }
 
   getAddressPart(user: string): string {

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -980,6 +980,11 @@ export class HomeComponent implements OnInit, OnDestroy {
         this.responseTime = info.responseTime;
 
         this.activePoolUserPrefixPart = this.getHumanReadablePart(this.activePoolUser);
+        if (this.activePoolUserPrefixPart === 'ecash') {
+          this.currencyDecimalPlaces = 2;
+          this.currencyDivider = 100;
+          this.currencyTicker = 'XEC';
+        }
         this.activePoolUserAddressPart = this.getAddressPart(this.activePoolUser);
         this.activePoolUserSuffixPart = this.getSuffixPart(this.activePoolUser);
 

--- a/main/http_server/axe-os/src/app/directives/tooltip.directive.ts
+++ b/main/http_server/axe-os/src/app/directives/tooltip.directive.ts
@@ -17,7 +17,7 @@ import {
   standalone: true,
   template: `{{ text }}`,
   host: {
-    'class': 'fixed z-[99999] bg-[#2b2b2b] text-[#ffffff] app-tooltip-text px-2.5 py-1.5 rounded shadow-xl pointer-events-none border border-neutral-700 max-w-[250px] whitespace-normal text-center'
+    'class': 'fixed z-[99999] bg-[#2b2b2b] text-[#ffffff] app-tooltip-text px-2.5 py-1.5 rounded shadow-xl pointer-events-none border border-neutral-700 whitespace-normal text-center'
   }
 })
 export class TooltipContentComponent {

--- a/main/http_server/axe-os/src/app/pipes/address.pipe.ts
+++ b/main/http_server/axe-os/src/app/pipes/address.pipe.ts
@@ -1,8 +1,8 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-    name: 'address',
-    pure: true
+  name: 'address',
+  pure: true,
 })
 export class AddressPipe implements PipeTransform {
   private static _this = new AddressPipe();
@@ -17,7 +17,13 @@ export class AddressPipe implements PipeTransform {
     const maxLength = args?.length ?? 22;
 
     let segments: string[] = [];
-    for (let i = 0; i < value.length; i += 4) {
+    let segmentStartIdx = 0;
+    let colonIndex = value.indexOf(':');
+    if (colonIndex != -1) {
+      segmentStartIdx = colonIndex + 1;
+      segments.push(value.slice(0, colonIndex + 1));
+    }
+    for (let i = segmentStartIdx; i < value.length; i += 4) {
       segments.push(value.slice(i, i + 4));
     }
 
@@ -28,9 +34,13 @@ export class AddressPipe implements PipeTransform {
     let left = segments.slice(0, mid);
     let right = segments.slice(mid);
     do {
-      if (left.length > right.length) left.pop(); else right.shift();
+      if (left.length > right.length) left.pop();
+      else right.shift();
       formatted = left.join(' ') + '...' + right.join(' ');
-    } while (formatted.length > maxLength && (left.length > 1 || right.length > 1));
+    } while (
+      formatted.length > maxLength &&
+      (left.length > 1 || right.length > 1)
+    );
 
     return formatted;
   }

--- a/main/http_server/axe-os/src/app/pipes/sats.pipe.ts
+++ b/main/http_server/axe-os/src/app/pipes/sats.pipe.ts
@@ -1,18 +1,32 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-    name: 'sats',
-    pure: true
+  name: 'sats',
+  pure: true,
 })
 export class SatsPipe implements PipeTransform {
   private static _this = new SatsPipe();
 
-  public static transform(value: number, args?: any): string {
-    return this._this.transform(value, args);
+  public static transform(
+    value: number,
+    coin?: string,
+    decimalPlaces?: number,
+    valueDivider?: number,
+  ): string {
+    return this._this.transform(value, coin, decimalPlaces, valueDivider);
   }
 
-  transform(value: number, args?: any): string {
-    if (!value) return '0 BTC';
-    return (value / 100_000_000).toFixed(8) + ' BTC';
+  transform(
+    value: number,
+    coin?: string,
+    decimalPlaces?: number,
+    valueDivider?: number,
+  ): string {
+    if (!value) return '0 ' + (coin ?? 'BTC');
+    return (
+      (value / (valueDivider ?? 100_000_000)).toFixed(decimalPlaces ?? 8) +
+      ' ' +
+      (coin ?? 'BTC')
+    );
   }
 }


### PR DESCRIPTION
My first PR on here, any inputs on the code are very welcome.

Tested on my Bitaxe GT (unit tests as well)

Screenshot of the changes on the Web UI:
Before:
<img width="1104" height="224" alt="image" src="https://github.com/user-attachments/assets/3f002728-c1ba-4c7c-8b94-561598a036c6" />

After:
<img width="1099" height="216" alt="image" src="https://github.com/user-attachments/assets/0579f981-2495-4ee9-9537-63648bbfe8b2" />

Next areas of improvements for this support would probably be to add a toggle to hide the mandatory minerfund addres and stakingreward address from the coinbase output in the UI, but it is harder to do than I thought so it will probably come in another PR, if this one is merged.